### PR TITLE
Fix message bubbles and tool approval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "bin": {
         "lettabot": "dist/cli.js",
         "lettabot-message": "dist/cli/message.js",
+        "lettabot-react": "dist/cli/react.js",
         "lettabot-schedule": "dist/cron/cli.js"
       },
       "optionalDependencies": {
@@ -44,9 +45,9 @@
       "extraneous": true
     },
     "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.3.tgz",
-      "integrity": "sha512-jsElTJ0sQ4wHRz+C45tfect76BwbTbgkgKByOzpCN9xG61N5V6u/glvg1CsNJhq2xJIFpKHSwG3D2wPPuEYOrQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.4.tgz",
+      "integrity": "sha512-HTgrrTgZ9Jgeo6Z3oqbQ7lifOVvRR14vaDuBGPPUxk9Thm+vObaO4QfYYYWw4Zo5CWQDBEfsinFA6Gre+AqwNQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1263,9 +1264,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.13.11.tgz",
-      "integrity": "sha512-L1zQ+Pvn2FNzxNdgCXR5pQxS1Yhnbc+Mm/VyfcwrxCQ4QlIewv1q5MSexP0qZHTHC4ZnOjdbaDPMJWMXBMPeBw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.14.1.tgz",
+      "integrity": "sha512-4XQQxqDUlFNo7uKBilyIJ4KKHC8QrFoeMfZXmr9LgtNMtXYqB+I5AYuCnG9BBueeZgO1hlDN2ekJZELyJUqrPQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2263,9 +2264,9 @@
       }
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3558,9 +3559,9 @@
       "peer": true
     },
     "node_modules/ink/node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- Separate message bubbles when stream message type changes (assistant → tool_call → assistant)
- Track `sentAnyMessage` to avoid spurious "(No response from agent)" 
- Add `canUseTool` workaround for SDK v0.0.3 `bypassPermissions` bug (see letta-ai/letta-code-sdk#10)
- Clean up verbose debug logging

## Test plan
- [x] Tested on Signal - messages before/after tool calls now appear as separate bubbles
- [x] No more "(No response from agent)" when agent uses tools then reasoning

Written by Cameron ◯ Letta Code