### PR TITLE
fix: MockChannelAdapter handles commands like real channels

### DIFF
--- a/src/test/mock-channel.ts
+++ b/src/test/mock-channel.ts
@@ -6,6 +6,7 @@
 
 import type { ChannelAdapter } from '../channels/types.js';
 import type { InboundMessage, OutboundMessage } from '../core/types.js';
+import { parseCommand, HELP_TEXT } from '../core/commands.js';
 
 export class MockChannelAdapter implements ChannelAdapter {
   readonly id = 'mock' as const;
@@ -71,6 +72,18 @@ export class MockChannelAdapter implements ChannelAdapter {
     }
     
     const chatId = options.chatId || 'test-chat-123';
+    
+    // Handle slash commands locally (like real channels do)
+    const command = parseCommand(text);
+    if (command) {
+      if (command === 'help' || command === 'start') {
+        return HELP_TEXT;
+      } else if (this.onCommand) {
+        const result = await this.onCommand(command);
+        return result || '(No response)';
+      }
+      return '(Command not handled)';
+    }
     
     // Create promise that resolves when bot sends response
     const responsePromise = new Promise<OutboundMessage>((resolve) => {


### PR DESCRIPTION
## Fix

The e2e test for /help failed because MockChannelAdapter was passing commands to the agent instead of handling them locally.

Real channels (Telegram, Signal, etc.) intercept /help and return HELP_TEXT directly. Now MockChannelAdapter does the same.

## What Changed

MockChannelAdapter now:
1. Checks for commands before calling onMessage
2. Returns HELP_TEXT for /help and /start
3. Delegates /status and /heartbeat to onCommand

This makes e2e tests consistent with real behavior.