### PR TITLE
feat: backfill Slack thread context on @mention

### DIFF
--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -47,10 +47,13 @@ Socket Mode lets your bot connect without exposing a public endpoint.
 | Scope | Purpose |
 |-------|---------|
 | `app_mentions:read` | React when someone @mentions your bot |
+| `channels:history` | Read thread history in public channels |
 | `chat:write` | Send messages |
+| `groups:history` | Read thread history in private channels |
 | `im:history` | Read DM message history |
 | `im:read` | View DM channel info |
 | `im:write` | Start DM conversations |
+| `users:read` | Resolve display names in thread context |
 
 ## Step 4: Enable Events
 
@@ -125,6 +128,7 @@ Registered channel: Slack
 ### Thread Replies
 - If you mention the bot in a thread, it will reply in that thread
 - If you mention the bot in a channel (not a thread), it starts a new thread from your message
+- When mentioned mid-thread, the bot automatically reads prior messages so it understands the conversation context
 
 ## Cross-Channel Memory
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -62,6 +62,19 @@ export interface InboundReaction {
 }
 
 /**
+ * A message from thread history, used for thread context backfill.
+ * When the bot is mentioned in an existing thread, prior messages
+ * are fetched and included so the agent has full conversation context.
+ */
+export interface ThreadContextMessage {
+  userId: string;
+  userName?: string;
+  text: string;
+  timestamp: Date;
+  isBotMessage?: boolean;
+}
+
+/**
  * Inbound message from any channel
  */
 export interface InboundMessage {
@@ -83,6 +96,7 @@ export interface InboundMessage {
   reaction?: InboundReaction;
   isBatch?: boolean;                  // Is this a batched group message?
   batchedMessages?: InboundMessage[]; // Original individual messages (for batch formatting)
+  threadContext?: ThreadContextMessage[];  // Prior messages in thread (backfilled)
 }
 
 /**

--- a/src/setup/slack-wizard.ts
+++ b/src/setup/slack-wizard.ts
@@ -98,10 +98,13 @@ oauth_config:
   scopes:
     bot:
       - app_mentions:read
+      - channels:history
       - chat:write
+      - groups:history
       - im:history
       - im:read
       - im:write
+      - users:read
 settings:
   org_deploy_enabled: false
   socket_mode_enabled: true
@@ -117,7 +120,7 @@ settings:
   p.note(
     'Creates app with everything pre-configured:\n' +
     '  • Socket Mode enabled\n' +
-    '  • 5 bot scopes (app_mentions:read, chat:write, im:*)\n' +
+    '  • 8 bot scopes (mentions, channels/groups history, chat, im, users)\n' +
     '  • 2 event subscriptions (app_mention, message.im)\n\n' +
     'Just review and click "Create"!',
     'One-Click Setup'


### PR DESCRIPTION
## Summary
- When the bot is @mentioned in an existing Slack thread, fetch prior messages via `conversations.replies` and include them in the message envelope so the agent has full conversation context before responding.
- Smart deduplication: only backfills messages after the bot's last response in the thread, so repeat @mentions don't re-send stale context.
- Resolves `<@U123>` user mentions to display names with in-memory caching (`users.info` API).
- Caps context at 4000 total chars / 500 per message to avoid bloating the envelope.
- Adds `channels:history`, `groups:history`, and `users:read` to the Slack app manifest and docs.

**Note for existing Slack users:** After updating, you'll need to reinstall your Slack app to pick up the new OAuth scopes. Go to your app's "Install App" page and click "Reinstall to Workspace".

## Test plan
- [x] TypeScript compiles clean
- [x] 334 unit tests pass (4 new thread context formatter tests)
- [ ] @mention the bot in an existing Slack thread and verify the agent sees prior messages
- [ ] @mention in a thread where the bot already responded -- verify only new messages are included
- [ ] Verify name resolution works (display names, not raw user IDs)

Written by Cameron ◯ Letta Code

"We are what we repeatedly do. Excellence, then, is not an act, but a habit." - Aristotle