### PR TITLE
Add Home Assistant documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ lettabot skills
 lettabot skills status
 ```
 
+### Home Assistant
+
+Control your smart home with LettaBot:
+
+```bash
+# 1. Install the skill from ClawdHub
+npx clawdhub@latest install homeassistant
+
+# 2. Enable the skill
+lettabot skills sync
+# Select "homeassistant" from the list
+
+# 3. Configure credentials (see skill docs for details)
+# You'll need: HA URL + Long-Lived Access Token
+```
+
+Then ask your bot things like:
+- "Turn off the living room lights"
+- "What's the temperature in the bedroom?"
+- "Set the thermostat to 72"
+
 ## CLI Commands
 
 | Command | Description |


### PR DESCRIPTION
## Summary

Documents how to use the Home Assistant integration via ClawdHub.

The skill sync workflow already supports ClawdHub skills - this just adds documentation so users know about it.

## Instructions added

```bash
# 1. Install the skill from ClawdHub
npx clawdhub@latest install homeassistant

# 2. Enable the skill
lettabot skills sync
# Select "homeassistant" from the list
```

## Test plan
- [x] Verified workflow works with existing skill sync functionality

Closes #... (if there's a related issue for Home Assistant integration request)

🐙 Generated with [Letta Code](https://letta.com)