### PR TITLE
fix: add keyv as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "googleapis": "^170.1.0",
         "grammy": "^1.39.3",
         "gray-matter": "^4.0.3",
+        "keyv": "^5.6.0",
         "node-schedule": "^2.1.1",
         "open": "^11.0.0",
         "openai": "^6.17.0",
@@ -1268,8 +1269,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@letta-ai/letta-client": {
       "version": "1.7.7",
@@ -4811,7 +4811,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "update-notifier": "^7.3.1",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "keyv": "^5.6.0"
   },
   "optionalDependencies": {
     "@slack/bolt": "^4.6.0",


### PR DESCRIPTION
## Summary
- Adds `keyv` as a direct dependency to fix `ERR_MODULE_NOT_FOUND` on fresh installs
- `keyv` is a transitive dep of Baileys via `@cacheable/utils`, but since Baileys is in `optionalDependencies`, some npm versions don't properly resolve it

## Test plan
- [x] Fresh `npm install` should now include keyv
- [x] WhatsApp channel should start without module errors

Written by Cameron ◯ Letta Code