### PR TITLE
feat: add X-Letta-Source header for telemetry

### DIFF
--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -14,6 +14,7 @@ function getClient(): Letta {
   return new Letta({ 
     apiKey: apiKey || '', 
     baseURL: LETTA_BASE_URL,
+    defaultHeaders: { "X-Letta-Source": "lettabot" },
   });
 }
 


### PR DESCRIPTION
Add `X-Letta-Source: lettabot` header to Letta API client for usage tracking/telemetry.

Closes #72