### PR TITLE
feat: centralized group access gating (deferred)

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -328,6 +328,10 @@ Ask the bot owner to approve with:
     return this.config.dmPolicy || 'pairing';
   }
 
+  getAllowedUsers(): string[] {
+    return this.config.allowedUsers || [];
+  }
+
   supportsEditing(): boolean {
     return true;
   }

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -307,6 +307,10 @@ This code expires in 1 hour.`;
     return this.config.dmPolicy || 'pairing';
   }
 
+  getAllowedUsers(): string[] {
+    return this.config.allowedUsers || [];
+  }
+
   supportsEditing(): boolean {
     return false;
   }

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -281,6 +281,10 @@ export class SlackAdapter implements ChannelAdapter {
     return this.config.dmPolicy || 'pairing';
   }
 
+  getAllowedUsers(): string[] {
+    return this.config.allowedUsers || [];
+  }
+
   async sendTypingIndicator(_chatId: string): Promise<void> {
     // Slack doesn't have a typing indicator API for bots
     // This is a no-op

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -525,6 +525,10 @@ export class TelegramAdapter implements ChannelAdapter {
     return this.config.dmPolicy || 'pairing';
   }
 
+  getAllowedUsers(): string[] {
+    return (this.config.allowedUsers || []).map(String);
+  }
+
   async sendTypingIndicator(chatId: string): Promise<void> {
     await this.bot.api.sendChatAction(chatId, 'typing');
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -27,6 +27,7 @@ export interface ChannelAdapter {
   supportsEditing?(): boolean;
   sendFile?(file: OutboundFile): Promise<{ messageId: string }>;
   getDmPolicy?(): string;
+  getAllowedUsers?(): string[];
   
   // Event handlers (set by bot core)
   onMessage?: (msg: InboundMessage) => Promise<void>;

--- a/src/channels/whatsapp/index.ts
+++ b/src/channels/whatsapp/index.ts
@@ -981,6 +981,10 @@ export class WhatsAppAdapter implements ChannelAdapter {
     return this.config.dmPolicy || 'pairing';
   }
 
+  getAllowedUsers(): string[] {
+    return this.config.allowedUsers || [];
+  }
+
   supportsEditing(): boolean {
     return false;
   }


### PR DESCRIPTION
## Summary

**Deferred portion** of the group chat support, split from the original PR per @cpfiffer's [review](#issuecomment-3857520097).

The genuinely new parts (GroupBatcher, Telegram group gating, instantGroups, channel group support) are in #187.

This PR adds **centralized access gating** in `bot.ts` — when `dmPolicy` is `pairing`, group messages are checked against an approved-groups store before being batched. A paired user's first message in a group auto-approves it for everyone; unpaired users in unapproved groups are silently ignored.

### Why deferred

As noted in the review, this centralized gating overlaps with existing per-channel implementations (WhatsApp `access-control.ts`/`group-gating.ts`, Signal `group-gating.ts`). It fits more naturally into the #109 multi-agent refactor (`LettaGateway` unified routing layer), where it can be done holistically without duplicating per-channel logic.

### Changes (on top of #187)

| File | Change |
|------|--------|
| `src/core/bot.ts` | `isGroupApproved`/`approveGroup` check in `handleMessage()` |
| `README.md` | Group access control documentation |