### PR TITLE
Fix heartbeat skip logic to only check user messages

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -178,7 +178,10 @@ Ask the bot owner to approve with:
             return;
           }
           if (command === 'heartbeat') {
-            await this.onCommand('heartbeat');
+            const result = await this.onCommand('heartbeat');
+            if (result) {
+              await message.channel.send(result);
+            }
             return;
           }
         }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -138,11 +138,10 @@ export class TelegramAdapter implements ChannelAdapter {
       }
     });
     
-    // Handle /heartbeat (silent - no reply)
+    // Handle /heartbeat - trigger heartbeat manually (silent - no reply)
     this.bot.command('heartbeat', async (ctx) => {
       if (this.onCommand) {
         await this.onCommand('heartbeat');
-        // No reply - heartbeat runs silently
       }
     });
     

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -20,6 +20,7 @@ export class LettaBot {
   private config: BotConfig;
   private channels: Map<string, ChannelAdapter> = new Map();
   private messageQueue: Array<{ msg: InboundMessage; adapter: ChannelAdapter }> = [];
+  private lastUserMessageTime: Date | null = null;
   
   // Callback to trigger heartbeat (set by main.ts)
   public onTriggerHeartbeat?: () => Promise<void>;
@@ -151,6 +152,8 @@ export class LettaBot {
    * Process a single message
    */
   private async processMessage(msg: InboundMessage, adapter: ChannelAdapter): Promise<void> {
+    // Track when user last sent a message (for heartbeat skip logic)
+    this.lastUserMessageTime = new Date();
     
     // Track last message target for heartbeat delivery
     this.store.lastMessageTarget = {
@@ -429,5 +432,12 @@ export class LettaBot {
    */
   getLastMessageTarget(): { channel: string; chatId: string } | null {
     return this.store.lastMessageTarget || null;
+  }
+  
+  /**
+   * Get the time of the last user message (for heartbeat skip logic)
+   */
+  getLastUserMessageTime(): Date | null {
+    return this.lastUserMessageTime;
   }
 }


### PR DESCRIPTION
- Previously heartbeats were skipped if agent had ANY recent activity (Gmail polling, cron jobs, other heartbeats, etc.)
- Now only skips if user sent a message in the last 5 minutes
- Added getLastUserMessageTime() to LettaBot to track user messages
- Manual /heartbeat command bypasses the skip check
- Discord /heartbeat now replies with confirmation (Telegram stays silent)

🐙 Generated with [Letta Code](https://letta.com)