### PR TITLE
feat(skills): install to agent-scoped location instead of .skills/

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -424,7 +424,7 @@ export class LettaBot {
                   updateAgentName(session.agentId, this.config.agentName).catch(() => {});
                 }
                 if (session.agentId) {
-                  installSkillsToAgent(session.agentId);
+                  installSkillsToAgent(session.agentId, this.config.skills);
                 }
               }
             } else if (session.conversationId && session.conversationId !== this.store.conversationId) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -104,6 +104,15 @@ export interface OutboundFile {
 }
 
 /**
+ * Skills installation config
+ */
+export interface SkillsConfig {
+  cronEnabled?: boolean;
+  googleEnabled?: boolean;
+  additionalSkills?: string[];
+}
+
+/**
  * Bot configuration
  */
 export interface BotConfig {
@@ -112,6 +121,9 @@ export interface BotConfig {
   model?: string; // e.g., 'anthropic/claude-sonnet-4-5-20250929'
   agentName?: string; // Name for the agent (set via API after creation)
   allowedTools: string[];
+  
+  // Skills
+  skills?: SkillsConfig;
   
   // Security
   allowedUsers?: string[];  // Empty = allow all


### PR DESCRIPTION
## Summary

Skills now install to `~/.letta/agents/{agentId}/skills/` after agent creation, aligning with Letta Code CLI behavior. This removes the duplicate installation that was happening at both startup and after agent creation.

- Add `SkillsConfig` type and pass through `BotConfig`
- Update `installSkillsToAgent()` to actually install skills
- Remove `installSkillsToWorkingDir()` call from main.ts startup

Reimplemented from PR #114 (closed due to merge conflicts).

## Test plan

- [x] Build compiles
- [x] All 272 tests pass
- [ ] Fresh user: skills install to `~/.letta/agents/{id}/skills/` after agent creation
- [ ] Existing `.skills/` directory still works (read-only, highest priority)

Closes #108

"The best way to predict the future is to invent it." - Alan Kay

Written by Cameron ◯ Letta Code