### PR TITLE
fix: auto-reset conversation when stream receives no data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "bin": {
         "lettabot": "dist/cli.js",
+        "lettabot-channels": "dist/cli/channels.js",
         "lettabot-message": "dist/cli/message.js",
         "lettabot-react": "dist/cli/react.js",
         "lettabot-schedule": "dist/cron/cli.js"

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -287,6 +287,7 @@ export class LettaBot {
       let lastMsgType: string | null = null;
       let lastAssistantUuid: string | null = null;
       let sentAnyMessage = false;
+      let receivedAnyData = false; // Track if stream received ANY data at all
       const msgTypeCounts: Record<string, number> = {};
       
       // Stream watchdog - abort if idle for too long
@@ -335,6 +336,7 @@ export class LettaBot {
         for await (const streamMsg of session.stream()) {
           const msgUuid = (streamMsg as any).uuid;
           watchdog.ping();
+          receivedAnyData = true;
           msgTypeCounts[streamMsg.type] = (msgTypeCounts[streamMsg.type] || 0) + 1;
           
           // Verbose logging: show every stream message type
@@ -361,9 +363,8 @@ export class LettaBot {
             console.log(`[Bot] Generating response...`);
           } else if (streamMsg.type === 'reasoning' && lastMsgType !== 'reasoning') {
             console.log(`[Bot] Reasoning...`);
-          } else if (streamMsg.type === 'system' && lastMsgType !== 'system') {
-            const subtype = (streamMsg as any).subtype || 'unknown';
-            console.log(`[Bot] System message: ${subtype}`);
+          } else if (streamMsg.type === 'init' && lastMsgType !== 'init') {
+            console.log(`[Bot] Session initialized`);
           }
           lastMsgType = streamMsg.type;
           
@@ -461,10 +462,29 @@ export class LettaBot {
       
       // Only show "no response" if we never sent anything
       if (!sentAnyMessage) {
-        console.warn('[Bot] No message sent during stream - sending "(No response from agent)"');
-        console.warn('[Bot] This may indicate: tool approval hang, stream error, or ADE session conflict');
-        console.warn('[Bot] Check if ADE web interface is open - simultaneous access can cause this issue');
-        await adapter.sendMessage({ chatId: msg.chatId, text: '(No response from agent)', threadId: msg.threadId });
+        if (!receivedAnyData) {
+          // Stream received NOTHING - likely stuck approval or connection issue
+          console.error('[Bot] Stream received NO DATA at all - conversation may be stuck');
+          console.error('[Bot] This usually means a pending tool approval from a previous session');
+          console.error('[Bot] Auto-resetting conversation to recover...');
+          
+          // Clear conversation ID to force new conversation on next message
+          const oldConvoId = this.store.conversationId;
+          this.store.conversationId = null; // Auto-saves via setter
+          
+          await adapter.sendMessage({ 
+            chatId: msg.chatId, 
+            text: '(Connection issue detected - conversation reset. Please try again.)', 
+            threadId: msg.threadId 
+          });
+          console.log(`[Bot] Conversation reset: ${oldConvoId} -> (new conversation on next message)`);
+        } else {
+          console.warn('[Bot] No message sent during stream - sending "(No response from agent)"');
+          console.warn('[Bot] Stream DID receive data but no assistant response');
+          console.warn('[Bot] Message type counts:', msgTypeCounts);
+          console.warn('[Bot] Check if ADE web interface is open - simultaneous access can cause this issue');
+          await adapter.sendMessage({ chatId: msg.chatId, text: '(No response from agent)', threadId: msg.threadId });
+        }
       }
       
     } catch (error) {


### PR DESCRIPTION
## Problem

When a conversation has a stuck tool approval from a previous session (client disconnected mid-approval), the stream receives NO data at all - not even the init message. Users see "(No response from agent)" and responses appear in ADE instead of their channel.

Reported by Signo on Discord: https://discord.com/channels/1161736243340640419/1468629588052672532

## Root Cause

1. CLI sends tool call to server
2. Server requests approval
3. Client disconnects before responding (crash, timeout, etc.)
4. Server waits forever for approval
5. Next message to that conversation gets "cannot send a new message: waiting for approval"
6. CLI/SDK swallows error, stream times out with no data

## Fix

- Track if stream received ANY data (not just assistant messages)
- If stream times out with zero data → assume stuck approval state
- Auto-reset conversation and tell user to try again
- User's next message creates fresh conversation

## What Users See

Before:
```
(No response from agent)
```
(and must manually run `lettabot reset-conversation`)

After:
```
(Connection issue detected - conversation reset. Please try again.)
```
(next message works automatically)

## Additional Improvements

- Log message type counts when stream has data but no response
- Fix TypeScript error: `'system'` → `'init'` for stream message type

## Related

- #125 - Detect and handle stuck conversation states
- #127 - Server should timeout pending approvals
- #132 - Tool approvals requested despite bypassPermissions