### PR TITLE
fix(whatsapp): skip historical backfill messages

### DIFF
--- a/src/channels/whatsapp.ts
+++ b/src/channels/whatsapp.ts
@@ -208,6 +208,11 @@ Ask the bot owner to approve with:
     
     // Handle incoming messages
     this.sock.ev.on('messages.upsert', async ({ messages, type }: any) => {
+      // Only process new messages, not historical backfill
+      if (type !== 'notify') {
+        console.log(`[WhatsApp] Skipping ${messages.length} historical message(s) (type: ${type})`);
+        return;
+      }
       
       for (const m of messages) {
         const messageId = m.key.id || '';


### PR DESCRIPTION
## Summary

- Filter WhatsApp `messages.upsert` events to only process `type: 'notify'` (new messages)
- Skip `type: 'append'` (historical backfill) to prevent responding to old messages on reconnect
- Log skipped messages for debugging visibility

## Problem

The WhatsApp adapter was processing ALL messages from `messages.upsert`, including historical sync messages. This could cause the bot to respond to old messages when:
- Reconnecting after being offline
- WhatsApp performs history sync

## Solution

Check the `type` parameter (which was already destructured but unused) and early-return for non-`notify` messages.

Written by Cameron ◯ Letta Code

"The present is theirs; the future, for which I really worked, is mine." - Nikola Tesla