### PR TITLE
fix: make polling interval configurable via lettabot.yaml

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -170,6 +170,9 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.integrations?.google?.enabled && config.integrations.google.account) {
     env.GMAIL_ACCOUNT = config.integrations.google.account;
   }
+  if (config.integrations?.google?.pollIntervalSec) {
+    env.POLLING_INTERVAL_MS = String(config.integrations.google.pollIntervalSec * 1000);
+  }
 
   if (config.attachments?.maxMB !== undefined) {
     env.ATTACHMENTS_MAX_MB = String(config.attachments.maxMB);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -120,6 +120,7 @@ export interface GoogleConfig {
   enabled: boolean;
   account?: string;
   services?: string[];  // e.g., ['gmail', 'calendar', 'drive', 'contacts', 'docs', 'sheets']
+  pollIntervalSec?: number;  // Polling interval in seconds (default: 60)
 }
 
 // Default config


### PR DESCRIPTION
## Summary

- Add `pollIntervalSec` field to `GoogleConfig` in the YAML config types
- Wire it through `configToEnv()` to set `POLLING_INTERVAL_MS`

Previously the email polling interval (default 60s) could only be configured via the `POLLING_INTERVAL_MS` environment variable. It can now be set in `lettabot.yaml`:

```yaml
integrations:
  google:
    enabled: true
    account: you@gmail.com
    pollIntervalSec: 120  # default: 60
```

The env var still works as a fallback.