### PR TITLE
test: add formatter and backoff unit tests

### DIFF
--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import { formatMessageEnvelope } from './formatter.js';
+import type { InboundMessage } from './types.js';
+
+// Helper to create base message
+function createMessage(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    channel: 'telegram',
+    chatId: '123456789',
+    userId: 'user123',
+    text: 'Hello world',
+    timestamp: new Date('2026-02-02T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('formatMessageEnvelope', () => {
+  describe('basic envelope structure', () => {
+    it('includes channel and chatId', () => {
+      const msg = createMessage({ channel: 'telegram', chatId: '123' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('[telegram:123');
+    });
+
+    it('includes messageId when present', () => {
+      const msg = createMessage({ messageId: 'msg456' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('msg:msg456');
+    });
+
+    it('omits messageId when not present', () => {
+      const msg = createMessage({ messageId: undefined });
+      const result = formatMessageEnvelope(msg);
+      expect(result).not.toContain('msg:');
+    });
+
+    it('includes message text after envelope', () => {
+      const msg = createMessage({ text: 'Test message' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('] Test message');
+    });
+  });
+
+  describe('sender formatting', () => {
+    it('uses userName when available', () => {
+      const msg = createMessage({ userName: 'John Doe' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('John Doe');
+    });
+
+    it('formats Slack users with @ prefix', () => {
+      const msg = createMessage({ 
+        channel: 'slack', 
+        userName: undefined,
+        userHandle: 'cameron' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('@cameron');
+    });
+
+    it('formats Discord users with @ prefix', () => {
+      const msg = createMessage({ 
+        channel: 'discord', 
+        userName: undefined,
+        userHandle: 'user#1234' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('@user#1234');
+    });
+
+    it('formats US phone numbers nicely for WhatsApp', () => {
+      const msg = createMessage({ 
+        channel: 'whatsapp', 
+        userName: undefined,
+        userId: '+15551234567' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('+1 (555) 123-4567');
+    });
+
+    it('formats 10-digit phone numbers as US', () => {
+      const msg = createMessage({ 
+        channel: 'whatsapp', 
+        userName: undefined,
+        userId: '5551234567' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('+1 (555) 123-4567');
+    });
+  });
+
+  describe('group formatting', () => {
+    it('includes group name for group chats', () => {
+      const msg = createMessage({ 
+        isGroup: true, 
+        groupName: 'Test Group' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('Test Group');
+    });
+
+    it('adds # prefix for Slack channels', () => {
+      const msg = createMessage({ 
+        channel: 'slack',
+        isGroup: true, 
+        groupName: 'general' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('#general');
+    });
+
+    it('adds # prefix for Discord channels', () => {
+      const msg = createMessage({ 
+        channel: 'discord',
+        isGroup: true, 
+        groupName: 'chat' 
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('#chat');
+    });
+
+    it('omits group name for DMs', () => {
+      const msg = createMessage({ isGroup: false });
+      const result = formatMessageEnvelope(msg);
+      expect(result).not.toContain('#');
+    });
+  });
+
+  describe('format hints', () => {
+    it('includes Slack format hint', () => {
+      const msg = createMessage({ channel: 'slack' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('(Format: mrkdwn:');
+    });
+
+    it('includes Telegram format hint', () => {
+      const msg = createMessage({ channel: 'telegram' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('(Format: MarkdownV2:');
+    });
+
+    it('includes WhatsApp format hint', () => {
+      const msg = createMessage({ channel: 'whatsapp' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('(Format:');
+      expect(result).toContain('NO: headers');
+    });
+
+    it('includes Signal format hint', () => {
+      const msg = createMessage({ channel: 'signal' });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('(Format: ONLY:');
+    });
+  });
+
+  describe('attachments', () => {
+    it('includes attachment info', () => {
+      const msg = createMessage({
+        attachments: [{
+          id: 'att1',
+          name: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024,
+        }]
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('Attachments:');
+      expect(result).toContain('photo.jpg');
+      expect(result).toContain('image/jpeg');
+    });
+
+    it('formats file sizes correctly', () => {
+      const msg = createMessage({
+        attachments: [
+          { id: '1', name: 'small.txt', size: 500 },
+          { id: '2', name: 'medium.txt', size: 2048 },
+          { id: '3', name: 'large.txt', size: 1048576 },
+        ]
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('500 B');
+      expect(result).toContain('2.0 KB');
+      expect(result).toContain('1.0 MB');
+    });
+
+    it('includes local path when available', () => {
+      const msg = createMessage({
+        attachments: [{
+          id: 'att1',
+          name: 'doc.pdf',
+          localPath: '/tmp/lettabot/attachments/doc.pdf',
+        }]
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('saved to /tmp/lettabot/attachments/doc.pdf');
+    });
+  });
+
+  describe('options', () => {
+    it('respects includeSender: false', () => {
+      const msg = createMessage({ userName: 'John' });
+      const result = formatMessageEnvelope(msg, { includeSender: false });
+      expect(result).not.toContain('John');
+    });
+
+    it('respects includeGroup: false', () => {
+      const msg = createMessage({ isGroup: true, groupName: 'TestGroup' });
+      const result = formatMessageEnvelope(msg, { includeGroup: false });
+      expect(result).not.toContain('TestGroup');
+    });
+
+    it('respects includeDay: false', () => {
+      const msg = createMessage();
+      const result = formatMessageEnvelope(msg, { includeDay: false });
+      // Should not include day of week
+      expect(result).not.toMatch(/Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/);
+    });
+  });
+});

--- a/src/utils/backoff.test.ts
+++ b/src/utils/backoff.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { 
+  computeBackoff, 
+  createReconnectManager, 
+  sleepWithAbort,
+  DEFAULT_RECONNECT_POLICY,
+  type BackoffPolicy,
+  type ReconnectPolicy,
+} from './backoff.js';
+
+describe('computeBackoff', () => {
+  const policy: BackoffPolicy = {
+    initialMs: 1000,
+    maxMs: 10000,
+    factor: 2,
+    jitter: 0, // No jitter for predictable tests
+  };
+
+  it('returns initialMs for first attempt', () => {
+    const delay = computeBackoff(policy, 1);
+    expect(delay).toBe(1000);
+  });
+
+  it('doubles delay for each attempt (factor=2)', () => {
+    expect(computeBackoff(policy, 1)).toBe(1000);
+    expect(computeBackoff(policy, 2)).toBe(2000);
+    expect(computeBackoff(policy, 3)).toBe(4000);
+    expect(computeBackoff(policy, 4)).toBe(8000);
+  });
+
+  it('caps at maxMs', () => {
+    const delay = computeBackoff(policy, 10); // Would be 512000 without cap
+    expect(delay).toBe(10000);
+  });
+
+  it('handles attempt 0 same as attempt 1', () => {
+    expect(computeBackoff(policy, 0)).toBe(1000);
+  });
+
+  it('handles negative attempts', () => {
+    expect(computeBackoff(policy, -1)).toBe(1000);
+  });
+
+  describe('with jitter', () => {
+    const jitterPolicy: BackoffPolicy = {
+      initialMs: 1000,
+      maxMs: 10000,
+      factor: 2,
+      jitter: 0.25,
+    };
+
+    it('adds jitter within expected range', () => {
+      // Run multiple times to check jitter range
+      const delays = Array.from({ length: 100 }, () => computeBackoff(jitterPolicy, 1));
+      
+      // All delays should be between 1000 and 1250 (1000 + 25% jitter)
+      delays.forEach(delay => {
+        expect(delay).toBeGreaterThanOrEqual(1000);
+        expect(delay).toBeLessThanOrEqual(1250);
+      });
+
+      // Should have some variation (not all same value)
+      const uniqueDelays = new Set(delays);
+      expect(uniqueDelays.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe('with DEFAULT_RECONNECT_POLICY', () => {
+    it('starts at 2000ms', () => {
+      // With jitter, first delay is 2000 + up to 25% jitter
+      const delay = computeBackoff(DEFAULT_RECONNECT_POLICY, 1);
+      expect(delay).toBeGreaterThanOrEqual(2000);
+      expect(delay).toBeLessThanOrEqual(2500);
+    });
+
+    it('caps at 30000ms', () => {
+      const delay = computeBackoff(DEFAULT_RECONNECT_POLICY, 20);
+      expect(delay).toBeLessThanOrEqual(30000);
+    });
+  });
+});
+
+describe('createReconnectManager', () => {
+  const policy: ReconnectPolicy = {
+    initialMs: 1000,
+    maxMs: 10000,
+    factor: 2,
+    jitter: 0,
+    maxAttempts: 5,
+  };
+
+  it('starts with 0 attempts', () => {
+    const manager = createReconnectManager(policy);
+    expect(manager.getAttempts()).toBe(0);
+  });
+
+  it('increments attempt counter', () => {
+    const manager = createReconnectManager(policy);
+    expect(manager.increment()).toBe(1);
+    expect(manager.increment()).toBe(2);
+    expect(manager.getAttempts()).toBe(2);
+  });
+
+  it('resets attempt counter', () => {
+    const manager = createReconnectManager(policy);
+    manager.increment();
+    manager.increment();
+    manager.reset();
+    expect(manager.getAttempts()).toBe(0);
+  });
+
+  it('detects exhausted attempts', () => {
+    const manager = createReconnectManager(policy);
+    expect(manager.isExhausted()).toBe(false);
+    
+    for (let i = 0; i < 5; i++) {
+      manager.increment();
+    }
+    
+    expect(manager.isExhausted()).toBe(true);
+  });
+
+  it('nextDelay increments and returns delay', () => {
+    const manager = createReconnectManager(policy);
+    
+    const delay1 = manager.nextDelay();
+    expect(manager.getAttempts()).toBe(1);
+    expect(delay1).toBe(1000);
+
+    const delay2 = manager.nextDelay();
+    expect(manager.getAttempts()).toBe(2);
+    expect(delay2).toBe(2000);
+  });
+
+  it('returns policy', () => {
+    const manager = createReconnectManager(policy);
+    expect(manager.getPolicy()).toBe(policy);
+  });
+});
+
+describe('sleepWithAbort', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves after specified time', async () => {
+    const promise = sleepWithAbort(1000);
+    
+    vi.advanceTimersByTime(999);
+    // Promise should still be pending
+    
+    vi.advanceTimersByTime(1);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('rejects when signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    
+    await expect(sleepWithAbort(1000, controller.signal)).rejects.toThrow('Aborted');
+  });
+
+  it('rejects when signal is aborted during sleep', async () => {
+    const controller = new AbortController();
+    const promise = sleepWithAbort(5000, controller.signal);
+    
+    vi.advanceTimersByTime(1000);
+    controller.abort();
+    
+    await expect(promise).rejects.toThrow('Aborted');
+  });
+
+  it('works without abort signal', async () => {
+    const promise = sleepWithAbort(100);
+    vi.advanceTimersByTime(100);
+    await expect(promise).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add comprehensive tests for core utilities:

**formatter.test.ts (23 tests):**
- Envelope structure (channel, chatId, messageId)
- Sender formatting (usernames, phone numbers, @ prefixes)
- Group formatting (# prefix for Slack/Discord)
- Format hints per channel
- Attachment formatting with sizes
- Options (includeSender, includeGroup, includeDay)

**backoff.test.ts (18 tests):**
- computeBackoff() exponential calculation
- Jitter behavior and max cap enforcement
- createReconnectManager() state tracking
- sleepWithAbort() with fake timers

**Total: 52 -> 93 tests**