### PR TITLE
feat: add Railway template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ That's it! Message your bot on Telegram.
 
 > **Note:** For detailed environment variable reference and multi-channel setup, see [SKILL.md](./SKILL.md)
 
+## Deploy to Railway
+
+Deploy LettaBot to the cloud with one click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/letta-ai/lettabot)
+
+You'll need:
+- A Letta API key from [app.letta.com](https://app.letta.com)
+- A Telegram bot token (or other channel credentials)
+
+See [Railway Setup Guide](docs/railway-setup.md) for detailed instructions.
+
 ## Voice Messages
 
 LettaBot can transcribe voice messages using OpenAI Whisper. Voice messages are automatically converted to text and sent to the agent with a `[Voice message]:` prefix.
@@ -296,6 +308,7 @@ lettabot destroy
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)
+- [Railway Deployment](docs/railway-setup.md)
 - [Slack Setup](docs/slack-setup.md)
 - [Discord Setup](docs/discord-setup.md)
 - [WhatsApp Setup](docs/whatsapp-setup.md)

--- a/docs/railway-setup.md
+++ b/docs/railway-setup.md
@@ -1,0 +1,129 @@
+# Deploy LettaBot on Railway
+
+Railway provides a simple way to deploy LettaBot to the cloud with persistent storage and automatic restarts.
+
+## Quick Start
+
+1. Click the Deploy button in the README (or create a new project from the [lettabot repo](https://github.com/letta-ai/lettabot))
+2. Set the required environment variables
+3. Deploy
+
+## Required Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LETTA_API_KEY` | Your API key from [app.letta.com](https://app.letta.com) |
+
+Plus at least ONE channel:
+
+| Channel | Variable | How to get it |
+|---------|----------|---------------|
+| Telegram | `TELEGRAM_BOT_TOKEN` | Message [@BotFather](https://t.me/BotFather) on Telegram |
+| Slack | `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` | Create app at [api.slack.com/apps](https://api.slack.com/apps) |
+| Discord | `DISCORD_BOT_TOKEN` | Create app at [discord.com/developers](https://discord.com/developers/applications) |
+
+## Optional Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LETTA_BASE_URL` | `https://api.letta.com` | For self-hosted Letta servers |
+| `AGENT_NAME` | `LettaBot` | Name for your agent |
+| `MODEL` | `zai/glm-4.7` | Model to use (free) |
+| `WORKING_DIR` | `/tmp/lettabot` | Data directory (set to `/data` with volume) |
+| `TELEGRAM_DM_POLICY` | `pairing` | Access control: `pairing`, `allowlist`, or `open` |
+| `SLACK_ALLOWED_USERS` | (empty) | Comma-separated Slack user IDs |
+| `DISCORD_DM_POLICY` | `pairing` | Access control: `pairing`, `allowlist`, or `open` |
+
+## Persistent Storage
+
+To persist the agent ID and session data across redeploys:
+
+1. In Railway, go to your service settings
+2. Add a **Volume** mounted at `/data`
+3. Set `WORKING_DIR=/data` in your environment variables
+
+This ensures:
+- Agent ID is preserved (no duplicate agents)
+- WhatsApp session persists (if using WhatsApp)
+- Cron jobs are saved
+
+## Self-Hosted Letta Server
+
+To use a self-hosted Letta server instead of Letta Cloud:
+
+1. Set `LETTA_BASE_URL` to your server URL (e.g., `http://your-letta-service:8283`)
+2. Leave `LETTA_API_KEY` empty (or set it if your server requires auth)
+
+You can run Letta as another Railway service:
+
+```bash
+# In another Railway service, use the official Letta Docker image
+docker.io/letta/letta:latest
+```
+
+## Channel-Specific Notes
+
+### Telegram (Recommended)
+Easiest channel to set up. Just need the bot token from @BotFather.
+
+### Slack
+Requires two tokens:
+- **Bot Token** (`xoxb-...`) - OAuth & Permissions page
+- **App Token** (`xapp-...`) - Basic Information > App-Level Tokens
+
+Enable Socket Mode in your Slack app settings.
+
+### Discord
+Requires:
+- Bot token from the Bot section
+- **Message Content Intent** enabled under Privileged Gateway Intents
+
+### WhatsApp (Advanced)
+WhatsApp requires a QR code scan on first setup:
+
+1. Deploy to Railway
+2. View the deployment logs
+3. Look for the QR code in the logs
+4. Scan with your phone (WhatsApp > Settings > Linked Devices)
+
+With a volume mounted, subsequent deploys won't need re-scanning.
+
+Set `WHATSAPP_ENABLED=true` and optionally:
+- `WHATSAPP_SELF_CHAT_MODE=true` for personal number (only responds to "Message Yourself")
+- `WHATSAPP_SELF_CHAT_MODE=false` for dedicated bot number (responds to all)
+
+### Signal
+Signal is **not supported** on Railway as it requires the signal-cli daemon.
+
+## Access Control
+
+By default, LettaBot uses **pairing** mode:
+1. Unauthorized users get a pairing code
+2. You approve codes via the CLI
+
+On Railway, you can't easily run CLI commands, so consider:
+- **allowlist mode**: Set `TELEGRAM_DM_POLICY=allowlist` and `TELEGRAM_ALLOWED_USERS=123456789`
+- **open mode**: Set `TELEGRAM_DM_POLICY=open` (not recommended for public bots)
+
+To approve pairing codes, you can use Railway's shell feature or the Letta Code CLI connected to the same agent.
+
+## Health Checks
+
+LettaBot exposes a health endpoint at `/health` on the `PORT` environment variable (Railway sets this automatically).
+
+## Troubleshooting
+
+### "No config found" error
+Make sure you have `LETTA_API_KEY` set AND at least one channel token.
+
+### Agent keeps getting recreated
+Mount a volume at `/data` and set `WORKING_DIR=/data` to persist the agent ID.
+
+### WhatsApp disconnects frequently
+This is normal during initial setup. Once paired and with a volume mounted, it should stabilize.
+
+### Can't access pairing approval
+Either:
+- Use allowlist mode instead of pairing
+- Use Railway's shell feature to run `lettabot pairing list`
+- Connect via Letta Code CLI to the same agent

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS"
+  },
+  "deploy": {
+    "startCommand": "npm run build && npm run start",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "on_failure"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,40 @@ import { spawn } from 'node:child_process';
 // Load YAML config and apply to process.env (overrides .env values)
 import { loadConfig, applyConfigToEnv, syncProviders, resolveConfigPath } from './config/index.js';
 import { isLettaCloudUrl } from './utils/server.js';
+
+// Check if sufficient ENV vars are set for headless/Railway deployment
+function hasSufficientEnvConfig(): boolean {
+  // Need API key (cloud) or base URL (self-hosted)
+  const hasAuth = !!process.env.LETTA_API_KEY || !!process.env.LETTA_BASE_URL;
+  
+  // Need at least one channel
+  const hasChannel = !!(
+    process.env.TELEGRAM_BOT_TOKEN ||
+    process.env.SLACK_BOT_TOKEN ||
+    process.env.DISCORD_BOT_TOKEN ||
+    process.env.WHATSAPP_ENABLED === 'true' ||
+    process.env.SIGNAL_PHONE_NUMBER
+  );
+  
+  return hasAuth && hasChannel;
+}
+
+// Check if config exists BEFORE loading - auto-onboard from ENV vars if possible (Railway/Docker support)
+const configPath = resolveConfigPath();
+if (!existsSync(configPath)) {
+  if (hasSufficientEnvConfig()) {
+    console.log('[Config] No config file found, running setup from environment variables...');
+    const { onboard } = await import('./onboard.js');
+    await onboard({ nonInteractive: true });
+  } else {
+    console.log(`\n  No config found. Either:`);
+    console.log(`    1. Run "lettabot onboard" for interactive setup`);
+    console.log(`    2. Set LETTA_API_KEY + channel token(s) as environment variables\n`);
+    process.exit(1);
+  }
+}
+
+// Now load the config (either existing or just created by auto-onboard)
 const yamlConfig = loadConfig();
 console.log(`[Config] Loaded from ${resolveConfigPath()}`);
 console.log(`[Config] Mode: ${yamlConfig.server.mode}, Agent: ${yamlConfig.agent.name}, Model: ${yamlConfig.agent.model}`);
@@ -119,13 +153,6 @@ import { HeartbeatService } from './cron/heartbeat.js';
 import { PollingService } from './polling/service.js';
 import { agentExists } from './tools/letta-api.js';
 import { installSkillsToWorkingDir } from './skills/loader.js';
-
-// Check if config exists
-const configPath = resolveConfigPath();
-if (!existsSync(configPath)) {
-  console.log(`\n  No config found at ${configPath}. Run "lettabot onboard" first.\n`);
-  process.exit(1);
-}
 
 // Parse heartbeat target (format: "telegram:123456789", "slack:C1234567890", or "discord:123456789012345678")
 function parseHeartbeatTarget(raw?: string): { channel: string; chatId: string } | undefined {


### PR DESCRIPTION
## Summary

- Auto-onboard from ENV vars when no config file exists
- Add `railway.json` for build/deploy configuration  
- Add comprehensive Railway deployment guide (`docs/railway-setup.md`)
- Add "Deploy on Railway" button to README

## How it works

When LettaBot starts without a config file but with sufficient environment variables (`LETTA_API_KEY` + at least one channel token), it automatically runs the non-interactive onboard to create the config. This enables one-click deployment to Railway.

## Test plan

- [ ] Test local startup with ENV vars only (no lettabot.yaml)
- [ ] Test Railway deployment
- [ ] Verify health check endpoint works
- [ ] Test with volume for persistent storage

## Files changed

| File | Change |
|------|--------|
| `src/main.ts` | Added `hasSufficientEnvConfig()` + auto-onboard logic |
| `railway.json` | New - Railway build/deploy config |
| `docs/railway-setup.md` | New - Deployment guide |
| `README.md` | Added Deploy button + docs link |