### PR TITLE
fix: increase stream idle timeout default from 30s to 120s

### DIFF
--- a/src/core/stream-watchdog.test.ts
+++ b/src/core/stream-watchdog.test.ts
@@ -13,17 +13,17 @@ describe('StreamWatchdog', () => {
   });
 
   describe('default behavior', () => {
-    it('uses 30s default idle timeout', () => {
+    it('uses 120s default idle timeout', () => {
       const onAbort = vi.fn();
       const watchdog = new StreamWatchdog({ onAbort });
       watchdog.start();
 
-      // Should not abort before 30s
-      vi.advanceTimersByTime(29000);
+      // Should not abort before 120s
+      vi.advanceTimersByTime(119000);
       expect(onAbort).not.toHaveBeenCalled();
       expect(watchdog.isAborted).toBe(false);
 
-      // Should abort at 30s
+      // Should abort at 120s
       vi.advanceTimersByTime(1000);
       expect(onAbort).toHaveBeenCalledTimes(1);
       expect(watchdog.isAborted).toBe(true);
@@ -36,16 +36,16 @@ describe('StreamWatchdog', () => {
       const watchdog = new StreamWatchdog({ onAbort });
       watchdog.start();
 
-      // Advance 25s, then ping
-      vi.advanceTimersByTime(25000);
+      // Advance 100s, then ping
+      vi.advanceTimersByTime(100000);
       watchdog.ping();
 
-      // Advance another 25s - should not abort (only 25s since ping)
-      vi.advanceTimersByTime(25000);
+      // Advance another 100s - should not abort (only 100s since ping)
+      vi.advanceTimersByTime(100000);
       expect(onAbort).not.toHaveBeenCalled();
 
-      // Advance 5 more seconds - now 30s since last ping
-      vi.advanceTimersByTime(5000);
+      // Advance 20 more seconds - now 120s since last ping
+      vi.advanceTimersByTime(20000);
       expect(onAbort).toHaveBeenCalledTimes(1);
 
       watchdog.stop();

--- a/src/core/stream-watchdog.ts
+++ b/src/core/stream-watchdog.ts
@@ -30,7 +30,7 @@ export class StreamWatchdog {
     const envTimeout = Number(process.env.LETTA_STREAM_IDLE_TIMEOUT_MS);
     this.idleTimeoutMs = Number.isFinite(envTimeout) && envTimeout > 0
       ? envTimeout
-      : (options.idleTimeoutMs ?? 30000);
+      : (options.idleTimeoutMs ?? 120000);
     this.logIntervalMs = options.logIntervalMs ?? 10000;
     this.onAbort = options.onAbort;
   }


### PR DESCRIPTION
## Summary

Increase the default stream idle timeout from 30s to 120s.

## Problem

Tools execute client-side without emitting stream messages. When an agent uses multiple tools (10-20s each) plus API processing gaps, the cumulative "idle" time can exceed 30s even though the agent is actively working. This causes false timeouts and "(No response from agent)" errors.

## Solution

Bump the default timeout to 120s. Users can still override via `LETTA_STREAM_IDLE_TIMEOUT_MS` env var.

## Test plan

- [x] Updated tests to use new 120s default
- [x] All watchdog tests pass (12/12)

Written by Cameron ◯ Letta Code