### PR TITLE
fix: false "no response" error after short streaming replies

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -544,7 +544,8 @@ export class LettaBot implements AgentSession {
             const preview = response.length > 50 ? response.slice(0, 50) + '...' : response;
             console.log(`[Bot] Sent: "${preview}"`);
           } catch {
-            // Ignore send errors
+            // Edit failures (e.g. "message not modified") are OK if we already sent the message
+            if (messageId) sentAnyMessage = true;
           }
         }
         // Reset for next message bubble
@@ -630,9 +631,10 @@ export class LettaBot implements AgentSession {
                 } else {
                   const result = await adapter.sendMessage({ chatId: msg.chatId, text: response, threadId: msg.threadId });
                   messageId = result.messageId;
+                  sentAnyMessage = true;
                 }
               } catch {
-                // Ignore edit errors
+                // Ignore edit errors (e.g. rate limits)
               }
               lastUpdate = Date.now();
             }


### PR DESCRIPTION
## Summary
- Short single-chunk responses (e.g. "Yep.") triggered a false "(No response)" error alongside the actual reply
- Root cause: streaming edit path sent the message to Telegram but never set `sentAnyMessage`, then `finalizeMessage()` tried editing to identical content, Telegram rejected it ("message not modified"), and the catch swallowed the error
- Fix: track sends from the streaming path + treat edit-not-modified as success when the message already exists

## Test plan
- [x] Send a short-answer prompt ("say ok") to bot via Telegram
- [x] Confirm response appears without the spurious "(No response)" error

Written by Cameron ◯ Letta Code

"The stream carried everything -- we just forgot to look." - on debugging