### PR TITLE
feat: add e2e tests with Letta Cloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  unit:
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,5 +24,30 @@ jobs:
       - name: Build
         run: npm run build
       
-      - name: Run tests
+      - name: Run unit tests
         run: npm run test:run
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    # Only run e2e on main branch (has secrets)
+    if: github.ref == 'refs/heads/main' || github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build
+        run: npm run build
+      
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
+          LETTA_E2E_AGENT_ID: ${{ secrets.LETTA_E2E_AGENT_ID }}

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ LettaBot can transcribe voice messages using OpenAI Whisper. Voice messages are 
 
 ### Configuration
 
-Add your OpenAI API key to `lettabot.config.yaml`:
+Add your OpenAI API key to `lettabot.yaml`:
 
 ```yaml
 transcription:

--- a/SKILL.md
+++ b/SKILL.md
@@ -178,7 +178,7 @@ Each channel supports three DM policies:
 
 ## Configuration File
 
-After onboarding, config is saved to `~/.config/lettabot/config.yaml`:
+After onboarding, config is saved to `~/.lettabot/config.yaml`:
 
 ```yaml
 server:
@@ -296,7 +296,7 @@ If an AI agent is helping with setup and WhatsApp is configured:
 
 The agent can verify success by checking:
 - `lettabot server` output shows "Connected to Telegram" (or other channel)
-- Config file exists at `~/.config/lettabot/config.yaml`
+- Config file exists at `~/.lettabot/config.yaml`
 - User can message bot on configured channel(s)
 
 ## Self-Hosted Letta

