### PR TITLE
Make ChannelAdapter addReaction optional

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -26,6 +26,7 @@ export interface ChannelAdapter {
   // Capabilities (optional)
   supportsEditing?(): boolean;
   sendFile?(file: OutboundFile): Promise<{ messageId: string }>;
+  addReaction?(chatId: string, messageId: string, emoji: string): Promise<void>;
   getDmPolicy?(): string;
   
   // Event handlers (set by bot core)


### PR DESCRIPTION
## Summary\n- Formalize addReaction as an optional ChannelAdapter capability.\n\n## Context\nExtracted from #40 per review guidance.