### PR TITLE
fix: add api.port config + Telegram message splitting + error handling hardening

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -183,6 +183,17 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.attachments?.maxAgeDays !== undefined) {
     env.ATTACHMENTS_MAX_AGE_DAYS = String(config.attachments.maxAgeDays);
   }
+
+  // API server
+  if (config.api?.port !== undefined) {
+    env.PORT = String(config.api.port);
+  }
+  if (config.api?.host) {
+    env.API_HOST = config.api.host;
+  }
+  if (config.api?.corsOrigin) {
+    env.API_CORS_ORIGIN = config.api.corsOrigin;
+  }
   
   return env;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -59,6 +59,13 @@ export interface LettaBotConfig {
     maxMB?: number;
     maxAgeDays?: number;
   };
+
+  // API server (health checks, CLI messaging)
+  api?: {
+    port?: number;       // Default: 8080 (or PORT env var)
+    host?: string;       // Default: 127.0.0.1 (secure). Use '0.0.0.0' for Docker/Railway
+    corsOrigin?: string; // CORS origin. Default: same-origin only
+  };
 }
 
 export interface TranscriptionConfig {


### PR DESCRIPTION
## Summary
- **Port configuration**: Add `api.port`, `api.host`, `api.corsOrigin` to the `lettabot.yaml` config schema. Previously the API server port was only configurable via the raw `PORT` env var, which users couldn't figure out. Now `api: { port: 9090 }` in YAML works.
- **Telegram message splitting**: Split messages exceeding Telegram's 4096-char limit at paragraph/line boundaries (~3800 chars pre-formatting to account for MarkdownV2 escaping overhead). Safety-net re-split if formatting expands beyond 4096.
- **Error handling hardening**: Wrap two unguarded `adapter.sendMessage()` calls in `bot.ts` error paths with try/catch. Previously, if sending an error message to the channel also failed (e.g., Telegram API down), the unhandled rejection would crash the process.

Reported via Discord -- user had port 8080 conflicting with another service and Telegram dying on sends.

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Unit tests pass (330/330, 1 pre-existing unrelated failure in commands.test)
- [ ] Verify `api: { port: 9090 }` in lettabot.yaml correctly binds to port 9090
- [ ] Send a very long message (>4096 chars) via Telegram and confirm it arrives as multiple messages
- [ ] Verify error cascade no longer crashes: simulate a Telegram API failure during error reporting

Written by Cameron ◯ Letta Code

"When you can't make them see the light, make them feel the heat." - Ronald Reagan