### PR TITLE
feat: Add conversation persistence across messages

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -43,13 +43,22 @@ export class Store {
     // Allow env var override (useful for local server testing with specific agent)
     return this.data.agentId || process.env.LETTA_AGENT_ID || null;
   }
-  
+
   set agentId(id: string | null) {
     this.data.agentId = id;
     this.data.lastUsedAt = new Date().toISOString();
     if (id && !this.data.createdAt) {
       this.data.createdAt = new Date().toISOString();
     }
+    this.save();
+  }
+
+  get conversationId(): string | null {
+    return this.data.conversationId || null;
+  }
+
+  set conversationId(id: string | null) {
+    this.data.conversationId = id;
     this.save();
   }
   

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -99,6 +99,7 @@ export interface LastMessageTarget {
  */
 export interface AgentStore {
   agentId: string | null;
+  conversationId?: string | null; // Current conversation to resume
   baseUrl?: string; // Server URL this agent belongs to
   createdAt?: string;
   lastUsedAt?: string;


### PR DESCRIPTION
Previously, each message created a new conversation, losing context between requests. This change:

- Track conversationId in AgentStore for persistence
- Use resumeSession() when conversationId exists (same conversation)
- Use createSession(agentId) when only agentId exists (new conversation, same agent)
- Use createSession(undefined, {...}) for new agent creation
- Save conversationId after each message for resumption

This allows messages to the same chat to maintain conversation context while still preserving agent memory across conversation resets.