### PR TITLE
Fix: Save baseUrl when storing agent ID for local server support

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -240,8 +240,10 @@ export class LettaBot {
             // Save agent ID and attach ignore tool (only on first message)
             if (session.agentId && session.agentId !== this.store.agentId) {
               const isNewAgent = !this.store.agentId;
-              this.store.agentId = session.agentId;
-              console.log('Saved agent ID:', session.agentId);
+              // Save agent ID along with the current server URL
+              const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
+              this.store.setAgent(session.agentId, currentBaseUrl);
+              console.log('Saved agent ID:', session.agentId, 'on server:', currentBaseUrl);
               
               // Setup new agents: set name, install skills
               if (isNewAgent) {
@@ -327,8 +329,9 @@ export class LettaBot {
         }
         
         if (msg.type === 'result') {
-          if (session.agentId) {
-            this.store.agentId = session.agentId;
+          if (session.agentId && session.agentId !== this.store.agentId) {
+            const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
+            this.store.setAgent(session.agentId, currentBaseUrl);
           }
           break;
         }


### PR DESCRIPTION
## Summary
- Fixes agent ID storage to also save the server URL (baseUrl) when creating new agents
- Uses `store.setAgent(agentId, baseUrl)` instead of just setting `agentId`
- Enables proper server mismatch detection when switching between local and cloud Letta servers

## Test plan
- [x] Run with `LETTA_BASE_URL=http://localhost:8283 MODEL=openai/gpt-4o lettabot server`
- [ ] Verify new agent is created and `lettabot-agent.json` includes `baseUrl`
- [ ] Switch back to cloud server and verify mismatch warning appears

🤖 Generated with [Letta Code](https://letta.com)