### PR TITLE
Add inbound attachments with size limits and pruning

### DIFF
--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -50,3 +50,8 @@ features:
   heartbeat:
     enabled: false
     intervalMin: 30
+
+# Attachment handling (defaults to 20MB if omitted)
+# attachments:
+#   maxMB: 20
+#   maxAgeDays: 14

--- a/src/channels/attachments.ts
+++ b/src/channels/attachments.ts
@@ -1,0 +1,61 @@
+import { createWriteStream, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const SAFE_NAME_RE = /[^A-Za-z0-9._-]/g;
+
+export function sanitizeFilename(input: string): string {
+  const cleaned = input.replace(SAFE_NAME_RE, '_').replace(/^_+|_+$/g, '');
+  return cleaned || 'attachment';
+}
+
+export function buildAttachmentPath(
+  baseDir: string,
+  channel: string,
+  chatId: string,
+  filename?: string
+): string {
+  const safeChannel = sanitizeFilename(channel);
+  const safeChatId = sanitizeFilename(chatId);
+  const safeName = sanitizeFilename(filename || 'attachment');
+  const dir = join(baseDir, safeChannel, safeChatId);
+  mkdirSync(dir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const token = randomUUID().slice(0, 8);
+  return join(dir, `${stamp}-${token}-${safeName}`);
+}
+
+export async function downloadToFile(
+  url: string,
+  filePath: string,
+  headers?: Record<string, string>
+): Promise<void> {
+  ensureParentDir(filePath);
+  const res = await fetch(url, { headers });
+  if (!res.ok || !res.body) {
+    throw new Error(`Download failed (${res.status})`);
+  }
+  const stream = Readable.from(res.body as unknown as AsyncIterable<Uint8Array>);
+  await pipeline(stream, createWriteStream(filePath));
+}
+
+export async function writeStreamToFile(
+  stream: AsyncIterable<Uint8Array> | NodeJS.ReadableStream,
+  filePath: string
+): Promise<void> {
+  ensureParentDir(filePath);
+  const readable = isReadableStream(stream) ? stream : Readable.from(stream);
+  await pipeline(readable, createWriteStream(filePath));
+}
+
+function ensureParentDir(filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+function isReadableStream(
+  stream: AsyncIterable<Uint8Array> | NodeJS.ReadableStream
+): stream is NodeJS.ReadableStream {
+  return typeof (stream as NodeJS.ReadableStream).pipe === 'function';
+}

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -6,9 +6,10 @@
  */
 
 import type { ChannelAdapter } from './types.js';
-import type { InboundMessage, OutboundMessage } from '../core/types.js';
+import type { InboundAttachment, InboundMessage, OutboundFile, OutboundMessage } from '../core/types.js';
 import type { DmPolicy } from '../pairing/types.js';
 import { isUserAllowed, upsertPairingRequest } from '../pairing/store.js';
+import { buildAttachmentPath, downloadToFile } from './attachments.js';
 
 // Dynamic import to avoid requiring Discord deps if not used
 let Client: typeof import('discord.js').Client;
@@ -19,6 +20,8 @@ export interface DiscordConfig {
   token: string;
   dmPolicy?: DmPolicy;      // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: string[];  // Discord user IDs
+  attachmentsDir?: string;
+  attachmentsMaxBytes?: number;
 }
 
 export class DiscordAdapter implements ChannelAdapter {
@@ -28,6 +31,8 @@ export class DiscordAdapter implements ChannelAdapter {
   private client: InstanceType<typeof Client> | null = null;
   private config: DiscordConfig;
   private running = false;
+  private attachmentsDir?: string;
+  private attachmentsMaxBytes?: number;
 
   onMessage?: (msg: InboundMessage) => Promise<void>;
   onCommand?: (command: string) => Promise<string | null>;
@@ -37,6 +42,8 @@ export class DiscordAdapter implements ChannelAdapter {
       ...config,
       dmPolicy: config.dmPolicy || 'pairing',
     };
+    this.attachmentsDir = config.attachmentsDir;
+    this.attachmentsMaxBytes = config.attachmentsMaxBytes;
   }
 
   /**
@@ -165,7 +172,8 @@ Ask the bot owner to approve with:
         return;
       }
 
-      if (!content) return;
+      const attachments = await this.collectAttachments(message.attachments, message.channel.id);
+      if (!content && attachments.length === 0) return;
 
       if (content.startsWith('/')) {
         const command = content.slice(1).split(/\s+/)[0]?.toLowerCase();
@@ -199,10 +207,11 @@ Ask the bot owner to approve with:
           userName: displayName,
           userHandle: message.author.username,
           messageId: message.id,
-          text: content,
+          text: content || '',
           timestamp: message.createdAt,
           isGroup,
           groupName,
+          attachments,
         });
       }
     });
@@ -266,4 +275,50 @@ Ask the bot owner to approve with:
   supportsEditing(): boolean {
     return true;
   }
+
+  private async collectAttachments(attachments: unknown, channelId: string): Promise<InboundAttachment[]> {
+    if (!attachments || typeof attachments !== 'object') return [];
+    const list = Array.from((attachments as { values: () => Iterable<DiscordAttachment> }).values?.() || []);
+    if (list.length === 0) return [];
+    const results: InboundAttachment[] = [];
+    for (const attachment of list) {
+      const name = attachment.name || attachment.id || 'attachment';
+      const entry: InboundAttachment = {
+        id: attachment.id,
+        name,
+        mimeType: attachment.contentType || undefined,
+        size: attachment.size,
+        kind: attachment.contentType?.startsWith('image/') ? 'image' : 'file',
+        url: attachment.url,
+      };
+      if (this.attachmentsDir && attachment.url) {
+        if (this.attachmentsMaxBytes === 0) {
+          results.push(entry);
+          continue;
+        }
+        if (this.attachmentsMaxBytes && attachment.size && attachment.size > this.attachmentsMaxBytes) {
+          console.warn(`[Discord] Attachment ${name} exceeds size limit, skipping download.`);
+          results.push(entry);
+          continue;
+        }
+        const target = buildAttachmentPath(this.attachmentsDir, 'discord', channelId, name);
+        try {
+          await downloadToFile(attachment.url, target);
+          entry.localPath = target;
+        } catch (err) {
+          console.warn('[Discord] Failed to download attachment:', err);
+        }
+      }
+      results.push(entry);
+    }
+    return results;
+  }
 }
+
+type DiscordAttachment = {
+  id?: string;
+  name?: string | null;
+  contentType?: string | null;
+  size?: number;
+  url?: string;
+};

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -25,6 +25,8 @@ export interface SignalConfig {
   dmPolicy?: DmPolicy;        // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: string[];    // Phone numbers (config allowlist)
   selfChatMode?: boolean;     // Respond to Note to Self (default: true)
+  attachmentsDir?: string;
+  attachmentsMaxBytes?: number;
 }
 
 type SignalRpcResponse<T> = {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -5,7 +5,10 @@
  */
 
 import type { ChannelAdapter } from './types.js';
-import type { InboundMessage, OutboundMessage } from '../core/types.js';
+import type { InboundAttachment, InboundMessage, OutboundFile, OutboundMessage } from '../core/types.js';
+import { createReadStream } from 'node:fs';
+import { basename } from 'node:path';
+import { buildAttachmentPath, downloadToFile } from './attachments.js';
 
 // Dynamic import to avoid requiring Slack deps if not used
 let App: typeof import('@slack/bolt').App;
@@ -14,6 +17,8 @@ export interface SlackConfig {
   botToken: string;       // xoxb-...
   appToken: string;       // xapp-... (for Socket Mode)
   allowedUsers?: string[]; // Slack user IDs (e.g., U01234567)
+  attachmentsDir?: string;
+  attachmentsMaxBytes?: number;
 }
 
 export class SlackAdapter implements ChannelAdapter {
@@ -23,11 +28,15 @@ export class SlackAdapter implements ChannelAdapter {
   private app: InstanceType<typeof App> | null = null;
   private config: SlackConfig;
   private running = false;
+  private attachmentsDir?: string;
+  private attachmentsMaxBytes?: number;
   
   onMessage?: (msg: InboundMessage) => Promise<void>;
   
   constructor(config: SlackConfig) {
     this.config = config;
+    this.attachmentsDir = config.attachmentsDir;
+    this.attachmentsMaxBytes = config.attachmentsMaxBytes;
   }
   
   async start(): Promise<void> {
@@ -63,6 +72,10 @@ export class SlackAdapter implements ChannelAdapter {
       }
       
       if (this.onMessage) {
+        const attachments = await this.collectAttachments(
+          (message as { files?: SlackFile[] }).files,
+          channelId
+        );
         // Determine if this is a group/channel (not a DM)
         // DMs have channel IDs starting with 'D', channels start with 'C'
         const isGroup = !channelId.startsWith('D');
@@ -78,6 +91,7 @@ export class SlackAdapter implements ChannelAdapter {
           threadId: threadTs,
           isGroup,
           groupName: isGroup ? channelId : undefined,  // Would need conversations.info for name
+          attachments,
         });
       }
     });
@@ -97,6 +111,10 @@ export class SlackAdapter implements ChannelAdapter {
       }
       
       if (this.onMessage) {
+        const attachments = await this.collectAttachments(
+          (event as { files?: SlackFile[] }).files,
+          channelId
+        );
         // app_mention is always in a channel (group)
         const isGroup = !channelId.startsWith('D');
         
@@ -111,6 +129,7 @@ export class SlackAdapter implements ChannelAdapter {
           threadId: threadTs,
           isGroup,
           groupName: isGroup ? channelId : undefined,
+          attachments,
         });
       }
     });
@@ -142,6 +161,27 @@ export class SlackAdapter implements ChannelAdapter {
     
     return { messageId: result.ts || '' };
   }
+
+  async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
+    if (!this.app) throw new Error('Slack not started');
+
+    const basePayload = {
+      channels: file.chatId,
+      file: createReadStream(file.filePath),
+      filename: basename(file.filePath),
+      initial_comment: file.caption,
+    };
+    const result = file.threadId
+      ? await this.app.client.files.upload({ ...basePayload, thread_ts: file.threadId })
+      : await this.app.client.files.upload(basePayload);
+
+    const shares = (result.file as { shares?: Record<string, Record<string, { ts?: string }[]>> } | undefined)?.shares;
+    const ts = shares?.public?.[file.chatId]?.[0]?.ts
+      || shares?.private?.[file.chatId]?.[0]?.ts
+      || '';
+
+    return { messageId: ts };
+  }
   
   async editMessage(chatId: string, messageId: string, text: string): Promise<void> {
     if (!this.app) throw new Error('Slack not started');
@@ -152,9 +192,128 @@ export class SlackAdapter implements ChannelAdapter {
       text,
     });
   }
