### PR TITLE
feat: add {{NO_REPLY}} silent marker for agent opt-out

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -389,8 +389,8 @@ export class LettaBot {
       // Helper to finalize and send current accumulated response
       const finalizeMessage = async () => {
         // Check for silent marker - agent chose not to reply
-        if (response.trim() === '{{NO_REPLY}}') {
-          console.log('[Bot] Agent chose not to reply (NO_REPLY marker)');
+        if (response.trim() === '<no-reply/>') {
+          console.log('[Bot] Agent chose not to reply (no-reply marker)');
           sentAnyMessage = true;
           response = '';
           messageId = null;
@@ -468,9 +468,9 @@ export class LettaBot {
             response += streamMsg.content;
             
             // Stream updates only for channels that support editing (Telegram, Slack)
-            // Hold back streaming edits while response could still become NO_REPLY
+            // Hold back streaming edits while response could still become <no-reply/>
             const canEdit = adapter.supportsEditing?.() ?? true;
-            const mayBeNoReply = '{{NO_REPLY}}'.startsWith(response.trim());
+            const mayBeNoReply = '<no-reply/>'.startsWith(response.trim());
             if (canEdit && !mayBeNoReply && Date.now() - lastUpdate > 500 && response.length > 0) {
               try {
                 if (messageId) {
@@ -534,8 +534,8 @@ export class LettaBot {
       }
       
       // Check for silent marker - agent chose not to reply
-      if (response.trim() === '{{NO_REPLY}}') {
-        console.log('[Bot] Agent chose not to reply (NO_REPLY marker)');
+      if (response.trim() === '<no-reply/>') {
+        console.log('[Bot] Agent chose not to reply (no-reply marker)');
         sentAnyMessage = true;
         response = '';
       }

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -74,7 +74,7 @@ You don't need to notify the user about everything. Use judgment about what's wo
 
 Not all messages warrant a response. If a message doesn't need a reply, respond with exactly:
 
-\`{{NO_REPLY}}\`
+\`<no-reply/>\`
 
 This suppresses the message so nothing is sent to the user. Use this for:
 - Messages in a group not directed at you
@@ -83,7 +83,7 @@ This suppresses the message so nothing is sent to the user. Use this for:
 - Notifications or updates that don't require a response
 - Messages you've already addressed
 
-When in doubt, prefer \`{{NO_REPLY}}\` over a low-value response. Users appreciate an agent that knows when to stay quiet.
+When in doubt, prefer \`<no-reply/>\` over a low-value response. Users appreciate an agent that knows when to stay quiet.
 
 ## Available Channels
 


### PR DESCRIPTION
## Human Summary for @cpfiffer 

The fact that the bot responds to every message is problematic, especially when moving to groups where it can be overwhelmed by new messages.

Another common failure case is reactions, which are treated by default as messages. The worst I've experienced is accidentally forwarding a set of Telegram messages instead of copying them into a single message, which prompted the model to respond to each one individually.

This is a simple opt-out mechanism, though it could probably be improved (Kimi doesn't seem to be using it consistently, even though it's defined both in the system prompt and in a learned behavior memory block).

## Claude Summary
- Allow the agent to respond with `{{NO_REPLY}}` to indicate a message doesn't warrant a reply, suppressing message delivery
- Guard streaming edits with a prefix check so partial tokens (e.g. `{{N`) are never sent to the channel
- Add guidance to the system prompt encouraging the agent to prefer silence over low-value responses