--- a/e2e/bot.e2e.test.ts
+++ b/e2e/bot.e2e.test.ts
@@ -1,0 +1,92 @@
+/**
+ * E2E Tests for LettaBot
+ * 
+ * These tests use a real Letta Cloud agent to verify the full message flow.
+ * Requires LETTA_API_KEY and LETTA_E2E_AGENT_ID environment variables.
+ * 
+ * Run with: npm run test:e2e
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { LettaBot } from '../src/core/bot.js';
+import { MockChannelAdapter } from '../src/test/mock-channel.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Skip if no API key (local dev without secrets)
+const SKIP_E2E = !process.env.LETTA_API_KEY || !process.env.LETTA_E2E_AGENT_ID;
+
+describe.skipIf(SKIP_E2E)('e2e: LettaBot with Letta Cloud', () => {
+  let bot: LettaBot;
+  let mockAdapter: MockChannelAdapter;
+  let tempDir: string;
+
+  beforeAll(async () => {
+    // Create temp directory for test data
+    tempDir = mkdtempSync(join(tmpdir(), 'lettabot-e2e-'));
+    
+    // Set agent ID from secrets
+    process.env.LETTA_AGENT_ID = process.env.LETTA_E2E_AGENT_ID;
+    
+    // Initialize bot with test config
+    bot = new LettaBot({
+      model: 'claude-sonnet-4-20250514', // Good balance of speed/quality
+      workingDir: tempDir,
+      agentName: 'e2e-test',
+    });
+    
+    // Register mock channel
+    mockAdapter = new MockChannelAdapter();
+    bot.registerChannel(mockAdapter);
+    
+    console.log('[E2E] Bot initialized with agent:', process.env.LETTA_E2E_AGENT_ID);
+  }, 30000); // 30s timeout for setup
+
+  afterAll(async () => {
+    // Cleanup temp directory
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('responds to a simple message', async () => {
+    const response = await mockAdapter.simulateMessage('Say "E2E TEST OK" and nothing else.');
+    
+    expect(response).toBeTruthy();
+    expect(response.length).toBeGreaterThan(0);
+    // The agent should respond with something containing our test phrase
+    expect(response.toUpperCase()).toContain('E2E TEST OK');
+  }, 60000); // 60s timeout
+
+  it('handles /status command', async () => {
+    const response = await mockAdapter.simulateMessage('/status');
+    
+    expect(response).toBeTruthy();
+    // Status should contain agent info
+    expect(response).toMatch(/agent|status/i);
+  }, 30000);
+
+  it('handles /help command', async () => {
+    const response = await mockAdapter.simulateMessage('/help');
+    
+    expect(response).toBeTruthy();
+    expect(response).toContain('LettaBot');
+    expect(response).toContain('/status');
+  }, 10000);
+
+  it('maintains conversation context', async () => {
+    // First message - set context
+    await mockAdapter.simulateMessage('Remember this number: 42424242');
+    
+    // Clear messages but keep session
+    mockAdapter.clearMessages();
+    
+    // Second message - recall context
+    const response = await mockAdapter.simulateMessage('What number did I just tell you to remember?');
+    
+    expect(response).toContain('42424242');
+  }, 120000); // 2 min timeout for multi-turn
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "node dist/main.js",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:e2e": "vitest run e2e/",
     "skills": "tsx src/cli.ts skills",
     "skills:list": "tsx src/cli.ts skills list",
     "skills:status": "tsx src/cli.ts skills status",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,15 @@ async function server() {
   
   // Check if configured
   if (!existsSync(configPath)) {
-    console.log(`No config found at ${configPath}. Run "lettabot onboard" first.\n`);
+    console.log(`
+No config file found. Searched locations:
+  1. ./lettabot.yaml (project-local - recommended)
+  2. ./lettabot.yml
+  3. ~/.lettabot/config.yaml (user global)
+  4. ~/.lettabot/config.yml
+
+Run "lettabot onboard" to create a config file.
+`);
     process.exit(1);
   }
   

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -118,4 +118,22 @@ export class Store {
     this.data.lastMessageTarget = target || undefined;
     this.save();
   }
+  
+  // Recovery tracking
+  
+  get recoveryAttempts(): number {
+    return this.data.recoveryAttempts || 0;
+  }
+  
+  incrementRecoveryAttempts(): number {
+    this.data.recoveryAttempts = (this.data.recoveryAttempts || 0) + 1;
+    this.data.lastRecoveryAt = new Date().toISOString();
+    this.save();
+    return this.data.recoveryAttempts;
+  }
+  
+  resetRecoveryAttempts(): void {
+    this.data.recoveryAttempts = 0;
+    this.save();
+  }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -43,7 +43,7 @@ export interface TriggerContext {
 // Original Types
 // =============================================================================
 
-export type ChannelId = 'telegram' | 'slack' | 'whatsapp' | 'signal' | 'discord';
+export type ChannelId = 'telegram' | 'slack' | 'whatsapp' | 'signal' | 'discord' | 'mock';
 
 export interface InboundAttachment {
   id?: string;
@@ -149,4 +149,8 @@ export interface AgentStore {
   createdAt?: string;
   lastUsedAt?: string;
   lastMessageTarget?: LastMessageTarget;
+  
+  // Recovery tracking
+  recoveryAttempts?: number; // Count of consecutive recovery attempts
+  lastRecoveryAt?: string;   // When last recovery was attempted
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,15 @@ import { agentExists, findAgentByName } from './tools/letta-api.js';
 const configPath = resolveConfigPath();
 const isContainerDeploy = !!(process.env.RAILWAY_ENVIRONMENT || process.env.RENDER || process.env.FLY_APP_NAME || process.env.DOCKER_DEPLOY);
 if (!existsSync(configPath) && !isContainerDeploy) {
-  console.log(`\n  No config found at ${configPath}. Run "lettabot onboard" first.\n`);
+  console.log(`
+No config file found. Searched locations:
+  1. ./lettabot.yaml (project-local - recommended)
+  2. ./lettabot.yml
+  3. ~/.lettabot/config.yaml (user global)
+  4. ~/.lettabot/config.yml
+
+Run "lettabot onboard" to create a config file.
+`);
   process.exit(1);
 }
 

--- a/src/test/mock-channel.ts
+++ b/src/test/mock-channel.ts
@@ -1,0 +1,117 @@
+/**
+ * Mock Channel Adapter for E2E Testing
+ * 
+ * Captures messages sent by the bot and allows simulating inbound messages.
+ */
+
+import type { ChannelAdapter } from '../channels/types.js';
+import type { InboundMessage, OutboundMessage } from '../core/types.js';
+
+export class MockChannelAdapter implements ChannelAdapter {
+  readonly id = 'mock' as const;
+  readonly name = 'Mock (Testing)';
+  
+  private running = false;
+  private sentMessages: OutboundMessage[] = [];
+  private responseResolvers: Array<(msg: OutboundMessage) => void> = [];
+  
+  onMessage?: (msg: InboundMessage) => Promise<void>;
+  onCommand?: (command: string) => Promise<string | null>;
+  
+  async start(): Promise<void> {
+    this.running = true;
+  }
+  
+  async stop(): Promise<void> {
+    this.running = false;
+  }
+  
+  isRunning(): boolean {
+    return this.running;
+  }
+  
+  async sendMessage(msg: OutboundMessage): Promise<{ messageId: string }> {
+    const messageId = `mock-${Date.now()}`;
+    this.sentMessages.push(msg);
+    
+    // Resolve any waiting promises
+    const resolver = this.responseResolvers.shift();
+    if (resolver) {
+      resolver(msg);
+    }
+    
+    return { messageId };
+  }
+  
+  async editMessage(_chatId: string, _messageId: string, _text: string): Promise<void> {
+    // No-op for mock
+  }
+  
+  async sendTypingIndicator(_chatId: string): Promise<void> {
+    // No-op for mock
+  }
+  
+  supportsEditing(): boolean {
+    return false; // Disable streaming edits for simpler testing
+  }
+  
+  /**
+   * Simulate an inbound message and wait for response
+   */
+  async simulateMessage(
+    text: string,
+    options: {
+      userId?: string;
+      chatId?: string;
+      userName?: string;
+    } = {}
+  ): Promise<string> {
+    if (!this.onMessage) {
+      throw new Error('No message handler registered');
+    }
+    
+    const chatId = options.chatId || 'test-chat-123';
+    
+    // Create promise that resolves when bot sends response
+    const responsePromise = new Promise<OutboundMessage>((resolve) => {
+      this.responseResolvers.push(resolve);
+    });
+    
+    // Send the inbound message
+    const inbound: InboundMessage = {
+      channel: 'mock',
+      chatId,
+      userId: options.userId || 'test-user-456',
+      userName: options.userName || 'Test User',
+      text,
+      timestamp: new Date(),
+    };
+    
+    // Don't await - let it process async
+    this.onMessage(inbound).catch(err => {
+      console.error('[MockChannel] Error processing message:', err);
+    });
+    
+    // Wait for response with timeout
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error('Response timeout (60s)')), 60000);
+    });
+    
+    const response = await Promise.race([responsePromise, timeoutPromise]);
+    return response.text;
+  }
+  
+  /**
+   * Get all sent messages (for assertions)
+   */
+  getSentMessages(): OutboundMessage[] {
+    return [...this.sentMessages];
+  }
+  
+  /**
+   * Clear sent messages
+   */
+  clearMessages(): void {
+    this.sentMessages = [];
+  }
+}


### PR DESCRIPTION
## Summary

E2E testing infrastructure that tests the full message flow against a real Letta Cloud agent.

## What's Added

### MockChannelAdapter (`src/test/mock-channel.ts`)
- Simulates a messaging channel for testing
- Captures sent messages
- `simulateMessage()` sends inbound and waits for response

### E2E Tests (`e2e/bot.e2e.test.ts`)
- **Simple message/response** - Agent responds to a message
- **/status command** - Returns agent info
- **/help command** - Returns help text
- **Context retention** - Agent remembers across turns

### CI Workflow Updates
- Separate `unit` and `e2e` jobs
- E2E runs on main branch (has secrets)
- Skipped on PRs from forks (no secrets access)

## Setup Required

Add this secret to the repo:
- `LETTA_E2E_AGENT_ID` - ID of a test agent on Letta Cloud

The `LETTA_API_KEY` secret already exists.

## Running Locally

```bash
export LETTA_API_KEY=your-key
export LETTA_E2E_AGENT_ID=agent-xxx
npm run test:e2e
```

Without env vars, e2e tests are automatically skipped.