+
+  async addReaction(chatId: string, messageId: string, emoji: string): Promise<void> {
+    if (!this.app) throw new Error('Slack not started');
+    const name = resolveSlackEmojiName(emoji);
+    if (!name) {
+      throw new Error('Unknown emoji alias for Slack');
+    }
+    await this.app.client.reactions.add({
+      channel: chatId,
+      name,
+      timestamp: messageId,
+    });
+  }
   
   async sendTypingIndicator(_chatId: string): Promise<void> {
     // Slack doesn't have a typing indicator API for bots
     // This is a no-op
   }
+
+  private async collectAttachments(
+    files: SlackFile[] | undefined,
+    channelId: string
+  ): Promise<InboundAttachment[]> {
+    return collectSlackAttachments(
+      this.attachmentsDir,
+      this.attachmentsMaxBytes,
+      channelId,
+      files,
+      this.config.botToken
+    );
+  }
+}
+
+type SlackFile = {
+  id?: string;
+  name?: string;
+  mimetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
+};
+
+async function maybeDownloadSlackFile(
+  attachmentsDir: string | undefined,
+  attachmentsMaxBytes: number | undefined,
+  channelId: string,
+  file: SlackFile,
+  token: string
+): Promise<InboundAttachment> {
+  const name = file.name || file.id || 'attachment';
+  const url = file.url_private_download || file.url_private;
+  const attachment: InboundAttachment = {
+    id: file.id,
+    name,
+    mimeType: file.mimetype,
+    size: file.size,
+    kind: file.mimetype?.startsWith('image/') ? 'image' : 'file',
+    url,
+  };
+  if (!attachmentsDir) {
+    return attachment;
+  }
+  if (attachmentsMaxBytes === 0) {
+    return attachment;
+  }
+  if (attachmentsMaxBytes && file.size && file.size > attachmentsMaxBytes) {
+    console.warn(`[Slack] Attachment ${name} exceeds size limit, skipping download.`);
+    return attachment;
+  }
+  if (!url) {
+    return attachment;
+  }
+  const target = buildAttachmentPath(attachmentsDir, 'slack', channelId, name);
+  try {
+    await downloadToFile(url, target, { Authorization: `Bearer ${token}` });
+    attachment.localPath = target;
+  } catch (err) {
+    console.warn('[Slack] Failed to download attachment:', err);
+  }
+  return attachment;
+}
+
+async function collectSlackAttachments(
+  attachmentsDir: string | undefined,
+  attachmentsMaxBytes: number | undefined,
+  channelId: string,
+  files: SlackFile[] | undefined,
+  token: string
+): Promise<InboundAttachment[]> {
+  if (!files || files.length === 0) return [];
+  const attachments: InboundAttachment[] = [];
+  for (const file of files) {
+    attachments.push(await maybeDownloadSlackFile(attachmentsDir, attachmentsMaxBytes, channelId, file, token));
+  }
+  return attachments;
+}
+
+const EMOJI_ALIAS_TO_UNICODE: Record<string, string> = {
+  eyes: '👀',
+  thumbsup: '👍',
+  thumbs_up: '👍',
+  '+1': '👍',
+  heart: '❤️',
+  fire: '🔥',
+  smile: '😄',
+  laughing: '😆',
+  tada: '🎉',
+  clap: '👏',
+  ok_hand: '👌',
+};
+
+const UNICODE_TO_ALIAS = new Map<string, string>(
+  Object.entries(EMOJI_ALIAS_TO_UNICODE).map(([name, value]) => [value, name])
+);
+
+function resolveSlackEmojiName(input: string): string | null {
+  const aliasMatch = input.match(/^:([^:]+):$/);
+  if (aliasMatch) {
+    return aliasMatch[1];
+  }
+  if (EMOJI_ALIAS_TO_UNICODE[input]) {
+    return input;
+  }
+  return UNICODE_TO_ALIAS.get(input) || null;
 }

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -5,20 +5,24 @@
  * Supports DM pairing for secure access control.
  */
 
