### PR TITLE
fix: restore env var channel config for container deploys

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -256,6 +256,45 @@ export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
   // Filter out disabled/misconfigured channels
   const channels = normalizeChannels(config.channels);
 
+  // Env var fallback for container deploys without lettabot.yaml (e.g. Railway)
+  if (!channels.telegram && process.env.TELEGRAM_BOT_TOKEN) {
+    channels.telegram = {
+      enabled: true,
+      token: process.env.TELEGRAM_BOT_TOKEN,
+      dmPolicy: (process.env.TELEGRAM_DM_POLICY as 'pairing' | 'allowlist' | 'open') || 'pairing',
+    };
+  }
+  if (!channels.slack && process.env.SLACK_BOT_TOKEN && process.env.SLACK_APP_TOKEN) {
+    channels.slack = {
+      enabled: true,
+      botToken: process.env.SLACK_BOT_TOKEN,
+      appToken: process.env.SLACK_APP_TOKEN,
+      dmPolicy: (process.env.SLACK_DM_POLICY as 'pairing' | 'allowlist' | 'open') || 'pairing',
+    };
+  }
+  if (!channels.whatsapp && process.env.WHATSAPP_ENABLED === 'true') {
+    channels.whatsapp = {
+      enabled: true,
+      selfChat: process.env.WHATSAPP_SELF_CHAT_MODE !== 'false',
+      dmPolicy: (process.env.WHATSAPP_DM_POLICY as 'pairing' | 'allowlist' | 'open') || 'pairing',
+    };
+  }
+  if (!channels.signal && process.env.SIGNAL_PHONE_NUMBER) {
+    channels.signal = {
+      enabled: true,
+      phone: process.env.SIGNAL_PHONE_NUMBER,
+      selfChat: process.env.SIGNAL_SELF_CHAT_MODE !== 'false',
+      dmPolicy: (process.env.SIGNAL_DM_POLICY as 'pairing' | 'allowlist' | 'open') || 'pairing',
+    };
+  }
+  if (!channels.discord && process.env.DISCORD_BOT_TOKEN) {
+    channels.discord = {
+      enabled: true,
+      token: process.env.DISCORD_BOT_TOKEN,
+      dmPolicy: (process.env.DISCORD_DM_POLICY as 'pairing' | 'allowlist' | 'open') || 'pairing',
+    };
+  }
+
   return [{
     name: agentName,
     id,


### PR DESCRIPTION
## Summary

Regression from #217 (multi-agent main.ts wiring). Railway deploy crashes with:

```
Error: No channels configured in any agent.
```

**Root cause:** `normalizeAgents()` reads channels from the YAML config object. On Railway/Docker, there's no `lettabot.yaml` -- channels are configured via environment variables (`TELEGRAM_BOT_TOKEN`, etc.). The old code read env vars directly; the new code only reads the YAML object.

**Fix:** In the legacy single-agent path of `normalizeAgents()`, fall back to `process.env` for any channel not already configured via YAML. YAML always takes priority. Multi-agent mode (`agents:` array) still requires YAML -- env vars can't express per-agent config.

### 4 new tests

- Picks up channels from env vars when YAML has none
- Does NOT override YAML channels with env vars
- Does NOT apply env vars in multi-agent mode
- Picks up all 5 channel types from env vars

## Test plan

- [x] `npm run build` passes
- [x] 390 tests pass (8 new)
- [x] Existing tests unaffected (env vars cleaned up in beforeEach/afterEach)