### PR TITLE
fix: WhatsApp self-chat detection + debug logging

### DIFF
--- a/src/channels/whatsapp/inbound/extract.ts
+++ b/src/channels/whatsapp/inbound/extract.ts
@@ -196,8 +196,9 @@ export async function extractInboundMessage(
   // Check if sender mentioned the bot
   const wasMentioned = mentionedJids?.includes(selfJid) ?? false;
 
-  // Detect self-chat
-  const isSelfChat = !isGroup && from === selfE164;
+  // Detect self-chat (including LID-based self-chat on newer WhatsApp versions)
+  const isLidChat = remoteJid.includes('@lid');
+  const isSelfChat = !isGroup && (from === selfE164 || isLidChat);
 
   // Build normalized message (convert all nulls to undefined for type safety)
   const inboundMessage: WebInboundMessage = {


### PR DESCRIPTION
## Summary

- Fix self-chat detection inconsistency that silently drops messages for selfChat users
- Add `DEBUG_WHATSAPP=1` env var for verbose message filter logging

## Problem

Kian's WhatsApp bot is configured with `selfChat: true` but no messages get through - not self-chat, not external. No error logs.

**Root cause:** Two different self-chat detection mechanisms that disagree:

1. `isSelfChatMessage()` (utils.ts) - correctly detects LID-based self-chat
2. `isExtractedSelfChat` (extract.ts) - only checks `from === selfE164`, **misses LID-based self-chat**

On newer WhatsApp versions, self-chat uses LID JIDs (`@lid` suffix). The `fromMe` filter passes (via #1) but the `selfChatMode` filter drops the message (via #2) - silently, with zero logging.

## Fix

**extract.ts:** Include LID-based self-chat in detection:
```typescript
// Before (broken):
const isSelfChat = !isGroup && from === selfE164;

// After (fixed):
const isLidChat = remoteJid.includes('@lid');
const isSelfChat = !isGroup && (from === selfE164 || isLidChat);
```

**index.ts:** Add `DEBUG_WHATSAPP=1` verbose logging at all 8 filter points:
- Message type filter
- Status/broadcast filter
- Sent message filter
- fromMe filter
- Extraction failures
- Dedupe filter
- Old message filter
- selfChatMode DM filter

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:run` passes (pre-existing telegram-format failures only)
- [ ] Kian tests with `DEBUG_WHATSAPP=1` to verify messages flow through
- [ ] Self-chat via LID works

Written by Cameron ◯ Letta Code