### PR TITLE
fix: abort agent when stuck in tool-call loop

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -165,6 +165,9 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.features?.heartbeat?.enabled) {
     env.HEARTBEAT_INTERVAL_MIN = String(config.features.heartbeat.intervalMin || 30);
   }
+  if (config.features?.maxToolCalls !== undefined) {
+    env.MAX_TOOL_CALLS = String(config.features.maxToolCalls);
+  }
   
   // Integrations - Google (Gmail polling)
   if (config.integrations?.google?.enabled && config.integrations.google.account) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -43,6 +43,7 @@ export interface LettaBotConfig {
       enabled: boolean;
       intervalMin?: number;
     };
+    maxToolCalls?: number;  // Abort if agent calls this many tools in one turn (default: 100)
   };
 
   // Integrations (Google Workspace, etc.)

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -478,6 +478,15 @@ export class LettaBot {
             await finalizeMessage();
           }
           
+          // Detect tool-call loops: abort if agent calls too many tools without producing a result
+          const maxToolCalls = this.config.maxToolCalls ?? 100;
+          if (streamMsg.type === 'tool_call' && (msgTypeCounts['tool_call'] || 0) >= maxToolCalls) {
+            console.error(`[Bot] Agent stuck in tool loop (${msgTypeCounts['tool_call']} tool calls, limit=${maxToolCalls}), aborting`);
+            session.abort().catch(() => {});
+            response = '(Agent got stuck in a tool loop and was stopped. Try sending your message again.)';
+            break;
+          }
+
           // Log meaningful events (always, not just on type change for tools)
           if (streamMsg.type === 'tool_call') {
             const toolName = (streamMsg as any).toolName || 'unknown';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -121,10 +121,13 @@ export interface BotConfig {
   model?: string; // e.g., 'anthropic/claude-sonnet-4-5-20250929'
   agentName?: string; // Name for the agent (set via API after creation)
   allowedTools: string[];
-  
+
   // Skills
   skills?: SkillsConfig;
-  
+
+  // Safety
+  maxToolCalls?: number; // Abort if agent calls this many tools in one turn (default: 100)
+
   // Security
   allowedUsers?: string[];  // Empty = allow all
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -329,6 +329,7 @@ async function main() {
     model: config.model,
     agentName: process.env.AGENT_NAME || 'LettaBot',
     allowedTools: config.allowedTools,
+    maxToolCalls: process.env.MAX_TOOL_CALLS ? Number(process.env.MAX_TOOL_CALLS) : undefined,
     skills: {
       cronEnabled: config.cronEnabled,
       googleEnabled: config.polling.gmail.enabled,


### PR DESCRIPTION
## Summary

- Adds a safeguard that aborts the session when the agent enters an infinite tool-calling loop (e.g. 216 consecutive `tool_call` stream events with no useful result)
- The existing stream watchdog didn't catch this because the stream was actively sending data — just not producing anything useful
- Default limit is 100 tool calls per turn, configurable via `lettabot.yaml`:
  ```yaml
  features:
    maxToolCalls: 150
  ```
- When triggered, the user gets a message explaining what happened and suggesting to retry