-import { Bot } from 'grammy';
+import { Bot, InputFile } from 'grammy';
 import type { ChannelAdapter } from './types.js';
-import type { InboundMessage, OutboundMessage } from '../core/types.js';
+import type { InboundAttachment, InboundMessage, OutboundFile, OutboundMessage } from '../core/types.js';
 import type { DmPolicy } from '../pairing/types.js';
 import {
   isUserAllowed,
   upsertPairingRequest,
   formatPairingMessage,
 } from '../pairing/store.js';
+import { basename } from 'node:path';
+import { buildAttachmentPath, downloadToFile } from './attachments.js';
 
 export interface TelegramConfig {
   token: string;
   dmPolicy?: DmPolicy;           // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: number[];       // Telegram user IDs (config allowlist)
+  attachmentsDir?: string;
+  attachmentsMaxBytes?: number;
 }
 
 export class TelegramAdapter implements ChannelAdapter {
@@ -28,6 +32,8 @@ export class TelegramAdapter implements ChannelAdapter {
   private bot: Bot;
   private config: TelegramConfig;
   private running = false;
+  private attachmentsDir?: string;
+  private attachmentsMaxBytes?: number;
   
   onMessage?: (msg: InboundMessage) => Promise<void>;
   onCommand?: (command: string) => Promise<string | null>;
@@ -38,6 +44,8 @@ export class TelegramAdapter implements ChannelAdapter {
       dmPolicy: config.dmPolicy || 'pairing',  // Default to pairing
     };
     this.bot = new Bot(config.token);
+    this.attachmentsDir = config.attachmentsDir;
+    this.attachmentsMaxBytes = config.attachmentsMaxBytes;
     this.setupHandlers();
   }
   
@@ -166,6 +174,30 @@ export class TelegramAdapter implements ChannelAdapter {
         });
       }
     });
