### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your personal AI assistant that remembers everything across **Telegram, Slack, D
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - A Letta API key from [app.letta.com](https://app.letta.com) (or a running [Letta Docker server](https://docs.letta.com/guides/docker/))
 - A Telegram bot token from [@BotFather](https://t.me/BotFather)
 


### PR DESCRIPTION
Lettabot actually requires Node 20+

If you try to install it under Node 18, you'll get a bunch of warnings
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@isaacs/balanced-match@4.0.1',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v18.19.1', npm: '9.2.0' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@isaacs/brace-expansion@5.0.0',
npm WARN EBADENGINE   required: { node: '20 || >=22' },
npm WARN EBADENGINE   current: { node: 'v18.19.1', npm: '9.2.0' }
npm WARN EBADENGINE }
...
```

When it tries to install `@whiskeysockets/baileys`