### PR TITLE
fix(voice): telegram transcription + signal diagnostics

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -175,9 +175,9 @@ export class TelegramAdapter implements ChannelAdapter {
       }
     });
 
-    // Handle non-text messages with attachments
+    // Handle non-text messages with attachments (excluding voice - handled separately)
     this.bot.on('message', async (ctx) => {
-      if (!ctx.message || ctx.message.text) return;
+      if (!ctx.message || ctx.message.text || ctx.message.voice) return;
       const userId = ctx.from?.id;
       const chatId = ctx.chat.id;
       if (!userId) return;


### PR DESCRIPTION
## Problems

**Telegram**: Voice files arrive but no auto-transcription. The generic `message` handler was processing voice messages as attachments before `message:voice` could transcribe them.

**Signal**: Inconsistent - sometimes transcription works, sometimes shows `[Voice message received]` with no content.

## Fixes

### Telegram
Skip voice messages in the generic attachment handler so they're processed by the dedicated voice handler:
```typescript
if (!ctx.message || ctx.message.text || ctx.message.voice) return;
```

### Signal
Added diagnostic logging to understand failures:
- Log all attachments received
- Check file existence before reading
- Warn when audio attachment has no ID

This will help identify why Signal voice messages sometimes fail.