### PR TITLE
feat: add listening mode for groups

### DIFF
--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -35,10 +35,18 @@ channels:
     enabled: true
     token: YOUR-TELEGRAM-BOT-TOKEN
     dmPolicy: pairing  # 'pairing', 'allowlist', or 'open'
+    # groupPollIntervalMin: 5       # Batch interval for group messages (default: 10)
+    # instantGroups: ["-100123456"] # Groups that bypass batching
+    # listeningGroups: ["-100123456"] # Groups where bot observes but only replies when @mentioned
   # slack:
   #   enabled: true
   #   appToken: xapp-...
   #   botToken: xoxb-...
+  #   listeningGroups: ["C0123456789"]  # Channels where bot observes only
+  # discord:
+  #   enabled: true
+  #   token: YOUR-DISCORD-BOT-TOKEN
+  #   listeningGroups: ["1234567890123456789"]  # Server/channel IDs where bot observes only
   # whatsapp:
   #   enabled: true
   #   selfChat: false

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -62,7 +62,7 @@ export function loadConfig(): LettaBotConfig {
     // Fix instantGroups: YAML parses large numeric IDs (e.g. Discord snowflakes)
     // as JavaScript numbers, losing precision for values > Number.MAX_SAFE_INTEGER.
     // Re-extract from document AST to preserve the original string representation.
-    fixInstantGroupIds(content, parsed);
+    fixLargeGroupIds(content, parsed);
 
     // Merge with defaults
     return {
@@ -146,6 +146,9 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.channels.slack?.instantGroups?.length) {
     env.SLACK_INSTANT_GROUPS = config.channels.slack.instantGroups.join(',');
   }
+  if (config.channels.slack?.listeningGroups?.length) {
+    env.SLACK_LISTENING_GROUPS = config.channels.slack.listeningGroups.join(',');
+  }
   if (config.channels.whatsapp?.enabled) {
     env.WHATSAPP_ENABLED = 'true';
     if (config.channels.whatsapp.selfChat) {
@@ -160,6 +163,9 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.channels.whatsapp?.instantGroups?.length) {
     env.WHATSAPP_INSTANT_GROUPS = config.channels.whatsapp.instantGroups.join(',');
   }
+  if (config.channels.whatsapp?.listeningGroups?.length) {
+    env.WHATSAPP_LISTENING_GROUPS = config.channels.whatsapp.listeningGroups.join(',');
+  }
   if (config.channels.signal?.phone) {
     env.SIGNAL_PHONE_NUMBER = config.channels.signal.phone;
     // Signal selfChat defaults to true, so only set env if explicitly false
@@ -173,11 +179,17 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.channels.signal?.instantGroups?.length) {
     env.SIGNAL_INSTANT_GROUPS = config.channels.signal.instantGroups.join(',');
   }
+  if (config.channels.signal?.listeningGroups?.length) {
+    env.SIGNAL_LISTENING_GROUPS = config.channels.signal.listeningGroups.join(',');
+  }
   if (config.channels.telegram?.groupPollIntervalMin !== undefined) {
     env.TELEGRAM_GROUP_POLL_INTERVAL_MIN = String(config.channels.telegram.groupPollIntervalMin);
   }
   if (config.channels.telegram?.instantGroups?.length) {
     env.TELEGRAM_INSTANT_GROUPS = config.channels.telegram.instantGroups.join(',');
+  }
+  if (config.channels.telegram?.listeningGroups?.length) {
+    env.TELEGRAM_LISTENING_GROUPS = config.channels.telegram.listeningGroups.join(',');
   }
   if (config.channels.discord?.token) {
     env.DISCORD_BOT_TOKEN = config.channels.discord.token;
@@ -194,7 +206,10 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.channels.discord?.instantGroups?.length) {
     env.DISCORD_INSTANT_GROUPS = config.channels.discord.instantGroups.join(',');
   }
-  
+  if (config.channels.discord?.listeningGroups?.length) {
+    env.DISCORD_LISTENING_GROUPS = config.channels.discord.listeningGroups.join(',');
+  }
+
   // Features
   if (config.features?.cron) {
     env.CRON_ENABLED = 'true';
@@ -333,46 +348,51 @@ export async function syncProviders(config: LettaBotConfig): Promise<void> {
 }
 
 /**
- * Fix instantGroups arrays that may contain large numeric IDs parsed by YAML.
+ * Fix group ID arrays that may contain large numeric IDs parsed by YAML.
  * Discord snowflake IDs exceed Number.MAX_SAFE_INTEGER, so YAML parses them
  * as lossy JavaScript numbers. We re-read from the document AST to get the
  * original string representation.
  */
-function fixInstantGroupIds(yamlContent: string, parsed: Partial<LettaBotConfig>): void {
+function fixLargeGroupIds(yamlContent: string, parsed: Partial<LettaBotConfig>): void {
   if (!parsed.channels) return;
+
+  const channels = ['telegram', 'slack', 'whatsapp', 'signal', 'discord'] as const;
+  const groupFields = ['instantGroups', 'listeningGroups'] as const;
 
   try {
     const doc = YAML.parseDocument(yamlContent);
-    const channels = ['telegram', 'slack', 'whatsapp', 'signal', 'discord'] as const;
 
     for (const ch of channels) {
-      const seq = doc.getIn(['channels', ch, 'instantGroups'], true);
-      if (YAML.isSeq(seq)) {
-        const fixed = seq.items.map((item: unknown) => {
-          if (YAML.isScalar(item)) {
-            // For numbers, use the original source text to avoid precision loss
-            if (typeof item.value === 'number' && item.source) {
-              return item.source;
+      for (const field of groupFields) {
+        const seq = doc.getIn(['channels', ch, field], true);
+        if (YAML.isSeq(seq)) {
+          const fixed = seq.items.map((item: unknown) => {
+            if (YAML.isScalar(item)) {
+              // For numbers, use the original source text to avoid precision loss
+              if (typeof item.value === 'number' && item.source) {
+                return item.source;
+              }
+              return String(item.value);
             }
-            return String(item.value);
+            return String(item);
+          });
+          const cfg = parsed.channels[ch];
+          if (cfg) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (cfg as any)[field] = fixed;
           }
-          return String(item);
-        });
-        const cfg = parsed.channels[ch];
-        if (cfg) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (cfg as any).instantGroups = fixed;
         }
       }
     }
   } catch {
     // Fallback: just ensure entries are strings (won't fix precision, but safe)
-    const channels = ['telegram', 'slack', 'whatsapp', 'signal', 'discord'] as const;
     for (const ch of channels) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const cfg = parsed.channels?.[ch] as any;
-      if (cfg && Array.isArray(cfg.instantGroups)) {
-        cfg.instantGroups = cfg.instantGroups.map((v: unknown) => String(v));
+      for (const field of groupFields) {
+        if (cfg && Array.isArray(cfg[field])) {
+          cfg[field] = cfg[field].map((v: unknown) => String(v));
+        }
       }
     }
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -150,6 +150,7 @@ export interface TelegramConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group chat IDs that bypass batching
+  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
 }
 
 export interface SlackConfig {
@@ -161,6 +162,7 @@ export interface SlackConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Channel IDs that bypass batching
+  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
 }
 
 export interface WhatsAppConfig {
@@ -175,6 +177,7 @@ export interface WhatsAppConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group JIDs that bypass batching
+  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
 }
 
 export interface SignalConfig {
@@ -189,6 +192,7 @@ export interface SignalConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group IDs that bypass batching
+  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
 }
 
 export interface DiscordConfig {
@@ -199,6 +203,7 @@ export interface DiscordConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching
+  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
 }
 
 export interface GoogleAccountConfig {

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -123,6 +123,7 @@ export class LettaBot implements AgentSession {
   private groupBatcher?: GroupBatcher;
   private groupIntervals: Map<string, number> = new Map();
   private instantGroupIds: Set<string> = new Set();
+  private listeningGroupIds: Set<string> = new Set();
   private processing = false;
   
   constructor(config: BotConfig) {
@@ -338,11 +339,14 @@ export class LettaBot implements AgentSession {
     console.log(`Registered channel: ${adapter.name}`);
   }
   
-  setGroupBatcher(batcher: GroupBatcher, intervals: Map<string, number>, instantGroupIds?: Set<string>): void {
+  setGroupBatcher(batcher: GroupBatcher, intervals: Map<string, number>, instantGroupIds?: Set<string>, listeningGroupIds?: Set<string>): void {
     this.groupBatcher = batcher;
     this.groupIntervals = intervals;
     if (instantGroupIds) {
       this.instantGroupIds = instantGroupIds;
+    }
+    if (listeningGroupIds) {
+      this.listeningGroupIds = listeningGroupIds;
     }
     console.log('[Bot] Group batcher configured');
   }
@@ -353,6 +357,14 @@ export class LettaBot implements AgentSession {
     const effective = (count === 1 && msg.batchedMessages)
       ? msg.batchedMessages[0]
       : msg;
+
+    // Check if this group is in listening mode
+    const isListening = this.listeningGroupIds.has(`${msg.channel}:${msg.chatId}`)
+      || (msg.serverId && this.listeningGroupIds.has(`${msg.channel}:${msg.serverId}`));
+    if (isListening && !msg.wasMentioned) {
+      effective.isListeningMode = true;
+    }
+
     this.messageQueue.push({ msg: effective, adapter });
     if (!this.processing) {
       this.processQueue().catch(err => console.error('[Queue] Fatal error in processQueue:', err));
@@ -538,23 +550,32 @@ export class LettaBot implements AgentSession {
   private async processMessage(msg: InboundMessage, adapter: ChannelAdapter, retried = false): Promise<void> {
     // Track timing and last target
     this.lastUserMessageTime = new Date();
-    this.store.lastMessageTarget = {
-      channel: msg.channel,
-      chatId: msg.chatId,
-      messageId: msg.messageId,
-      updatedAt: new Date().toISOString(),
-    };
-    
-    await adapter.sendTypingIndicator(msg.chatId);
-    
+
+    // Skip heartbeat target update for listening mode (don't redirect heartbeats)
+    if (!msg.isListeningMode) {
+      this.store.lastMessageTarget = {
+        channel: msg.channel,
+        chatId: msg.chatId,
+        messageId: msg.messageId,
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    // Skip typing indicator for listening mode
+    if (!msg.isListeningMode) {
+      await adapter.sendTypingIndicator(msg.chatId);
+    }
+
     // Pre-send approval recovery
     const recovery = await this.attemptRecovery();
     if (recovery.shouldReset) {
-      await adapter.sendMessage({
-        chatId: msg.chatId,
-        text: '(Session recovery failed after multiple attempts. Try: lettabot reset-conversation)',
-        threadId: msg.threadId,
-      });
+      if (!msg.isListeningMode) {
+        await adapter.sendMessage({
+          chatId: msg.chatId,
+          text: '(Session recovery failed after multiple attempts. Try: lettabot reset-conversation)',
+          threadId: msg.threadId,
+        });
+      }
       return;
     }
 
@@ -567,7 +588,7 @@ export class LettaBot implements AgentSession {
     } : undefined;
 
     const formattedText = msg.isBatch && msg.batchedMessages
-      ? formatGroupBatchEnvelope(msg.batchedMessages)
+      ? formatGroupBatchEnvelope(msg.batchedMessages, {}, msg.isListeningMode)
       : formatMessageEnvelope(msg, {}, sessionContext);
     const messageToSend = await buildMultimodalMessage(formattedText, msg);
 
@@ -781,6 +802,12 @@ export class LettaBot implements AgentSession {
       // Detect unsupported multimodal
       if (Array.isArray(messageToSend) && response.includes('[Image omitted]')) {
         console.warn('[Bot] Model does not support images -- consider a vision-capable model or features.inlineImages: false');
+      }
+
+      // Listening mode: agent processed for memory, suppress response delivery
+      if (msg.isListeningMode) {
+        console.log(`[Bot] Listening mode: processed ${msg.channel}:${msg.chatId} for memory (response suppressed)`);
+        return;
       }
 
       // Send final response

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -383,7 +383,8 @@ export function formatMessageEnvelope(
  */
 export function formatGroupBatchEnvelope(
   messages: InboundMessage[],
-  options: EnvelopeOptions = {}
+  options: EnvelopeOptions = {},
+  isListeningMode?: boolean,
 ): string {
   if (messages.length === 0) return '';
 
@@ -401,7 +402,10 @@ export function formatGroupBatchEnvelope(
     }
   }
   headerParts.push(`${messages.length} message${messages.length === 1 ? '' : 's'}`);
-  const header = `[${headerParts.join(' - ')}]`;
+  let header = `[${headerParts.join(' - ')}]`;
+  if (isListeningMode) {
+    header += '\n[OBSERVATION ONLY - Update memories. Do not reply unless addressed.]';
+  }
 
   // Chat log lines
   const lines = messages.map((msg) => {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -16,7 +16,7 @@ export interface AgentSession {
   registerChannel(adapter: ChannelAdapter): void;
 
   /** Configure group message batching */
-  setGroupBatcher(batcher: GroupBatcher, intervals: Map<string, number>, instantGroupIds?: Set<string>): void;
+  setGroupBatcher(batcher: GroupBatcher, intervals: Map<string, number>, instantGroupIds?: Set<string>, listeningGroupIds?: Set<string>): void;
 
   /** Process a batched group message */
   processGroupBatch(msg: InboundMessage, adapter: ChannelAdapter): void;

--- a/src/core/listening-mode.test.ts
+++ b/src/core/listening-mode.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import type { InboundMessage } from './types.js';
+import type { ChannelAdapter } from '../channels/types.js';
+
+/**
+ * Tests for listening mode detection in processGroupBatch.
+ *
+ * processGroupBatch is a public method on LettaBot that:
+ * 1. Checks if the group is in listeningGroupIds
+ * 2. If listening and NOT mentioned, sets isListeningMode = true
+ * 3. If mentioned, does NOT set isListeningMode (agent should reply)
+ *
+ * We test the detection logic directly since the full processGroupBatch
+ * requires an SDK session. The logic under test:
+ *   const isListening = listeningGroupIds.has(`${channel}:${chatId}`)
+ *     || (serverId && listeningGroupIds.has(`${channel}:${serverId}`));
+ *   if (isListening && !wasMentioned) msg.isListeningMode = true;
+ */
+
+function createGroupMessage(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    channel: 'discord',
+    chatId: '123456',
+    userId: 'user1',
+    userName: 'Alice',
+    text: 'Hello everyone',
+    timestamp: new Date('2026-02-02T12:00:00Z'),
+    isGroup: true,
+    groupName: 'general',
+    isBatch: true,
+    batchedMessages: [{
+      channel: 'discord',
+      chatId: '123456',
+      userId: 'user1',
+      userName: 'Alice',
+      text: 'Hello everyone',
+      timestamp: new Date('2026-02-02T12:00:00Z'),
+      isGroup: true,
+    }],
+    ...overrides,
+  };
+}
+
+/**
+ * Simulate the listening mode detection from processGroupBatch.
+ * Extracted logic from src/core/bot.ts lines 149-154.
+ */
+function applyListeningMode(
+  msg: InboundMessage,
+  listeningGroupIds: Set<string>,
+): InboundMessage {
+  const effective = (msg.batchedMessages?.length === 1 && msg.batchedMessages)
+    ? msg.batchedMessages[0]
+    : msg;
+
+  const isListening = listeningGroupIds.has(`${msg.channel}:${msg.chatId}`)
+    || (msg.serverId && listeningGroupIds.has(`${msg.channel}:${msg.serverId}`));
+  if (isListening && !msg.wasMentioned) {
+    effective.isListeningMode = true;
+  }
+
+  return effective;
+}
+
+describe('listening mode detection', () => {
+  describe('group matching', () => {
+    it('sets isListeningMode when chatId matches a listening group', () => {
+      const msg = createGroupMessage({ channel: 'discord', chatId: '123456' });
+      const listeningIds = new Set(['discord:123456']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBe(true);
+    });
+
+    it('sets isListeningMode when serverId matches a listening group', () => {
+      const msg = createGroupMessage({
+        channel: 'discord',
+        chatId: '123456',
+        serverId: 'server789',
+      });
+      const listeningIds = new Set(['discord:server789']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBe(true);
+    });
+
+    it('does not set isListeningMode when group is not in listening set', () => {
+      const msg = createGroupMessage({ channel: 'discord', chatId: '123456' });
+      const listeningIds = new Set(['discord:999999']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBeUndefined();
+    });
+
+    it('does not set isListeningMode for different channel with same chatId', () => {
+      const msg = createGroupMessage({ channel: 'telegram', chatId: '123456' });
+      const listeningIds = new Set(['discord:123456']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBeUndefined();
+    });
+  });
+
+  describe('mention override', () => {
+    it('does NOT set isListeningMode when bot is mentioned in a listening group', () => {
+      const msg = createGroupMessage({
+        channel: 'discord',
+        chatId: '123456',
+        wasMentioned: true,
+      });
+      const listeningIds = new Set(['discord:123456']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBeUndefined();
+    });
+
+    it('does NOT set isListeningMode when bot is mentioned via serverId match', () => {
+      const msg = createGroupMessage({
+        channel: 'discord',
+        chatId: '123456',
+        serverId: 'server789',
+        wasMentioned: true,
+      });
+      const listeningIds = new Set(['discord:server789']);
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBeUndefined();
+    });
+  });
+
+  describe('empty listening set', () => {
+    it('does not set isListeningMode when no listening groups configured', () => {
+      const msg = createGroupMessage();
+      const listeningIds = new Set<string>();
+      const result = applyListeningMode(msg, listeningIds);
+      expect(result.isListeningMode).toBeUndefined();
+    });
+  });
+
+  describe('single-message batch unwrapping', () => {
+    it('applies isListeningMode to the unwrapped single message', () => {
+      const inner: InboundMessage = {
+        channel: 'discord',
+        chatId: '123456',
+        userId: 'user1',
+        userName: 'Alice',
+        text: 'Hello',
+        timestamp: new Date(),
+        isGroup: true,
+      };
+      const batch = createGroupMessage({
+        batchedMessages: [inner],
+      });
+      const listeningIds = new Set(['discord:123456']);
+      const result = applyListeningMode(batch, listeningIds);
+      // Should return the unwrapped inner message with isListeningMode set
+      expect(result).toBe(inner);
+      expect(result.isListeningMode).toBe(true);
+    });
+
+    it('applies isListeningMode to batch wrapper for multi-message batches', () => {
+      const msgs: InboundMessage[] = [
+        { channel: 'discord', chatId: '123456', userId: 'u1', text: 'a', timestamp: new Date(), isGroup: true },
+        { channel: 'discord', chatId: '123456', userId: 'u2', text: 'b', timestamp: new Date(), isGroup: true },
+      ];
+      const batch = createGroupMessage({ batchedMessages: msgs });
+      const listeningIds = new Set(['discord:123456']);
+      const result = applyListeningMode(batch, listeningIds);
+      // Multi-message batch returns the wrapper
+      expect(result).toBe(batch);
+      expect(result.isListeningMode).toBe(true);
+    });
+  });
+});

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -83,6 +83,7 @@ export interface InboundMessage {
   reaction?: InboundReaction;
   isBatch?: boolean;                  // Is this a batched group message?
   batchedMessages?: InboundMessage[]; // Original individual messages (for batch formatting)
+  isListeningMode?: boolean;          // Listening mode: agent processes for memory but response is suppressed
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `listeningGroups` config option (per-channel, same pattern as `instantGroups`) where the bot periodically reads group messages and sends them to the Letta agent for memory updates, but **force-suppresses response delivery** unless the bot is explicitly @mentioned
- A group can be in both `instantGroups` and `listeningGroups` — instant processing + observe-only unless mentioned
- Listening mode skips typing indicators, heartbeat target updates, and error messages to remain invisible

## Changes

- `src/core/types.ts`: Add `isListeningMode` to `InboundMessage`
- `src/config/types.ts`: Add `listeningGroups?: string[]` to all 5 channel configs
- `src/config/io.ts`: Map `listeningGroups` to env vars, rename `fixInstantGroupIds` → `fixLargeGroupIds` to also fix `listeningGroups` entries
- `src/main.ts`: Parse `listeningGroups` env vars, build `listeningGroupIds` set, pass to bot
- `src/core/bot.ts`: Tag messages as listening mode in `processGroupBatch()`, force-suppress responses in `processMessage()`
- `src/core/formatter.ts`: Append `[OBSERVATION ONLY]` header to batch envelope when in listening mode
- `lettabot.example.yaml`: Document `listeningGroups` config

## Config Example

```yaml
channels:
  discord:
    enabled: true
    token: ...
    groupPollIntervalMin: 5
    listeningGroups:
      - "1468436705911640087"   # bot observes, replies only when @mentioned
```