### PR TITLE
Clarify WhatsApp self-chat mode in onboarding

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -129,6 +129,10 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   }
   if (config.channels.signal?.phone) {
     env.SIGNAL_PHONE_NUMBER = config.channels.signal.phone;
+    // Signal selfChat defaults to true, so only set env if explicitly false
+    if (config.channels.signal.selfChat === false) {
+      env.SIGNAL_SELF_CHAT_MODE = 'false';
+    }
   }
   if (config.channels.discord?.token) {
     env.DISCORD_BOT_TOKEN = config.channels.discord.token;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -77,6 +77,7 @@ export interface WhatsAppConfig {
 export interface SignalConfig {
   enabled: boolean;
   phone?: string;
+  selfChat?: boolean;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
 }


### PR DESCRIPTION
## Summary

Changed confusing self-chat yes/no prompts to clearer selects for both WhatsApp and Signal:

**WhatsApp - Before:**
```
◆ WhatsApp: Self-chat mode? (Message Yourself)
│ ○ Yes / ● No
```

**WhatsApp - After:**
```
◆ WhatsApp: Whose number is this?
│ ○ Dedicated bot number  (Responds to all incoming messages)
│ ○ My personal number    (Only responds to "Message Yourself" chat)
```

**Signal - Added:**
```
◆ Signal: Whose number is this?
│ ○ Dedicated bot number  (Responds to all incoming messages)
│ ○ My personal number    (Only responds to "Note to Self" chat)
```

## Context

From Slack - Caren was confused about what "self-chat mode" meant.

## Changes
- `src/onboard.ts` - Updated WhatsApp prompt, added Signal prompt
- `src/config/types.ts` - Added `selfChat` to SignalConfig
- `src/config/io.ts` - Handle SIGNAL_SELF_CHAT_MODE env var

## Test plan
- [x] Run onboarding with WhatsApp enabled - verify new select
- [x] Run onboarding with Signal enabled - verify new select  
- [x] Verify selfChat saves to yaml and env correctly

Written by Cameron ◯ Letta Code

"Simplicity is the ultimate sophistication." - da Vinci