### PR TITLE
fix: approval detection missing include param + /reset command + startup check

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -79,6 +79,13 @@ export class LettaBot {
         });
         return '⏰ Heartbeat triggered (silent mode - check server logs)';
       }
+      case 'reset': {
+        const oldConversationId = this.store.conversationId;
+        this.store.conversationId = null;
+        this.store.resetRecoveryAttempts();
+        console.log(`[Command] /reset - conversation cleared (was: ${oldConversationId})`);
+        return 'Conversation reset. Send a message to start a new conversation. (Agent memory is preserved.)';
+      }
       default:
         return null;
     }

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -4,7 +4,7 @@
  * Shared command parsing and help text for all channels.
  */
 
-export const COMMANDS = ['status', 'heartbeat', 'help', 'start'] as const;
+export const COMMANDS = ['status', 'heartbeat', 'reset', 'help', 'start'] as const;
 export type Command = typeof COMMANDS[number];
 
 export const HELP_TEXT = `LettaBot - AI assistant with persistent memory
@@ -12,6 +12,7 @@ export const HELP_TEXT = `LettaBot - AI assistant with persistent memory
 Commands:
 /status - Show current status
 /heartbeat - Trigger heartbeat
+/reset - Reset conversation (keeps agent memory)
 /help - Show this message
 
 Just send a message to get started!`;


### PR DESCRIPTION
## Summary

- **Root cause fix**: `getPendingApprovals()` was calling `agents.retrieve()` without `include: ['agent.pending_approval']`, so the Letta API never returned the `pending_approval` field. Server-side tool approvals (`requires_approval=true`) went undetected, leaving the agent permanently stuck with empty responses.
- **Proactive startup check**: `ensureNoToolApprovals()` runs on startup to disable any `requires_approval=true` tools before they can cause stuck states.
- **`/reset` slash command**: Allows resetting the conversation from any channel (Telegram, Slack, etc.) on deployed instances where CLI access isn't available. Clears conversation ID but preserves agent memory.
- **Robust parsing**: Handles both `ToolCallDelta` (non-array) and deprecated singular `tool_call` field formats in approval messages.

Related: letta-code-sdk #25 (bypassPermissions doesn't prevent server-side tool approvals)

## Test plan

- [ ] Deploy to Railway and verify stuck approval is detected and cleared on next message
- [ ] Verify `/reset` command works from Telegram
- [ ] Verify startup logs show tool approval check
- [ ] Verify normal message flow still works after recovery

Written by Cameron ◯ Letta Code

"The only way to do great work is to love what you do." - Steve Jobs