### PR TITLE
feat: add Signal group chat support with mention gating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       },
       "bin": {
         "lettabot": "dist/cli.js",
+        "lettabot-channels": "dist/cli/channels.js",
         "lettabot-message": "dist/cli/message.js",
         "lettabot-react": "dist/cli/react.js",
         "lettabot-schedule": "dist/cron/cli.js"

--- a/src/channels/signal/group-gating.test.ts
+++ b/src/channels/signal/group-gating.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import { applySignalGroupGating } from './group-gating.js';
+
+describe('applySignalGroupGating', () => {
+  const selfPhoneNumber = '+15551234567';
+  const selfUuid = 'abc-123-uuid';
+
+  describe('requireMention: true (default)', () => {
+    it('filters messages without mention', () => {
+      const result = applySignalGroupGating({
+        text: 'Hello everyone!',
+        groupId: 'test-group',
+        selfPhoneNumber,
+      });
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toBe('mention-required');
+    });
+
+    it('allows messages with native mention matching phone', () => {
+      const result = applySignalGroupGating({
+        text: 'Hey @bot',
+        groupId: 'test-group',
+        mentions: [{ number: '+15551234567', start: 4, length: 4 }],
+        selfPhoneNumber,
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.wasMentioned).toBe(true);
+      expect(result.method).toBe('native');
+    });
+
+    it('allows messages with native mention matching UUID', () => {
+      const result = applySignalGroupGating({
+        text: 'Hey @bot',
+        groupId: 'test-group',
+        mentions: [{ uuid: selfUuid, start: 4, length: 4 }],
+        selfPhoneNumber,
+        selfUuid,
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.method).toBe('native');
+    });
+
+    it('filters when mentions exist for others', () => {
+      const result = applySignalGroupGating({
+        text: 'Hey @alice',
+        groupId: 'test-group',
+        mentions: [{ number: '+19998887777', start: 4, length: 6 }],
+        selfPhoneNumber,
+      });
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toBe('mention-required');
+    });
+
+    it('allows messages matching regex pattern', () => {
+      const result = applySignalGroupGating({
+        text: '@lettabot what time is it?',
+        groupId: 'test-group',
+        selfPhoneNumber,
+        mentionPatterns: ['@lettabot', '@bot'],
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.method).toBe('regex');
+    });
+
+    it('allows replies to bot', () => {
+      const result = applySignalGroupGating({
+        text: 'Thanks for that!',
+        groupId: 'test-group',
+        quote: { author: '+15551234567', text: 'Previous message' },
+        selfPhoneNumber,
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.method).toBe('reply');
+    });
+
+    it('allows messages containing phone number (E.164 fallback)', () => {
+      const result = applySignalGroupGating({
+        text: 'Hey 15551234567 check this out',
+        groupId: 'test-group',
+        selfPhoneNumber,
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.method).toBe('e164');
+    });
+  });
+
+  describe('requireMention: false', () => {
+    it('allows all messages when requireMention is false for group', () => {
+      const result = applySignalGroupGating({
+        text: 'Hello everyone!',
+        groupId: 'test-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          'test-group': { requireMention: false },
+        },
+      });
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.wasMentioned).toBe(false);
+    });
+
+    it('allows all messages when wildcard has requireMention: false', () => {
+      const result = applySignalGroupGating({
+        text: 'Hello everyone!',
+        groupId: 'random-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          '*': { requireMention: false },
+        },
+      });
+
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it('specific group config overrides wildcard', () => {
+      const result = applySignalGroupGating({
+        text: 'Hello everyone!',
+        groupId: 'special-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          '*': { requireMention: false },
+          'special-group': { requireMention: true },
+        },
+      });
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toBe('mention-required');
+    });
+  });
+
+  describe('group allowlist', () => {
+    it('filters messages from groups not in allowlist', () => {
+      const result = applySignalGroupGating({
+        text: '@bot hello',
+        groupId: 'unknown-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          'allowed-group': { requireMention: true },
+        },
+        mentionPatterns: ['@bot'],
+      });
+
+      expect(result.shouldProcess).toBe(false);
+      expect(result.reason).toBe('group-not-in-allowlist');
+    });
+
+    it('allows messages from groups in allowlist', () => {
+      const result = applySignalGroupGating({
+        text: '@bot hello',
+        groupId: 'allowed-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          'allowed-group': { requireMention: true },
+        },
+        mentionPatterns: ['@bot'],
+      });
+
+      expect(result.shouldProcess).toBe(true);
+    });
+
+    it('wildcard allows all groups', () => {
+      const result = applySignalGroupGating({
+        text: '@bot hello',
+        groupId: 'any-group',
+        selfPhoneNumber,
+        groupsConfig: {
+          '*': { requireMention: true },
+        },
+        mentionPatterns: ['@bot'],
+      });
+
+      expect(result.shouldProcess).toBe(true);
+    });
+  });
+});

--- a/src/channels/signal/group-gating.ts
+++ b/src/channels/signal/group-gating.ts
@@ -1,0 +1,190 @@
+/**
+ * Signal Group Gating
+ *
+ * Filters group messages based on mention detection.
+ * Only processes messages where the bot is mentioned (unless requireMention: false).
+ */
+
+export interface SignalGroupConfig {
+  requireMention?: boolean;  // Default: true
+}
+
+export interface SignalMention {
+  start?: number;
+  length?: number;
+  uuid?: string;
+  number?: string;
+}
+
+export interface SignalQuote {
+  id?: number;
+  author?: string;
+  authorUuid?: string;
+  text?: string;
+}
+
+export interface SignalGroupGatingParams {
+  /** Message text */
+  text: string;
+  
+  /** Group ID (without "group:" prefix) */
+  groupId: string;
+  
+  /** Native Signal mentions from the message */
+  mentions?: SignalMention[];
+  
+  /** Quote/reply info if replying to a message */
+  quote?: SignalQuote;
+  
+  /** Bot's phone number (E.164) */
+  selfPhoneNumber: string;
+  
+  /** Bot's Signal UUID (if known) */
+  selfUuid?: string;
+  
+  /** Per-group configuration */
+  groupsConfig?: Record<string, SignalGroupConfig>;
+  
+  /** Regex patterns for text-based mention detection */
+  mentionPatterns?: string[];
+}
+
+export interface SignalGroupGatingResult {
+  /** Whether the message should be processed */
+  shouldProcess: boolean;
+  
+  /** Whether bot was mentioned */
+  wasMentioned?: boolean;
+  
+  /** Detection method used */
+  method?: 'native' | 'regex' | 'reply' | 'e164';
+  
+  /** Reason for filtering (if shouldProcess=false) */
+  reason?: string;
+}
+
+/**
+ * Apply group-specific gating logic for Signal messages.
+ *
+ * Detection methods (in priority order):
+ * 1. Native mentions array - Check if bot's phone/UUID is in mentions
+ * 2. Regex patterns - Match configured patterns in text
+ * 3. Reply to bot - Check if replying to bot's message
+ * 4. E.164 fallback - Bot's phone number appears in text
+ *
+ * @param params - Gating parameters
+ * @returns Gating decision
+ */
+export function applySignalGroupGating(params: SignalGroupGatingParams): SignalGroupGatingResult {
+  const { text, groupId, mentions, quote, selfPhoneNumber, selfUuid, groupsConfig, mentionPatterns } = params;
+
+  // Step 1: Check group allowlist (if groups config exists)
+  const groups = groupsConfig ?? {};
+  const allowlistEnabled = Object.keys(groups).length > 0;
+
+  if (allowlistEnabled) {
+    const hasWildcard = Object.hasOwn(groups, '*');
+    const hasSpecific = Object.hasOwn(groups, groupId) || Object.hasOwn(groups, `group:${groupId}`);
+
+    if (!hasWildcard && !hasSpecific) {
+      return {
+        shouldProcess: false,
+        reason: 'group-not-in-allowlist',
+      };
+    }
+  }
+
+  // Step 2: Resolve requireMention setting (default: true)
+  // Priority: specific group → wildcard → true
+  const groupConfig = groups[groupId] ?? groups[`group:${groupId}`];
+  const wildcardConfig = groups['*'];
+  const requireMention =
+    groupConfig?.requireMention ??
+    wildcardConfig?.requireMention ??
+    true; // Default: require mention for safety
+
+  // If requireMention is false, allow all messages from this group
+  if (!requireMention) {
+    return {
+      shouldProcess: true,
+      wasMentioned: false,
+    };
+  }
+
+  // Step 3: Detect mentions
+
+  // METHOD 1: Native Signal mentions array
+  if (mentions && mentions.length > 0) {
+    const selfDigits = selfPhoneNumber.replace(/\D/g, '');
+    
+    const mentioned = mentions.some((mention) => {
+      // Check UUID match
+      if (selfUuid && mention.uuid && mention.uuid === selfUuid) {
+        return true;
+      }
+      // Check phone number match (normalize to digits)
+      if (mention.number) {
+        const mentionDigits = mention.number.replace(/\D/g, '');
+        if (mentionDigits === selfDigits) {
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (mentioned) {
+      return { shouldProcess: true, wasMentioned: true, method: 'native' };
+    }
+
+    // If explicit mentions exist for other users, skip fallback methods
+    // (User specifically mentioned someone else, not the bot)
+    return { shouldProcess: false, wasMentioned: false, reason: 'mention-required' };
+  }
+
+  // METHOD 2: Regex pattern matching
+  if (mentionPatterns && mentionPatterns.length > 0) {
+    const cleanText = text.trim().replace(/[\u200B-\u200D\uFEFF]/g, '');
+    
+    for (const pattern of mentionPatterns) {
+      try {
+        const regex = new RegExp(pattern, 'i');
+        if (regex.test(cleanText)) {
+          return { shouldProcess: true, wasMentioned: true, method: 'regex' };
+        }
+      } catch (err) {
+        console.warn(`[Signal] Invalid mention pattern: ${pattern}`, err);
+      }
+    }
+  }
+
+  // METHOD 3: Reply to bot's message
+  if (quote) {
+    const selfDigits = selfPhoneNumber.replace(/\D/g, '');
+    
+    // Check if quote author matches bot
+    const isReplyToBot =
+      (selfUuid && quote.authorUuid === selfUuid) ||
+      (quote.author && quote.author.replace(/\D/g, '') === selfDigits);
+
+    if (isReplyToBot) {
+      return { shouldProcess: true, wasMentioned: true, method: 'reply' };
+    }
+  }
+
+  // METHOD 4: E.164 phone number fallback
+  if (selfPhoneNumber) {
+    const selfDigits = selfPhoneNumber.replace(/\D/g, '');
+    const textDigits = text.replace(/\D/g, '');
+
+    if (textDigits.includes(selfDigits)) {
+      return { shouldProcess: true, wasMentioned: true, method: 'e164' };
+    }
+  }
+
+  // No mention detected and mention required - skip this message
+  return {
+    shouldProcess: false,
+    wasMentioned: false,
+    reason: 'mention-required',
+  };
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -104,6 +104,9 @@ export interface SignalConfig {
   selfChat?: boolean;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
+  // Group gating
+  mentionPatterns?: string[];  // Regex patterns for mention detection (e.g., ["@bot"])
+  groups?: Record<string, { requireMention?: boolean }>;  // Per-group settings, "*" for defaults
 }
 
 export interface DiscordConfig {


### PR DESCRIPTION
## Summary

Add group message filtering to Signal adapter so bot only responds when mentioned (unless configured otherwise).

## Features

- **Native mentions** - Detects Signal's native @mentions (mentions array in SSE)
- **Quote/reply detection** - Responds when someone replies to bot's message
- **Regex patterns** - Match configurable patterns like `@bot`, `@lettabot`
- **E.164 fallback** - Detects phone number in message text
- **Per-group config** - Configure `requireMention` per group or use wildcard
- **Group allowlist** - Only respond in configured groups (when config exists)

## Config Example

```yaml
channels:
  signal:
    phone: "+15551234567"
    mentionPatterns:
      - "@bot"
      - "@lettabot"
    groups:
      "*":
        requireMention: true  # Default: only respond when mentioned
      "group:abc123xyz":
        requireMention: false  # Respond to all messages in this group
```

## Files Changed

- `src/channels/signal.ts` - Add mentions/quote types, gating call, config fields
- `src/channels/signal/group-gating.ts` - Gating logic (13 tests)
- `src/config/types.ts` - Add groups/mentionPatterns to SignalConfig

## Test Plan

- [x] 229 tests pass (including 13 new group-gating tests)
- [ ] Manual: Message in group without mention → ignored
- [ ] Manual: Message with native @mention → processed
- [ ] Manual: Message with text pattern (@bot) → processed
- [ ] Manual: Reply to bot's message → processed

Closes #137

Written by Cameron ◯ Letta Code