### PR TITLE
Support multiple Gmail accounts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,15 +199,18 @@ polling:
   intervalMs: 60000            # Check every 60 seconds (default: 60000)
   gmail:
     enabled: true
-    account: user@example.com  # Gmail account to poll
+    accounts:                  # Gmail accounts to poll
+      - user@example.com
+      - other@example.com
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `polling.enabled` | boolean | auto | Master switch. Defaults to `true` if any sub-config is enabled |
 | `polling.intervalMs` | number | `60000` | Polling interval in milliseconds |
-| `polling.gmail.enabled` | boolean | auto | Enable Gmail polling. Auto-detected from `account` |
+| `polling.gmail.enabled` | boolean | auto | Enable Gmail polling. Auto-detected from `account` or `accounts` |
 | `polling.gmail.account` | string | - | Gmail account to poll for unread messages |
+| `polling.gmail.accounts` | string[] | - | Gmail accounts to poll for unread messages |
 
 ### Legacy config path
 
@@ -217,7 +220,9 @@ For backward compatibility, Gmail polling can also be configured under `integrat
 integrations:
   google:
     enabled: true
-    account: user@example.com
+    accounts:
+      - account: user@example.com
+        services: [gmail, calendar]
     pollIntervalSec: 60
 ```
 
@@ -227,7 +232,7 @@ The top-level `polling` section takes priority if both are present.
 
 | Env Variable | Polling Config Equivalent |
 |--------------|--------------------------|
-| `GMAIL_ACCOUNT` | `polling.gmail.account` |
+| `GMAIL_ACCOUNT` | `polling.gmail.account` (comma-separated list allowed) |
 | `POLLING_INTERVAL_MS` | `polling.intervalMs` |
 
 ## Transcription Configuration
@@ -272,7 +277,7 @@ Environment variables override config file values:
 | `WHATSAPP_SELF_CHAT_MODE` | `channels.whatsapp.selfChat` |
 | `SIGNAL_PHONE_NUMBER` | `channels.signal.phone` |
 | `OPENAI_API_KEY` | `transcription.apiKey` |
-| `GMAIL_ACCOUNT` | `polling.gmail.account` |
+| `GMAIL_ACCOUNT` | `polling.gmail.account` (comma-separated list allowed) |
 | `POLLING_INTERVAL_MS` | `polling.intervalMs` |
 
 See [SKILL.md](../SKILL.md) for complete environment variable reference.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -208,16 +208,28 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   }
   
   // Polling - top-level polling config (preferred)
