### PR TITLE
Fix WhatsApp self-chat bypassing pairing check

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -265,8 +265,8 @@ Ask the bot owner to approve with:
         const isGroup = remoteJid.endsWith('@g.us');
         const pushName = m.pushName;
         
-        // Check access control (for DMs only, groups are open)
-        if (!isGroup) {
+        // Check access control (for DMs only, groups are open, self-chat always allowed)
+        if (!isGroup && !isSelfChat) {
           const access = await this.checkAccess(userId, pushName);
           
           if (access === 'blocked') {


### PR DESCRIPTION
## Problem

Self-chat messages were triggering pairing requests even when self-chat mode was enabled.

**Root cause:** The `isSelfChat` detection happened AFTER the access check, so the access check didn't know to skip pairing for self-chat messages.

## Fix

Add `&& !isSelfChat` to the access check condition:

```typescript
// Before
if (!isGroup) {

// After  
if (!isGroup && !isSelfChat) {
```

This skips the pairing flow entirely for self-chat messages.

## Test plan
- [x] Enable self-chat mode
- [x] Send message to yourself
- [x] Verify no pairing request is triggered

Written by Cameron ◯ Letta Code

"The simplest solution is usually the correct one." - Occam