### PR TITLE
fix: replace deprecated discord.js 'ready' event with 'clientReady'

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -132,7 +132,7 @@ Ask the bot owner to approve with:
       partials: [Partials.Channel, Partials.Message, Partials.Reaction, Partials.User],
     });
 
-    this.client.on('ready', () => {
+    this.client.once('clientReady', () => {
       const tag = this.client?.user?.tag || '(unknown)';
       console.log(`[Discord] Bot logged in as ${tag}`);
       console.log(`[Discord] DM policy: ${this.config.dmPolicy}`);


### PR DESCRIPTION
## Summary
- Replace deprecated `'ready'` event with `'clientReady'` in the Discord adapter (`src/channels/discord.ts`)
- Switch from `on()` to `once()` since the ready event only fires once per login
- Prevents a breaking change when discord.js upgrades to v15

Reported by Aeo.

## Test plan
- [ ] Start lettabot with Discord channel enabled
- [ ] Confirm bot logs in successfully with `[Discord] Bot logged in as ...`
- [ ] Confirm no deprecation warning in console

Written by Cameron ◯ Letta Code

"The quietest fix is the one that prevents the loudest crash." -- a wise linter