-  if (config.polling?.gmail?.enabled && config.polling.gmail.account) {
-    env.GMAIL_ACCOUNT = config.polling.gmail.account;
+  if (config.polling?.gmail?.enabled) {
+    const accounts = config.polling.gmail.accounts !== undefined
+      ? config.polling.gmail.accounts
+      : (config.polling.gmail.account ? [config.polling.gmail.account] : []);
+    if (accounts.length > 0) {
+      env.GMAIL_ACCOUNT = accounts.join(',');
+    }
   }
   if (config.polling?.intervalMs) {
     env.POLLING_INTERVAL_MS = String(config.polling.intervalMs);
   }
 
   // Integrations - Google (legacy path for Gmail polling, lower priority)
-  if (!env.GMAIL_ACCOUNT && config.integrations?.google?.enabled && config.integrations.google.account) {
-    env.GMAIL_ACCOUNT = config.integrations.google.account;
+  if (!env.GMAIL_ACCOUNT && config.integrations?.google?.enabled) {
+    const legacyAccounts = config.integrations.google.accounts
+      ? config.integrations.google.accounts
+          .filter(a => !a.services || a.services.length === 0 || a.services.includes('gmail'))
+          .map(a => a.account)
+      : (config.integrations.google.account ? [config.integrations.google.account] : []);
+    if (legacyAccounts.length > 0) {
+      env.GMAIL_ACCOUNT = legacyAccounts.join(',');
+    }
   }
   if (!env.POLLING_INTERVAL_MS && config.integrations?.google?.pollIntervalSec) {
     env.POLLING_INTERVAL_MS = String(config.integrations.google.pollIntervalSec * 1000);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -85,6 +85,7 @@ export interface PollingYamlConfig {
   gmail?: {
     enabled?: boolean;    // Enable Gmail polling
     account?: string;     // Gmail account to poll (e.g., user@example.com)
+    accounts?: string[];  // Multiple Gmail accounts to poll
   };
 }
 
@@ -149,9 +150,15 @@ export interface DiscordConfig {
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching
 }
 
+export interface GoogleAccountConfig {
+  account: string;
+  services?: string[];  // e.g., ['gmail', 'calendar', 'drive', 'contacts', 'docs', 'sheets']
+}
+
 export interface GoogleConfig {
   enabled: boolean;
   account?: string;
+  accounts?: GoogleAccountConfig[];
   services?: string[];  // e.g., ['gmail', 'calendar', 'drive', 'contacts', 'docs', 'sheets']
   pollIntervalSec?: number;  // Polling interval in seconds (default: 60)
 }

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -155,7 +155,7 @@ interface OnboardConfig {
   discord: { enabled: boolean; token?: string; dmPolicy?: 'pairing' | 'allowlist' | 'open'; allowedUsers?: string[] };
   
   // Google Workspace (via gog CLI)
-  google: { enabled: boolean; account?: string; services?: string[] };
+  google: { enabled: boolean; accounts: Array<{ account: string; services: string[] }> };
   
   // Features
   heartbeat: { enabled: boolean; interval?: string };
@@ -752,6 +752,7 @@ async function stepGoogle(config: OnboardConfig): Promise<void> {
   
   if (!setupGoogle) {
     config.google.enabled = false;
+    config.google.accounts = [];
     return;
   }
   
@@ -786,16 +787,19 @@ async function stepGoogle(config: OnboardConfig): Promise<void> {
           spinner.stop('Failed to install gog');
           p.log.error('Installation failed. Try manually: brew install steipete/tap/gogcli');
           config.google.enabled = false;
+          config.google.accounts = [];
           return;
         }
       } else {
         p.log.info('Install gog manually: brew install steipete/tap/gogcli');
         config.google.enabled = false;
+        config.google.accounts = [];
         return;
       }
     } else {
       p.log.info('Install gog manually from: https://gogcli.sh');
       config.google.enabled = false;
+      config.google.accounts = [];
       return;
     }
   }
@@ -837,6 +841,7 @@ async function stepGoogle(config: OnboardConfig): Promise<void> {
       if (!hasCredentials) {
         p.log.info('Run `gog auth credentials /path/to/client_secret.json` after downloading credentials.');
         config.google.enabled = false;
+        config.google.accounts = [];
         return;
       }
     }
@@ -861,60 +866,119 @@ async function stepGoogle(config: OnboardConfig): Promise<void> {
       }
     }
   }
+
+  const configuredAccounts = new Map<string, string[]>();
+  for (const entry of config.google.accounts) {
+    configuredAccounts.set(entry.account, entry.services || []);
+  }
   
