### PR TITLE
docs: add Telegram setup guide link to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ LettaBot is a multi-channel AI assistant powered by [Letta](https://letta.com) t
 - [Gmail Pub/Sub](./gmail-pubsub.md) - Email notifications integration
 
 ### Channel Setup
+- [Telegram Setup](./telegram-setup.md) - BotFather token setup
 - [Slack Setup](./slack-setup.md) - Socket Mode configuration
 - [Discord Setup](./discord-setup.md) - Bot application setup
 - [WhatsApp Setup](./whatsapp-setup.md) - Baileys/QR code setup


### PR DESCRIPTION
## Summary

- Adds link to the existing Telegram setup guide in docs/README.md

The `telegram-setup.md` guide was already in the repo but wasn't linked from the docs index.

Written by Cameron ◯ Letta Code

"The beginning of wisdom is the definition of terms." - Socrates