### PR TITLE
Fix lettabot-message CLI reading wrong store field

### DIFF
--- a/src/cli/message.ts
+++ b/src/cli/message.ts
@@ -22,7 +22,7 @@ interface LastTarget {
 
 interface AgentStore {
   agentId?: string;
-  lastTarget?: LastTarget;
+  lastMessageTarget?: LastTarget;  // Note: field is "lastMessageTarget" not "lastTarget"
 }
 
 // Store path (same location as bot uses)
@@ -32,7 +32,7 @@ function loadLastTarget(): LastTarget | null {
   try {
     if (existsSync(STORE_PATH)) {
       const store: AgentStore = JSON.parse(readFileSync(STORE_PATH, 'utf-8'));
-      return store.lastTarget || null;
+      return store.lastMessageTarget || null;
     }
   } catch {
     // Ignore


### PR DESCRIPTION
## Summary
- Fixed `lettabot-message` CLI looking for `lastTarget` instead of `lastMessageTarget`
- This caused the agent to fail to find the chat ID on fresh machines

## Test plan
- [ ] Run `lettabot-message send --text "test"` after a user has messaged the bot
- [ ] Verify it sends to the correct chat

🐾 Generated with [Letta Code](https://letta.com)