### PR TITLE
feat: add slash command support to all channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "bin": {
         "lettabot": "dist/cli.js",
+        "lettabot-channels": "dist/cli/channels.js",
         "lettabot-message": "dist/cli/message.js",
         "lettabot-react": "dist/cli/react.js",
         "lettabot-schedule": "dist/cron/cli.js"

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -10,6 +10,7 @@ import type { InboundAttachment, InboundMessage, InboundReaction, OutboundFile, 
 import type { DmPolicy } from '../pairing/types.js';
 import { isUserAllowed, upsertPairingRequest } from '../pairing/store.js';
 import { buildAttachmentPath, downloadToFile } from './attachments.js';
+import { HELP_TEXT } from '../core/commands.js';
 
 // Dynamic import to avoid requiring Discord deps if not used
 let Client: typeof import('discord.js').Client;
@@ -204,6 +205,10 @@ Ask the bot owner to approve with:
 
       if (content.startsWith('/')) {
         const command = content.slice(1).split(/\s+/)[0]?.toLowerCase();
+        if (command === 'help' || command === 'start') {
+          await message.channel.send(HELP_TEXT);
+          return;
+        }
         if (this.onCommand) {
           if (command === 'status') {
             const result = await this.onCommand('status');

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,0 +1,27 @@
+/**
+ * Slash Command Utilities
+ * 
+ * Shared command parsing and help text for all channels.
+ */
+
+export const COMMANDS = ['status', 'heartbeat', 'help', 'start'] as const;
+export type Command = typeof COMMANDS[number];
+
+export const HELP_TEXT = `LettaBot - AI assistant with persistent memory
+
+Commands:
+/status - Show current status
+/heartbeat - Trigger heartbeat
+/help - Show this message
+
+Just send a message to get started!`;
+
+/**
+ * Parse a slash command from message text.
+ * Returns the command name if valid, null otherwise.
+ */
+export function parseCommand(text: string | undefined | null): Command | null {
+  if (!text?.startsWith('/')) return null;
+  const cmd = text.slice(1).split(/\s+/)[0]?.toLowerCase();
+  return COMMANDS.includes(cmd as Command) ? (cmd as Command) : null;
+}


### PR DESCRIPTION
## Summary

Adds consistent slash command support across all channels.

| Channel | Before | After |
|---------|--------|-------|
| Telegram | Full support | Full support |
| Discord | /status, /heartbeat | + /help, /start |
| Signal | None | Full support |
| Slack | None | Full support |
| WhatsApp | None | Full support |

## Supported Commands

- `/status` - Show agent info (delegates to bot core)
- `/heartbeat` - Trigger heartbeat (delegates to bot core)
- `/help` - Show help message (handled locally)
- `/start` - Same as /help (handled locally)

## Implementation

- New `src/core/commands.ts` with shared `HELP_TEXT` and `parseCommand()`
- Each adapter checks for commands before calling `onMessage`
- Unknown commands (e.g., `/foo`) still pass through to the agent

## Testing

- Signal: `/status`, `/heartbeat`, `/help` respond correctly
- Slack: Works in DMs and @mentions
- WhatsApp: Works before debouncing
- Discord: Now has /help

Fixes #91