+
+    // Handle non-text messages with attachments
+    this.bot.on('message', async (ctx) => {
+      if (!ctx.message || ctx.message.text) return;
+      const userId = ctx.from?.id;
+      const chatId = ctx.chat.id;
+      if (!userId) return;
+
+      const { attachments, caption } = await this.collectAttachments(ctx.message, String(chatId));
+      if (attachments.length === 0 && !caption) return;
+
+      if (this.onMessage) {
+        await this.onMessage({
+          channel: 'telegram',
+          chatId: String(chatId),
+          userId: String(userId),
+          userName: ctx.from.username || ctx.from.first_name,
+          messageId: String(ctx.message.message_id),
+          text: caption || '',
+          timestamp: new Date(),
+          attachments,
+        });
+      }
+    });
     
     // Error handler
     this.bot.catch((err) => {
@@ -207,11 +239,34 @@ export class TelegramAdapter implements ChannelAdapter {
     });
     return { messageId: String(result.message_id) };
   }
+
+  async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
+    const input = new InputFile(file.filePath);
+    const caption = file.caption || undefined;
+
+    if (file.kind === 'image') {
+      const result = await this.bot.api.sendPhoto(file.chatId, input, { caption });
+      return { messageId: String(result.message_id) };
+    }
+
+    const result = await this.bot.api.sendDocument(file.chatId, input, { caption });
+    return { messageId: String(result.message_id) };
+  }
   
   async editMessage(chatId: string, messageId: string, text: string): Promise<void> {
     const { markdownToTelegramV2 } = await import('./telegram-format.js');
     const formatted = markdownToTelegramV2(text);
     await this.bot.api.editMessageText(chatId, Number(messageId), formatted, { parse_mode: 'MarkdownV2' });
+  }
+
+  async addReaction(chatId: string, messageId: string, emoji: string): Promise<void> {
+    const resolved = resolveTelegramEmoji(emoji);
+    if (!TELEGRAM_REACTION_SET.has(resolved)) {
+      throw new Error(`Unsupported Telegram reaction emoji: ${resolved}`);
+    }
+    await this.bot.api.setMessageReaction(chatId, Number(messageId), [
+      { type: 'emoji', emoji: resolved as TelegramReactionEmoji },
+    ]);
   }
   
   async sendTypingIndicator(chatId: string): Promise<void> {
@@ -224,4 +279,188 @@ export class TelegramAdapter implements ChannelAdapter {
   getBot(): Bot {
     return this.bot;
   }
+
+  private async collectAttachments(
+    message: any,
+    chatId: string
+  ): Promise<{ attachments: InboundAttachment[]; caption?: string }> {
+    const attachments: InboundAttachment[] = [];
+    const caption = message.caption as string | undefined;
+
+    if (message.photo && message.photo.length > 0) {
+      const photo = message.photo[message.photo.length - 1];
+      const attachment = await this.fetchTelegramFile({
+        fileId: photo.file_id,
+        fileName: `photo-${photo.file_unique_id}.jpg`,
+        mimeType: 'image/jpeg',
+        size: photo.file_size,
+        kind: 'image',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.document) {
+      const doc = message.document;
+      const attachment = await this.fetchTelegramFile({
+        fileId: doc.file_id,
+        fileName: doc.file_name,
+        mimeType: doc.mime_type,
+        size: doc.file_size,
+        kind: 'file',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.video) {
+      const video = message.video;
+      const attachment = await this.fetchTelegramFile({
+        fileId: video.file_id,
+        fileName: video.file_name || `video-${video.file_unique_id}.mp4`,
+        mimeType: video.mime_type,
+        size: video.file_size,
+        kind: 'video',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.audio) {
+      const audio = message.audio;
+      const attachment = await this.fetchTelegramFile({
+        fileId: audio.file_id,
+        fileName: audio.file_name || `audio-${audio.file_unique_id}.mp3`,
+        mimeType: audio.mime_type,
+        size: audio.file_size,
+        kind: 'audio',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.voice) {
+      const voice = message.voice;
+      const attachment = await this.fetchTelegramFile({
+        fileId: voice.file_id,
+        fileName: `voice-${voice.file_unique_id}.ogg`,
+        mimeType: voice.mime_type,
+        size: voice.file_size,
+        kind: 'audio',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.animation) {
+      const animation = message.animation;
+      const attachment = await this.fetchTelegramFile({
+        fileId: animation.file_id,
+        fileName: animation.file_name || `animation-${animation.file_unique_id}.mp4`,
+        mimeType: animation.mime_type,
+        size: animation.file_size,
+        kind: 'video',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    if (message.sticker) {
+      const sticker = message.sticker;
+      const attachment = await this.fetchTelegramFile({
+        fileId: sticker.file_id,
+        fileName: `sticker-${sticker.file_unique_id}.${sticker.is_animated ? 'tgs' : 'webp'}`,
+        mimeType: sticker.mime_type,
+        size: sticker.file_size,
+        kind: 'image',
+        chatId,
+      });
+      if (attachment) attachments.push(attachment);
+    }
+
+    return { attachments, caption };
+  }
+
+  private async fetchTelegramFile(options: {
+    fileId: string;
+    fileName?: string;
+    mimeType?: string;
+    size?: number;
+    kind?: InboundAttachment['kind'];
+    chatId: string;
+  }): Promise<InboundAttachment | null> {
+    const { fileId, fileName, mimeType, size, kind, chatId } = options;
+    const attachment: InboundAttachment = {
+      id: fileId,
+      name: fileName,
+      mimeType,
+      size,
+      kind,
+    };
+
+    if (!this.attachmentsDir) {
+      return attachment;
+    }
+    if (this.attachmentsMaxBytes === 0) {
+      return attachment;
+    }
+    if (this.attachmentsMaxBytes && size && size > this.attachmentsMaxBytes) {
+      console.warn(`[Telegram] Attachment ${fileName || fileId} exceeds size limit, skipping download.`);
+      return attachment;
+    }
+
+    try {
+      const file = await this.bot.api.getFile(fileId);
+      const remotePath = file.file_path;
+      if (!remotePath) return attachment;
+      const resolvedName = fileName || basename(remotePath) || fileId;
+      const target = buildAttachmentPath(this.attachmentsDir, 'telegram', chatId, resolvedName);
+      const url = `https://api.telegram.org/file/bot${this.config.token}/${remotePath}`;
+      await downloadToFile(url, target);
+      attachment.localPath = target;
+    } catch (err) {
+      console.warn('[Telegram] Failed to download attachment:', err);
+    }
+    return attachment;
+  }
 }
+
+const TELEGRAM_EMOJI_ALIAS_TO_UNICODE: Record<string, string> = {
+  eyes: '👀',
+  thumbsup: '👍',
+  thumbs_up: '👍',
+  '+1': '👍',
+  heart: '❤️',
+  fire: '🔥',
+  smile: '😄',
+  laughing: '😆',
+  tada: '🎉',
+  clap: '👏',
+  ok_hand: '👌',
+};
+
+function resolveTelegramEmoji(input: string): string {
+  const match = input.match(/^:([^:]+):$/);
+  const alias = match ? match[1] : null;
+  if (alias && TELEGRAM_EMOJI_ALIAS_TO_UNICODE[alias]) {
+    return TELEGRAM_EMOJI_ALIAS_TO_UNICODE[alias];
+  }
+  if (TELEGRAM_EMOJI_ALIAS_TO_UNICODE[input]) {
+    return TELEGRAM_EMOJI_ALIAS_TO_UNICODE[input];
+  }
+  return input;
+}
+
+const TELEGRAM_REACTION_EMOJIS = [
+  '👍', '👎', '❤', '🔥', '🥰', '👏', '😁', '🤔', '🤯', '😱', '🤬', '😢',
+  '🎉', '🤩', '🤮', '💩', '🙏', '👌', '🕊', '🤡', '🥱', '🥴', '😍', '🐳',
+  '❤‍🔥', '🌚', '🌭', '💯', '🤣', '⚡', '🍌', '🏆', '💔', '🤨', '😐', '🍓',
+  '🍾', '💋', '🖕', '😈', '😴', '😭', '🤓', '👻', '👨‍💻', '👀', '🎃', '🙈',
+  '😇', '😨', '🤝', '✍', '🤗', '🫡', '🎅', '🎄', '☃', '💅', '🤪', '🗿',
+  '🆒', '💘', '🙉', '🦄', '😘', '💊', '🙊', '😎', '👾', '🤷‍♂', '🤷',
+  '🤷‍♀', '😡',
+] as const;
+
+type TelegramReactionEmoji = typeof TELEGRAM_REACTION_EMOJIS[number];
+
+const TELEGRAM_REACTION_SET = new Set<string>(TELEGRAM_REACTION_EMOJIS);

--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -6,22 +6,25 @@
  */
 
 import type { ChannelAdapter } from './types.js';
-import type { InboundMessage, OutboundMessage } from '../core/types.js';
+import type { InboundAttachment, InboundMessage, OutboundFile, OutboundMessage } from '../core/types.js';
 import type { DmPolicy } from '../pairing/types.js';
 import {
   isUserAllowed,
   upsertPairingRequest,
   formatPairingMessage,
 } from '../pairing/store.js';
-import { existsSync, mkdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
 import qrcode from 'qrcode-terminal';
+import { buildAttachmentPath, writeStreamToFile } from './attachments.js';
 
 export interface WhatsAppConfig {
   sessionPath?: string;  // Where to store auth state
   dmPolicy?: DmPolicy;   // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: string[]; // Phone numbers (e.g., +15551234567)
   selfChatMode?: boolean; // Respond to "message yourself" (for personal number use)
+  attachmentsDir?: string;
+  attachmentsMaxBytes?: number;
 }
 
 export class WhatsAppAdapter implements ChannelAdapter {
@@ -32,6 +35,9 @@ export class WhatsAppAdapter implements ChannelAdapter {
   private config: WhatsAppConfig;
   private running = false;
   private sessionPath: string;
+  private attachmentsDir?: string;
+  private attachmentsMaxBytes?: number;
+  private downloadContentFromMessage?: (message: any, type: string) => Promise<AsyncIterable<Uint8Array>>;
   private myJid: string = '';  // Bot's own JID (for selfChatMode)
   private myNumber: string = ''; // Bot's phone number
   private selfChatLid: string = ''; // Self-chat LID (for selfChatMode conversion)
@@ -47,6 +53,8 @@ export class WhatsAppAdapter implements ChannelAdapter {
       dmPolicy: config.dmPolicy || 'pairing',  // Default to pairing
     };
     this.sessionPath = resolve(config.sessionPath || './data/whatsapp-session');
+    this.attachmentsDir = config.attachmentsDir;
+    this.attachmentsMaxBytes = config.attachmentsMaxBytes;
   }
   
   /**
@@ -142,6 +150,7 @@ Ask the bot owner to approve with:
       DisconnectReason,
       fetchLatestBaileysVersion,
       makeCacheableSignalKeyStore,
+      downloadContentFromMessage,
     } = await import('@whiskeysockets/baileys');
     
     // Load auth state
@@ -175,6 +184,10 @@ Ask the bot owner to approve with:
       markOnlineOnConnect: false,
       logger: silentLogger as any,
     });
+    this.downloadContentFromMessage = downloadContentFromMessage as unknown as (
+      message: any,
+      type: string
+    ) => Promise<AsyncIterable<Uint8Array>>;
     
     // Save credentials when updated
     this.sock.ev.on('creds.update', saveCreds);
@@ -253,12 +266,14 @@ Ask the bot owner to approve with:
           this.lidToJid.set(remoteJid, (m.key as any).senderPn);
         }
         
-        // Get message text
-        const text = m.message?.conversation || 
-                     m.message?.extendedTextMessage?.text ||
+        const messageContent = this.unwrapMessageContent(m.message);
+        const text = messageContent?.conversation ||
+                     messageContent?.extendedTextMessage?.text ||
                      '';
+        const preview = this.extractMediaPreview(messageContent);
+        const resolvedText = text || preview.caption || '';
         
-        if (!text) continue;
+        if (!resolvedText && !preview.hasMedia) continue;
         
         const userId = remoteJid.replace('@s.whatsapp.net', '').replace('@g.us', '');
         const isGroup = remoteJid.endsWith('@g.us');
@@ -302,17 +317,22 @@ Ask the bot owner to approve with:
         }
         
         if (this.onMessage) {
+          const attachments = preview.hasMedia
+            ? (await this.collectAttachments(messageContent, remoteJid, messageId)).attachments
+            : [];
+          const finalText = text || preview.caption || '';
           await this.onMessage({
             channel: 'whatsapp',
             chatId: remoteJid,
             userId,
             userName: pushName || undefined,
             messageId: m.key?.id || undefined,
-            text,
+            text: finalText,
             timestamp: new Date(m.messageTimestamp * 1000),
             isGroup,
             // Group name would require additional API call to get chat metadata
             // For now, we don't have it readily available from the message
+            attachments,
           });
         }
       }
@@ -331,22 +351,8 @@ Ask the bot owner to approve with:
   
   async sendMessage(msg: OutboundMessage): Promise<{ messageId: string }> {
     if (!this.sock) throw new Error('WhatsApp not connected');
-    
-    // Convert LID to proper JID for sending
-    let targetJid = msg.chatId;
-    if (targetJid.includes('@lid')) {
-      if (targetJid === this.selfChatLid && this.myNumber) {
-        // Self-chat LID -> our own number
-        targetJid = `${this.myNumber}@s.whatsapp.net`;
-      } else if (this.lidToJid.has(targetJid)) {
-        // Friend LID -> their real JID from senderPn
-        targetJid = this.lidToJid.get(targetJid)!;
-      } else {
-        // FAIL SAFE: Don't send to unknown LID - could go to wrong person
-        console.error(`[WhatsApp] Cannot send to unknown LID: ${targetJid}`);
-        throw new Error(`Cannot send to unknown LID - no mapping found`);
-      }
-    }
+
+    const targetJid = this.resolveTargetJid(msg.chatId);
     
     try {
       const result = await this.sock.sendMessage(targetJid, { text: msg.text });
@@ -365,6 +371,29 @@ Ask the bot owner to approve with:
       throw error;
     }
   }
+
+  async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
+    if (!this.sock) throw new Error('WhatsApp not connected');
+
+    const targetJid = this.resolveTargetJid(file.chatId);
+    const caption = file.caption || undefined;
+    const fileName = basename(file.filePath);
+    const payload = file.kind === 'image'
+      ? { image: { url: file.filePath }, caption }
+      : { document: { url: file.filePath }, caption, fileName };
+
+    const result = await this.sock.sendMessage(targetJid, payload);
+    const messageId = result?.key?.id || '';
+    if (messageId) {
+      this.sentMessageIds.add(messageId);
+      setTimeout(() => this.sentMessageIds.delete(messageId), 60000);
+    }
+    return { messageId };
+  }
+
+  async addReaction(_chatId: string, _messageId: string, _emoji: string): Promise<void> {
+    // WhatsApp reactions via Baileys are not supported here yet.
+  }
   
   supportsEditing(): boolean {
     return false;
@@ -378,4 +407,129 @@ Ask the bot owner to approve with:
     if (!this.sock) return;
     await this.sock.sendPresenceUpdate('composing', chatId);
   }
+
+  private unwrapMessageContent(message: any): any {
+    if (!message) return null;
+    if (message.ephemeralMessage?.message) return message.ephemeralMessage.message;
+    if (message.viewOnceMessage?.message) return message.viewOnceMessage.message;
+    if (message.viewOnceMessageV2?.message) return message.viewOnceMessageV2.message;
+    return message;
+  }
+
+  private extractMediaPreview(messageContent: any): { hasMedia: boolean; caption?: string } {
+    if (!messageContent) return { hasMedia: false };
+    const mediaMessage = messageContent.imageMessage
+      || messageContent.videoMessage
+      || messageContent.audioMessage
+      || messageContent.documentMessage
+      || messageContent.stickerMessage;
+    if (!mediaMessage) return { hasMedia: false };
+    return { hasMedia: true, caption: mediaMessage.caption as string | undefined };
+  }
+
+  private async collectAttachments(
+    messageContent: any,
+    chatId: string,
+    messageId: string
+  ): Promise<{ attachments: InboundAttachment[]; caption?: string }> {
+    const attachments: InboundAttachment[] = [];
+    if (!messageContent) return { attachments };
+    if (!this.downloadContentFromMessage) return { attachments };
+
+    let mediaMessage: any;
+    let mediaType: 'image' | 'video' | 'audio' | 'document' | 'sticker' | null = null;
+    let kind: InboundAttachment['kind'] = 'file';
+
+    if (messageContent.imageMessage) {
+      mediaMessage = messageContent.imageMessage;
+      mediaType = 'image';
+      kind = 'image';
+    } else if (messageContent.videoMessage) {
+      mediaMessage = messageContent.videoMessage;
+      mediaType = 'video';
+      kind = 'video';
+    } else if (messageContent.audioMessage) {
+      mediaMessage = messageContent.audioMessage;
+      mediaType = 'audio';
+      kind = 'audio';
+    } else if (messageContent.documentMessage) {
+      mediaMessage = messageContent.documentMessage;
+      mediaType = 'document';
+      kind = 'file';
+    } else if (messageContent.stickerMessage) {
+      mediaMessage = messageContent.stickerMessage;
+      mediaType = 'sticker';
+      kind = 'image';
+    }
+
+    if (!mediaMessage || !mediaType) return { attachments };
+
+    const mimeType = mediaMessage.mimetype as string | undefined;
+    const fileLength = mediaMessage.fileLength;
+    const size = typeof fileLength === 'number'
+      ? fileLength
+      : typeof fileLength?.toNumber === 'function'
+        ? fileLength.toNumber()
+        : undefined;
+    const ext = extensionFromMime(mimeType);
+    const defaultName = `whatsapp-${messageId}.${ext}`;
+    const name = mediaMessage.fileName || defaultName;
+
+    const attachment: InboundAttachment = {
+      name,
+      mimeType,
+      size,
+      kind,
+    };
+
+    if (this.attachmentsDir) {
+      if (this.attachmentsMaxBytes === 0) {
+        attachments.push(attachment);
+        const caption = mediaMessage.caption as string | undefined;
+        return { attachments, caption };
+      }
+      if (this.attachmentsMaxBytes && size && size > this.attachmentsMaxBytes) {
+        console.warn(`[WhatsApp] Attachment ${name} exceeds size limit, skipping download.`);
+        attachments.push(attachment);
+        const caption = mediaMessage.caption as string | undefined;
+        return { attachments, caption };
+      }
+      const target = buildAttachmentPath(this.attachmentsDir, 'whatsapp', chatId, name);
+      try {
+        const stream = await this.downloadContentFromMessage(mediaMessage, mediaType);
+        await writeStreamToFile(stream, target);
+        attachment.localPath = target;
+      } catch (err) {
+        console.warn('[WhatsApp] Failed to download attachment:', err);
+      }
+    }
+
+    attachments.push(attachment);
+    const caption = mediaMessage.caption as string | undefined;
+    return { attachments, caption };
+  }
+
+  private resolveTargetJid(chatId: string): string {
+    let targetJid = chatId;
+    if (targetJid.includes('@lid')) {
+      if (targetJid === this.selfChatLid && this.myNumber) {
+        targetJid = `${this.myNumber}@s.whatsapp.net`;
+      } else if (this.lidToJid.has(targetJid)) {
+        targetJid = this.lidToJid.get(targetJid)!;
+      } else {
+        console.error(`[WhatsApp] Cannot send to unknown LID: ${targetJid}`);
+        throw new Error('Cannot send to unknown LID - no mapping found');
+      }
+    }
+    return targetJid;
+  }
+}
+
+function extensionFromMime(mimeType?: string): string {
+  if (!mimeType) return 'bin';
+  const clean = mimeType.split(';')[0] || '';
+  const parts = clean.split('/');
+  if (parts.length < 2) return 'bin';
+  const ext = parts[1].trim();
+  return ext || 'bin';
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -158,6 +158,13 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.integrations?.google?.enabled && config.integrations.google.account) {
     env.GMAIL_ACCOUNT = config.integrations.google.account;
   }
+
+  if (config.attachments?.maxMB !== undefined) {
+    env.ATTACHMENTS_MAX_MB = String(config.attachments.maxMB);
+  }
+  if (config.attachments?.maxAgeDays !== undefined) {
+    env.ATTACHMENTS_MAX_AGE_DAYS = String(config.attachments.maxAgeDays);
+  }
   
   return env;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,12 @@ export interface LettaBotConfig {
   integrations?: {
     google?: GoogleConfig;
   };
+
+  // Attachment handling
+  attachments?: {
+    maxMB?: number;
+    maxAgeDays?: number;
+  };
 }
 
 export interface ProviderConfig {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,6 +45,16 @@ export interface TriggerContext {
 
 export type ChannelId = 'telegram' | 'slack' | 'whatsapp' | 'signal' | 'discord';
 
+export interface InboundAttachment {
+  id?: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  url?: string;
+  localPath?: string;
+  kind?: 'image' | 'file' | 'audio' | 'video';
+}
+
 /**
  * Inbound message from any channel
  */
@@ -60,6 +70,7 @@ export interface InboundMessage {
   threadId?: string;      // Slack thread_ts
   isGroup?: boolean;      // Is this from a group chat?
   groupName?: string;     // Group/channel name if applicable
+  attachments?: InboundAttachment[];
 }
 
 /**
@@ -70,6 +81,17 @@ export interface OutboundMessage {
   text: string;
   replyToMessageId?: string;
   threadId?: string;  // Slack thread_ts
+}
+
+/**
+ * Outbound file/image to any channel.
+ */
+export interface OutboundFile {
+  chatId: string;
+  filePath: string;
+  caption?: string;
+  threadId?: string;
+  kind?: 'image' | 'file';
 }
 
 /**


### PR DESCRIPTION
## Summary\n- capture inbound attachment metadata and include it in the message envelope\n- download inbound attachments (Slack/Discord/Telegram/WhatsApp) with size limits and retention config\n- prune attachments older than 14 days on startup and daily\n\n## Testing\n- npm run build *(fails: missing update-notifier dependency in src/cli.ts)*\n\nCloses #56