### PR TITLE
fix: multi-agent state isolation and config.id wiring

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -101,7 +101,7 @@ export class LettaBot implements AgentSession {
     mkdirSync(config.workingDir, { recursive: true });
     
     // Store in project root (same as main.ts reads for LETTA_AGENT_ID)
-    this.store = new Store('lettabot-agent.json');
+    this.store = new Store('lettabot-agent.json', config.agentName);
     
     console.log(`LettaBot initialized. Agent ID: ${this.store.agentId || '(new)'}`);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -481,8 +481,15 @@ async function main() {
       },
     });
     
-    // Verify agent exists (clear stale ID if deleted)
+    // Apply explicit agent ID from config (before store verification)
     let initialStatus = bot.getStatus();
+    if (agentConfig.id && !initialStatus.agentId) {
+      console.log(`[Agent:${agentConfig.name}] Using configured agent ID: ${agentConfig.id}`);
+      bot.setAgentId(agentConfig.id);
+      initialStatus = bot.getStatus();
+    }
+    
+    // Verify agent exists (clear stale ID if deleted)
     if (initialStatus.agentId) {
       const exists = await agentExists(initialStatus.agentId);
       if (!exists) {


### PR DESCRIPTION
## Summary

Two bugs from the Phase 1 multi-agent merge (#215, #216, #217):

**Bug 1 -- Store not scoped to agent name:**
`LettaBot` constructor called `new Store('lettabot-agent.json')` without passing the agent name. In multi-agent mode, all bots shared the same persisted agentId/conversationId state, defeating the entire purpose of Store v2's per-agent namespacing.

Fix: `new Store('lettabot-agent.json', config.agentName)` -- one line.

**Bug 2 -- `agentConfig.id` ignored:**
Users could set `id: agent-abc123` in their YAML config but it was never applied during startup. The agent discovery flow went store -> container name lookup -> lazy create, skipping the explicit config entirely.

Fix: Check `agentConfig.id` before store verification. If the store is empty and config has an explicit ID, use it.

### Not in this PR (filed separately)

- API routing ambiguity with multiple agents on same channel type
- WhatsApp/Signal shared paths need agent-scoping
- Heartbeat prompt/target not per-agent

## Test plan

- [x] `npm run build` passes
- [x] 382 tests pass
- [x] Existing store isolation tests verify per-agent namespacing works when name is passed