-  let selectedAccount: string | undefined;
-  
-  if (accounts.length > 0) {
-    const accountChoice = await p.select({
-      message: 'Google account',
+  const newAccounts: Array<{ account: string; services: string[] }> = [];
+  let selectedAccounts: string[] = [];
+
+  if (accounts.length === 0) {
+    const firstAccount = await addGoogleAccount();
+    if (!firstAccount) {
+      config.google.enabled = false;
+      config.google.accounts = [];
+      return;
+    }
+    newAccounts.push(firstAccount);
+    let addMore = true;
+    while (addMore) {
+      const more = await p.confirm({
+        message: 'Add another Google account?',
+        initialValue: false,
+      });
+      if (p.isCancel(more)) { p.cancel('Setup cancelled'); process.exit(0); }
+      if (!more) break;
+      const added = await addGoogleAccount();
+      if (added) {
+        newAccounts.push(added);
+      } else {
+        break;
+      }
+    }
+  } else {
+    const accountChoices = await p.multiselect({
+      message: 'Google accounts to enable',
       options: [
         ...accounts.map(a => ({ value: a, label: a, hint: 'Existing account' })),
         { value: '__new__', label: 'Add new account', hint: 'Authorize another account' },
       ],
-      initialValue: config.google.account || accounts[0],
+      initialValues: config.google.accounts.map(a => a.account).filter(a => accounts.includes(a)),
+      required: true,
     });
-    if (p.isCancel(accountChoice)) { p.cancel('Setup cancelled'); process.exit(0); }
-    
-    if (accountChoice === '__new__') {
-      selectedAccount = await addGoogleAccount();
-    } else {
-      selectedAccount = accountChoice as string;
+    if (p.isCancel(accountChoices)) { p.cancel('Setup cancelled'); process.exit(0); }
+
+    selectedAccounts = (accountChoices as string[]).filter(a => a !== '__new__');
+    if ((accountChoices as string[]).includes('__new__')) {
+      let addMore = true;
+      while (addMore) {
+        const added = await addGoogleAccount();
+        if (added) {
+          newAccounts.push(added);
+        } else {
+          addMore = false;
+          break;
+        }
+        const more = await p.confirm({
+          message: 'Add another Google account?',
+          initialValue: false,
+        });
+        if (p.isCancel(more)) { p.cancel('Setup cancelled'); process.exit(0); }
+        addMore = !!more;
+      }
     }
-  } else {
-    selectedAccount = await addGoogleAccount();
   }
-  
-  if (!selectedAccount) {
+
+  const allAccounts = Array.from(new Set([
+    ...selectedAccounts,
+    ...newAccounts.map(a => a.account),
+  ]));
+
+  if (allAccounts.length === 0) {
     config.google.enabled = false;
+    config.google.accounts = [];
     return;
   }
-  
-  // Select services
-  const selectedServices = await p.multiselect({
-    message: 'Which Google services do you want to enable?',
-    options: GOG_SERVICES.map(s => ({
-      value: s,
-      label: s.charAt(0).toUpperCase() + s.slice(1),
-      hint: s === 'gmail' ? 'Read/send emails' : 
-            s === 'calendar' ? 'View/create events' :
-            s === 'drive' ? 'Access files' :
-            s === 'contacts' ? 'Look up contacts' :
-            s === 'docs' ? 'Read documents' :
-            'Read/edit spreadsheets',
-    })),
-    initialValues: config.google.services || ['gmail', 'calendar'],
-    required: true,
-  });
-  if (p.isCancel(selectedServices)) { p.cancel('Setup cancelled'); process.exit(0); }
-  
+
+  const newAccountsByEmail = new Map<string, string[]>();
+  for (const entry of newAccounts) {
+    newAccountsByEmail.set(entry.account, entry.services);
+  }
+
+  const finalizedAccounts: Array<{ account: string; services: string[] }> = [];
+  for (const account of allAccounts) {
+    const presetServices = newAccountsByEmail.get(account) || configuredAccounts.get(account) || ['gmail', 'calendar'];
+    const selectedServices = newAccountsByEmail.has(account) ? presetServices : await p.multiselect({
+      message: `Services to enable for ${account}`,
+      options: GOG_SERVICES.map(s => ({
+        value: s,
+        label: s.charAt(0).toUpperCase() + s.slice(1),
+        hint: s === 'gmail' ? 'Read/send emails' : 
+              s === 'calendar' ? 'View/create events' :
+              s === 'drive' ? 'Access files' :
+              s === 'contacts' ? 'Look up contacts' :
+              s === 'docs' ? 'Read documents' :
+              'Read/edit spreadsheets',
+      })),
+      initialValues: presetServices,
+      required: true,
+    });
+    if (p.isCancel(selectedServices)) { p.cancel('Setup cancelled'); process.exit(0); }
+    finalizedAccounts.push({
+      account,
+      services: selectedServices as string[],
+    });
+  }
+
   config.google.enabled = true;
-  config.google.account = selectedAccount;
-  config.google.services = selectedServices as string[];
+  config.google.accounts = finalizedAccounts;
   
-  p.log.success(`Google Workspace configured: ${selectedAccount}`);
+  p.log.success(`Google Workspace configured: ${finalizedAccounts.length} account(s)`);
 }
 
-async function addGoogleAccount(): Promise<string | undefined> {
+async function addGoogleAccount(): Promise<{ account: string; services: string[] } | undefined> {
   const email = await p.text({
     message: 'Google account email',
     placeholder: 'you@gmail.com',
@@ -952,7 +1016,10 @@ async function addGoogleAccount(): Promise<string | undefined> {
   
   if (result.status === 0) {
     spinner.stop('Account authorized');
-    return email;
+    return {
+      account: email,
+      services: services as string[],
+    };
   } else {
     spinner.stop('Authorization failed');
     p.log.error('Failed to authorize account. Try manually: gog auth add ' + email);
@@ -1009,8 +1076,11 @@ function showSummary(config: OnboardConfig): void {
   lines.push(`Voice:     ${config.transcription.enabled ? 'Enabled (OpenAI Whisper)' : 'Disabled'}`);
 
   // Google
-  if (config.google.enabled) {
-    lines.push(`Google:    ${config.google.account} (${config.google.services?.join(', ') || 'all'})`);
+  if (config.google.enabled && config.google.accounts.length > 0) {
+    const googleAccounts = config.google.accounts.map(a => (
+      `${a.account} (${a.services?.join(', ') || 'all'})`
+    ));
+    lines.push(`Google:    ${googleAccounts.join(', ')}`);
   }
 
   p.note(lines.join('\n'), 'Configuration');
@@ -1258,11 +1328,21 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
       selfChat: existingConfig.channels.signal?.selfChat ?? true, // Default true
       dmPolicy: existingConfig.channels.signal?.dmPolicy,
     },
-    google: {
-      enabled: existingConfig.integrations?.google?.enabled || false,
-      account: existingConfig.integrations?.google?.account,
-      services: existingConfig.integrations?.google?.services,
-    },
+    google: (() => {
+      const existingAccounts = existingConfig.integrations?.google?.accounts
+        ? existingConfig.integrations.google.accounts.map(a => ({
+            account: a.account,
+            services: a.services || [],
+          }))
+        : (existingConfig.integrations?.google?.account ? [{
+            account: existingConfig.integrations.google.account,
+            services: existingConfig.integrations.google.services || [],
+          }] : []);
+      return {
+        enabled: (existingConfig.integrations?.google?.enabled || false) || existingAccounts.length > 0,
+        accounts: existingAccounts,
+      };
+    })(),
     heartbeat: { 
       enabled: existingConfig.features?.heartbeat?.enabled || false,
       interval: existingConfig.features?.heartbeat?.intervalMin?.toString(),
@@ -1409,6 +1489,10 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
     if (policy === 'open') return '⚠️ open';
     return 'pairing';
   };
+
+  const googleSummary = config.google.enabled && config.google.accounts.length > 0
+    ? config.google.accounts.map(a => `${a.account} - ${a.services?.join(', ') || 'all'}`).join(', ')
+    : '';
   
   // Show summary
   const summary = [
@@ -1423,7 +1507,7 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
     config.signal.enabled ? `  ✓ Signal (${formatAccess(config.signal.dmPolicy, config.signal.allowedUsers)})` : '  ✗ Signal',
     '',
     'Integrations:',
-    config.google.enabled ? `  ✓ Google (${config.google.account} - ${config.google.services?.join(', ') || 'all'})` : '  ✗ Google Workspace',
+    config.google.enabled ? `  ✓ Google (${googleSummary})` : '  ✗ Google Workspace',
     '',
     'Features:',
     config.heartbeat.enabled ? `  ✓ Heartbeat (${config.heartbeat.interval}min)` : '  ✗ Heartbeat',
@@ -1434,6 +1518,10 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
   p.note(summary, 'Configuration Summary');
   
   // Convert to YAML config
+  const gmailAccounts = config.google.enabled
+    ? config.google.accounts.filter(a => a.services?.includes('gmail')).map(a => a.account)
+    : [];
+
   const yamlConfig: LettaBotConfig = {
     server: {
       mode: config.authMethod === 'selfhosted' ? 'selfhosted' : 'cloud',
@@ -1506,8 +1594,14 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
       integrations: {
         google: {
           enabled: true,
-          account: config.google.account,
-          services: config.google.services,
+          accounts: config.google.accounts,
+        },
+      },
+    } : {}),
+    ...(gmailAccounts.length > 0 ? {
+      polling: {
+        gmail: {
+          accounts: gmailAccounts,
         },
       },
     } : {}),


### PR DESCRIPTION
## Summary
- add multi-account Gmail polling with per-account seen tracking
- update onboarding to configure multiple Google accounts and per-account services
- allow comma-separated GMAIL_ACCOUNT; update docs/examples

## Testing
- not run (user tested manually)
