### PR TITLE
Fallback when default conversation is missing

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -214,7 +214,11 @@ export class LettaBot {
       }
       console.log('[Bot] Session created/resumed');
       
-      const initTimeoutMs = 30000; // 30s timeout
+      const defaultTimeoutMs = 30000; // 30s timeout
+      const envTimeoutMs = Number(process.env.LETTA_SESSION_TIMEOUT_MS);
+      const initTimeoutMs = Number.isFinite(envTimeoutMs) && envTimeoutMs > 0
+        ? envTimeoutMs
+        : defaultTimeoutMs;
       const withTimeout = async <T>(promise: Promise<T>, label: string): Promise<T> => {
         let timeoutId: NodeJS.Timeout;
         const timeoutPromise = new Promise<T>((_, reject) => {


### PR DESCRIPTION
## Summary
- When resuming the default conversation on an existing agent, fallback to creating a new conversation if the default is missing.
- Apply the same fallback for silent sends (cron/heartbeat) in `sendToAgent`.

## Testing
- npm run build

Fixes #78
