### PR TITLE
feat(skills): consolidate skills to agent-scoped location

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -286,60 +286,85 @@ async function main() {
     }
       
     case 'destroy': {
-      const { rmSync, existsSync } = await import('node:fs');
+      const { rmSync, existsSync, readFileSync } = await import('node:fs');
       const { join } = await import('node:path');
       const p = await import('@clack/prompts');
-      
+      const { getAgentSkillsDir } = await import('./skills/loader.js');
+
       const dataDir = getDataDir();
       const workingDir = getWorkingDir();
       const agentJsonPath = join(dataDir, 'lettabot-agent.json');
-      const skillsDir = join(workingDir, '.skills');
       const cronJobsPath = join(dataDir, 'cron-jobs.json');
-      
+
+      // Build list of skill directories to clean up
+      const skillsDirs: { path: string; label: string }[] = [
+        { path: join(workingDir, '.skills'), label: 'Project skills (.skills/)' },
+      ];
+
+      // Read agent ID before deleting store (needed for agent-scoped skills dir)
+      if (existsSync(agentJsonPath)) {
+        try {
+          const store = JSON.parse(readFileSync(agentJsonPath, 'utf-8'));
+          if (store.agentId) {
+            skillsDirs.unshift({
+              path: getAgentSkillsDir(store.agentId),
+              label: 'Agent skills',
+            });
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      }
+
       p.intro('🗑️  Destroy LettaBot Data');
-      
+
       p.log.warn('This will delete:');
       p.log.message(`  • Agent store: ${agentJsonPath}`);
-      p.log.message(`  • Skills: ${skillsDir}`);
+      for (const dir of skillsDirs) {
+        p.log.message(`  • ${dir.label}: ${dir.path}`);
+      }
       p.log.message(`  • Cron jobs: ${cronJobsPath}`);
       p.log.message('');
       p.log.message('Note: The agent on Letta servers will NOT be deleted.');
-      
+
       const confirmed = await p.confirm({
         message: 'Are you sure you want to destroy all local data?',
         initialValue: false,
       });
-      
+
       if (!confirmed || p.isCancel(confirmed)) {
         p.cancel('Cancelled');
         break;
       }
-      
+
       // Delete files
       let deleted = 0;
-      
+
       if (existsSync(agentJsonPath)) {
         rmSync(agentJsonPath);
         p.log.success('Deleted lettabot-agent.json');
         deleted++;
       }
-      
-      if (existsSync(skillsDir)) {
-        rmSync(skillsDir, { recursive: true });
-        p.log.success('Deleted .skills/');
-        deleted++;
+
+      // Delete all skill directories
+      for (const dir of skillsDirs) {
+        if (existsSync(dir.path)) {
+          rmSync(dir.path, { recursive: true });
+          p.log.success(`Deleted ${dir.label}: ${dir.path}`);
+          deleted++;
+        }
       }
-      
+
       if (existsSync(cronJobsPath)) {
         rmSync(cronJobsPath);
         p.log.success('Deleted cron-jobs.json');
         deleted++;
       }
-      
+
       if (deleted === 0) {
         p.log.info('Nothing to delete');
       }
-      
+
       p.outro('✨ Done! Run `npx lettabot server` to create a fresh agent.');
       break;
     }

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -29,16 +29,98 @@ export class LettaBot {
   
   constructor(config: BotConfig) {
     this.config = config;
-    
+
     // Ensure working directory exists
     mkdirSync(config.workingDir, { recursive: true });
-    
+
     // Store in project root (same as main.ts reads for LETTA_AGENT_ID)
     this.store = new Store('lettabot-agent.json');
-    
+
     console.log(`LettaBot initialized. Agent ID: ${this.store.agentId || '(new)'}`);
   }
-  
+
+  /**
+   * Get base session options (shared across all session creation)
+   */
+  private getBaseSessionOptions() {
+    return {
+      permissionMode: 'bypassPermissions' as const,
+      allowedTools: this.config.allowedTools,
+      cwd: this.config.workingDir,
+      // Note: systemPrompt/memory now passed to createAgent() for new agents (SDK 0.0.5+)
+    };
+  }
+
+  /**
+   * Get or create a session for the agent.
+   *
+   * For fresh users (no agent), this:
+   * 1. Creates a new agent via createAgent()
+   * 2. Installs skills to agent-scoped directory (~/.letta/agents/{id}/skills/)
+   * 3. Returns a resumed session with skills available
+   *
+   * For returning users, this resumes the existing conversation/agent.
+   *
+   * See: https://github.com/letta-ai/lettabot/issues/108
+   */
+  private async getOrCreateSession(): Promise<{
+    session: Session;
+    usedSpecificConversation: boolean;
+    usedDefaultConversation: boolean;
+  }> {
+    const baseOptions = this.getBaseSessionOptions();
+
+    let session: Session;
+    let usedDefaultConversation = false;
+    let usedSpecificConversation = false;
+
+    if (this.store.conversationId) {
+      // Resume the specific conversation we've been using
+      console.log(`[Bot] Resuming conversation: ${this.store.conversationId}`);
+      process.env.LETTA_AGENT_ID = this.store.agentId || undefined;
+      usedSpecificConversation = true;
+      session = resumeSession(this.store.conversationId, baseOptions);
+    } else if (this.store.agentId) {
+      // Agent exists but no conversation - try default conversation
+      console.log(`[Bot] Resuming agent default conversation: ${this.store.agentId}`);
+      process.env.LETTA_AGENT_ID = this.store.agentId;
+      usedDefaultConversation = true;
+      session = resumeSession(this.store.agentId, baseOptions);
+    } else {
+      // Fresh user: Create agent first, install skills, then create session
+      console.log('[Bot] Creating new agent...');
+      const newAgentId = await createAgent({
+        model: this.config.model,
+        systemPrompt: SYSTEM_PROMPT,
+        memory: loadMemoryBlocks(this.config.agentName),
+      });
+      console.log(`[Bot] Agent created: ${newAgentId}`);
+
+      // Install feature-gated skills to agent-scoped directory
+      // ~/.letta/agents/{agentId}/skills/ (aligns with Letta Code CLI)
+      installSkillsToAgent(newAgentId, {
+        cronEnabled: this.config.cronEnabled,
+        googleEnabled: this.config.googleEnabled,
+      });
+
+      // Save agent ID immediately
+      const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
+      this.store.setAgent(newAgentId, currentBaseUrl);
+      process.env.LETTA_AGENT_ID = newAgentId;
+
+      // Set agent name
+      if (this.config.agentName) {
+        updateAgentName(newAgentId, this.config.agentName).catch(() => {});
+      }
+
+      // Create session for the new agent (SDK 0.0.5+ pattern)
+      console.log('[Bot] Creating session for new agent...');
+      session = createSession(newAgentId, baseOptions);
+    }
+
+    return { session, usedSpecificConversation, usedDefaultConversation };
+  }
+
   /**
    * Register a channel adapter
    */
@@ -182,43 +264,11 @@ export class LettaBot {
     console.log('[Bot] Typing indicator sent');
     
     // Create or resume session
-    let session: Session;
-    let usedDefaultConversation = false;
-    let usedSpecificConversation = false;
-    // Base options for sessions (systemPrompt/memory set via createAgent for new agents)
-    const baseOptions = {
-      permissionMode: 'bypassPermissions' as const,
-      allowedTools: this.config.allowedTools,
-      cwd: this.config.workingDir,
-      // bypassPermissions mode auto-allows all tools, no canUseTool callback needed
-    };
-    
     console.log('[Bot] Creating/resuming session');
+    let { session, usedSpecificConversation, usedDefaultConversation } = await this.getOrCreateSession();
+    console.log('[Bot] Session created/resumed');
+
     try {
-    if (this.store.conversationId) {
-      // Resume the specific conversation we've been using
-      console.log(`[Bot] Resuming conversation: ${this.store.conversationId}`);
-      process.env.LETTA_AGENT_ID = this.store.agentId || undefined;
-      usedSpecificConversation = true;
-      session = resumeSession(this.store.conversationId, baseOptions);
-    } else if (this.store.agentId) {
-        // Agent exists but no conversation - try default conversation
-        console.log(`[Bot] Resuming agent default conversation: ${this.store.agentId}`);
-        process.env.LETTA_AGENT_ID = this.store.agentId;
-        usedDefaultConversation = true;
-        session = resumeSession(this.store.agentId, baseOptions);
-      } else {
-        // Create new agent with default conversation
-        console.log('[Bot] Creating new agent');
-        const newAgentId = await createAgent({
-          model: this.config.model,
-          systemPrompt: SYSTEM_PROMPT,
-          memory: loadMemoryBlocks(this.config.agentName),
-        });
-        session = createSession(newAgentId, baseOptions);
-      }
-      console.log('[Bot] Session created/resumed');
-      
       const defaultTimeoutMs = 30000; // 30s timeout
       const envTimeoutMs = Number(process.env.LETTA_SESSION_TIMEOUT_MS);
       const initTimeoutMs = Number.isFinite(envTimeoutMs) && envTimeoutMs > 0
@@ -241,6 +291,7 @@ export class LettaBot {
       try {
         initInfo = await withTimeout(session.initialize(), 'Session initialize');
       } catch (error) {
+        const baseOptions = this.getBaseSessionOptions();
         if (usedSpecificConversation && this.store.agentId) {
           console.warn('[Bot] Conversation missing, creating a new conversation...');
           session.close();
@@ -373,26 +424,12 @@ export class LettaBot {
           }
           
           if (streamMsg.type === 'result') {
-            // Save agent ID and conversation ID
-            if (session.agentId && session.agentId !== this.store.agentId) {
-              const isNewAgent = !this.store.agentId;
-              // Save agent ID along with the current server URL
-              const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
-              this.store.setAgent(session.agentId, currentBaseUrl, session.conversationId || undefined);
-              console.log('Saved agent ID:', session.agentId, 'conversation ID:', session.conversationId, 'on server:', currentBaseUrl);
-              
-              // Setup new agents: set name, install skills
-              if (isNewAgent) {
-                if (this.config.agentName && session.agentId) {
-                  updateAgentName(session.agentId, this.config.agentName).catch(() => {});
-                }
-                if (session.agentId) {
-                  installSkillsToAgent(session.agentId);
-                }
-              }
-            } else if (session.conversationId && session.conversationId !== this.store.conversationId) {
-              // Update conversation ID if it changed
+            // Update conversation ID if changed
+            // Note: Agent setup (name, skills) is now done BEFORE first message
+            // via createAgent() flow, so skills are available immediately
+            if (session.conversationId && session.conversationId !== this.store.conversationId) {
               this.store.conversationId = session.conversationId;
+              console.log('Updated conversation ID:', session.conversationId);
             }
             break;
           }
@@ -454,39 +491,13 @@ export class LettaBot {
     text: string,
     _context?: TriggerContext
   ): Promise<string> {
-    // Base options for sessions (systemPrompt/memory set via createAgent for new agents)
-    const baseOptions = {
-      permissionMode: 'bypassPermissions' as const,
-      allowedTools: this.config.allowedTools,
-      cwd: this.config.workingDir,
-      // bypassPermissions mode auto-allows all tools, no canUseTool callback needed
-    };
-    
-    let session: Session;
-    let usedDefaultConversation = false;
-    let usedSpecificConversation = false;
-    if (this.store.conversationId) {
-      // Resume the specific conversation we've been using
-      usedSpecificConversation = true;
-      session = resumeSession(this.store.conversationId, baseOptions);
-    } else if (this.store.agentId) {
-      // Agent exists but no conversation - try default conversation
-      usedDefaultConversation = true;
-      session = resumeSession(this.store.agentId, baseOptions);
-    } else {
-      // Create new agent with default conversation
-      const newAgentId = await createAgent({
-        model: this.config.model,
-        systemPrompt: SYSTEM_PROMPT,
-        memory: loadMemoryBlocks(this.config.agentName),
-      });
-      session = createSession(newAgentId, baseOptions);
-    }
-    
+    let { session, usedSpecificConversation, usedDefaultConversation } = await this.getOrCreateSession();
+
     try {
       try {
         await session.send(text);
       } catch (error) {
+        const baseOptions = this.getBaseSessionOptions();
         if (usedSpecificConversation && this.store.agentId) {
           console.warn('[Bot] Conversation missing, creating a new conversation...');
           session.close();
@@ -512,10 +523,8 @@ export class LettaBot {
         }
         
         if (msg.type === 'result') {
-          if (session.agentId && session.agentId !== this.store.agentId) {
-            const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
-            this.store.setAgent(session.agentId, currentBaseUrl, session.conversationId || undefined);
-          } else if (session.conversationId && session.conversationId !== this.store.conversationId) {
+          // Update conversation ID if changed
+          if (session.conversationId && session.conversationId !== this.store.conversationId) {
             this.store.conversationId = session.conversationId;
           }
           break;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -113,9 +113,25 @@ export class Store {
   get lastMessageTarget(): LastMessageTarget | null {
     return this.data.lastMessageTarget || null;
   }
-  
+
   set lastMessageTarget(target: LastMessageTarget | null) {
     this.data.lastMessageTarget = target || undefined;
     this.save();
+  }
+
+  /**
+   * Get agent ID or throw if none exists.
+   * For CLI commands that require an existing agent.
+   */
+  static getAgentIdOrThrow(): string {
+    const storePath = resolve(getDataDir(), DEFAULT_STORE_PATH);
+    if (!existsSync(storePath)) {
+      throw new Error('No agent found. Run `lettabot onboard` or `lettabot server` first to create an agent.');
+    }
+    const data = JSON.parse(readFileSync(storePath, 'utf-8'));
+    if (!data.agentId) {
+      throw new Error('No agent found. Run `lettabot onboard` or `lettabot server` first to create an agent.');
+    }
+    return data.agentId;
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -105,7 +105,11 @@ export interface BotConfig {
   model?: string; // e.g., 'anthropic/claude-sonnet-4-5-20250929'
   agentName?: string; // Name for the agent (set via API after creation)
   allowedTools: string[];
-  
+
+  // Skills (feature-gated)
+  cronEnabled?: boolean;
+  googleEnabled?: boolean;
+
   // Security
   allowedUsers?: string[];  // Empty = allow all
 }

--- a/src/skills/sync.ts
+++ b/src/skills/sync.ts
@@ -1,15 +1,22 @@
 /**
- * Skills Sync - Interactive checklist to manage skills in working directory
+ * Skills Sync - Interactive checklist to manage skills in agent-scoped directory
+ *
+ * Skills are installed to: ~/.letta/agents/{agentId}/skills/
+ * This aligns with Letta Code CLI behavior.
+ * See: https://github.com/letta-ai/lettabot/issues/108
  */
 
 import { existsSync, readdirSync, cpSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
-import { PROJECT_SKILLS_DIR, GLOBAL_SKILLS_DIR, SKILLS_SH_DIR, parseSkillFile } from './loader.js';
+import { PROJECT_SKILLS_DIR, GLOBAL_SKILLS_DIR, SKILLS_SH_DIR, parseSkillFile, getAgentSkillsDir } from './loader.js';
+import { Store } from '../core/store.js';
 
 const HOME = process.env.HOME || process.env.USERPROFILE || '';
-const WORKING_DIR = process.env.WORKING_DIR || '/tmp/lettabot';
-const TARGET_DIR = join(WORKING_DIR, '.skills');
+
+// Agent-scoped skills directory (primary location for skill installs)
+const AGENT_ID = Store.getAgentIdOrThrow();
+const TARGET_DIR = getAgentSkillsDir(AGENT_ID);
 
 // Skill source directories
 const CLAWDHUB_DIR = join(HOME, 'clawd', 'skills');      // ~/clawd/skills (ClawdHub)

--- a/src/skills/wizard.ts
+++ b/src/skills/wizard.ts
@@ -1,17 +1,21 @@
 /**
  * Skills Wizard - Interactive CLI for managing skills
+ *
+ * Skills are installed to agent-scoped directory: ~/.letta/agents/{agentId}/skills/
+ * This aligns with Letta Code CLI behavior.
+ * See: https://github.com/letta-ai/lettabot/issues/108
  */
 
 import * as p from '@clack/prompts';
-import { join } from 'node:path';
 import { getSkillsSummary, type SkillsSummary } from './status.js';
 import { installSkillDeps } from './install.js';
-import { hasBinary, GLOBAL_SKILLS_DIR, SKILLS_SH_DIR } from './loader.js';
+import { hasBinary, GLOBAL_SKILLS_DIR, SKILLS_SH_DIR, getAgentSkillsDir } from './loader.js';
+import { Store } from '../core/store.js';
 import type { NodeManager, SkillStatus } from './types.js';
 
-// Skills in working directory (where Letta Code looks)
-const WORKING_DIR = process.env.WORKING_DIR || '/tmp/lettabot';
-const WORKING_SKILLS_DIR = join(WORKING_DIR, '.skills');
+// Agent-scoped skills directory (primary location for skill installs)
+const AGENT_ID = Store.getAgentIdOrThrow();
+const WORKING_SKILLS_DIR = getAgentSkillsDir(AGENT_ID);
 
 /**
  * Detect available node managers
@@ -294,6 +298,6 @@ export async function showStatus(): Promise<void> {
   }
   
   console.log('');
-  console.log(`  To enable: lettabot skills enable <name>`);
+  console.log(`  Run 'lettabot skills' to enable/disable skills`);
   console.log(`  Skills dir: ${WORKING_SKILLS_DIR}\n`);
 }


### PR DESCRIPTION
## Summary

- Install skills to `~/.letta/agents/{agentId}/skills/` instead of working directory `.skills/`
- Aligns with Letta Code CLI so both tools use the same skill location
- Existing `.skills/` directories continue to work (read-only, highest priority in SDK discovery)

## Changes

- **bot.ts**: Call `installSkillsToAgent()` after agent creation
- **loader.ts**: Remove `installSkillsToWorkingDir()`, keep `installSkillsToAgent()`
- **store.ts**: Add `Store.getAgentIdOrThrow()` static method for CLI tools
- **wizard.ts/sync.ts**: Target agent-scoped directory using shared helper
- **cli.ts**: Destroy command cleans up both agent-scoped and project skills
- **main.ts**: Remove startup skill installation (now happens after agent creation)

## Migration

No manual migration required:
- Existing `.skills/` directories continue to work (SDK searches them first)
- New skill installs go to agent-scoped location

## Not included

- WhatsApp session cleanup in destroy command (can be a follow-up)

## Test plan

- [ ] Fresh user: `lettabot server` → create agent → skills installed to `~/.letta/agents/{id}/skills/`
- [ ] Returning user: skills installed to agent-scoped dir on startup
- [ ] `lettabot skills` CLI targets agent-scoped directory
- [ ] `lettabot destroy` cleans up agent-scoped skills
- [ ] Existing `.skills/` directory still works (read-only)

Closes #108

🤖 Generated with [Claude Code](https://claude.ai/code)