### PR TITLE
Re-add format hints to message envelope

### DIFF
--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -7,7 +7,16 @@
 
 import type { InboundMessage } from './types.js';
 
-
+/**
+ * Channel format hints - tells the agent what formatting syntax to use
+ * Each channel has different markdown support - hints help agent format appropriately.
+ */
+const CHANNEL_FORMATS: Record<string, string> = {
+  slack: 'mrkdwn: *bold* _italic_ `code` - NO: headers, tables',
+  telegram: 'MarkdownV2: *bold* _italic_ `code` [links](url) - NO: headers, tables',
+  whatsapp: '*bold* _italic_ `code` - NO: headers, code fences, links, tables',
+  signal: 'ONLY: *bold* _italic_ `code` - NO: headers, code fences, links, quotes, tables',
+};
 
 export interface EnvelopeOptions {
   timezone?: 'local' | 'utc' | string;  // IANA timezone or 'local'/'utc'
@@ -170,6 +179,9 @@ export function formatMessageEnvelope(
   // Build envelope
   const envelope = `[${parts.join(' ')}]`;
   
-  // Add format hint as a separate note (not cluttering the main envelope)
-  return `${envelope} ${msg.text}`;
+  // Add format hint so agent knows what formatting syntax to use
+  const formatHint = CHANNEL_FORMATS[msg.channel];
+  const hint = formatHint ? `\n(Format: ${formatHint})` : '';
+  
+  return `${envelope} ${msg.text}${hint}`;
 }


### PR DESCRIPTION
## Summary
- Re-adds format hints that were removed in commit 51c59e4
- Shows agent what formatting syntax each channel supports
- Includes actual syntax examples (*bold*, _italic_, `code`)

Example envelope:
```
[signal:+15551234567 Cameron Thursday, Jan 29, 10:15 AM PST] Hello!
(Format: ONLY: *bold* _italic_ `code` - NO: headers, code fences, links, quotes, tables)
```

## Test plan
- [ ] Send message from Signal, verify format hint is included
- [ ] Agent should use minimal formatting for Signal

🐙 Generated with [Letta Code](https://letta.com)