### PR TITLE
Fix CLI instructions to use npx prefix

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -315,7 +315,7 @@ async function main() {
         p.log.info('Nothing to delete');
       }
       
-      p.outro('✨ Done! Run `lettabot server` to create a fresh agent.');
+      p.outro('✨ Done! Run `npx lettabot server` to create a fresh agent.');
       break;
     }
       

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -1105,5 +1105,5 @@ export async function onboard(): Promise<void> {
     p.log.success(`Agent ID saved: ${config.agentId} (${baseUrl})`);
   }
   
-  p.outro('🎉 Setup complete! Run `lettabot server` to start.');
+  p.outro('🎉 Setup complete! Run `npx lettabot server` to start.');
 }


### PR DESCRIPTION
## Summary
- Changed "lettabot server" to "npx lettabot server" in completion messages
- Affects onboarding and logout completion messages

## Test plan
- [x] Run onboarding and verify the message says `npx lettabot server`

🐙 Generated with [Letta Code](https://letta.com)