### PR TITLE
feat: prepare package for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,9 @@ jobs:
           echo "## Install" >> notes.md
           echo "" >> notes.md
           echo '```bash' >> notes.md
-          echo "git clone https://github.com/letta-ai/lettabot.git" >> notes.md
-          echo "cd lettabot" >> notes.md
-          echo "git checkout ${CURRENT_TAG}" >> notes.md
-          echo "npm install && npm run build && npm link" >> notes.md
+          echo "npx lettabot onboard" >> notes.md
+          echo "# or" >> notes.md
+          echo "npm install -g lettabot" >> notes.md
           echo '```' >> notes.md
 
           # Add full changelog link
@@ -103,5 +102,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: Ping letta-code agent to write a richer summary once
-      # letta-code-action supports release events / custom prompts
+      - name: Publish to npm
+        if: env.NPM_TOKEN != ''
+        run: |
+          CURRENT_TAG=${GITHUB_REF#refs/tags/}
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
+          # Set version from git tag (strip 'v' prefix)
+          VERSION=${CURRENT_TAG#v}
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+          # Determine npm tag (pre-releases get 'next', stable gets 'latest')
+          if echo "$CURRENT_TAG" | grep -qE '(alpha|beta|rc)'; then
+            npm publish --tag next --access public
+          else
+            npm publish --access public
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lettabot",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/main.js",
   "bin": {
@@ -14,7 +14,8 @@
     "setup": "tsx src/setup.ts",
     "dev": "tsx src/main.ts",
     "build": "tsc",
-    "postinstall": "npx patch-package",
+    "prepare": "npx patch-package || true",
+    "prepublishOnly": "npm run build && npm run test:run",
     "start": "node dist/main.js",
     "test": "vitest",
     "test:run": "vitest run",
@@ -31,15 +32,33 @@
     "skills:find": "npx skills find"
   },
   "keywords": [
-    "telegram",
-    "bot",
     "letta",
     "ai",
-    "agent"
+    "agent",
+    "chatbot",
+    "telegram",
+    "slack",
+    "whatsapp",
+    "signal",
+    "discord",
+    "multi-agent"
   ],
-  "author": "",
+  "author": "Letta <team@letta.com>",
   "license": "Apache-2.0",
-  "description": "Multi-channel AI assistant with persistent memory - Telegram, Slack, WhatsApp",
+  "description": "Multi-channel AI assistant with persistent memory - Telegram, Slack, WhatsApp, Signal, Discord",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/letta-ai/lettabot.git"
+  },
+  "homepage": "https://github.com/letta-ai/lettabot",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist/",
+    ".skills/",
+    "patches/"
+  ],
   "dependencies": {
     "@clack/prompts": "^0.11.0",
     "@hapi/boom": "^10.0.1",


### PR DESCRIPTION
## Summary

Prepares lettabot for npm publishing. After this merges, adding `NPM_TOKEN` to repo secrets enables automated publishing on every release tag.

### package.json changes

- **Version**: `1.0.0` -> `0.2.0` (too early for stable semver)
- **`files`**: Only ship `dist/`, `.skills/`, `patches/` (925 KB, down from 1.8 MB)
- **`engines`**: `node >= 20`
- **`repository`**, **`homepage`**, **`author`**: Standard npm metadata
- **`prepublishOnly`**: `npm run build && npm run test:run` (gate)
- **`prepare`**: `npx patch-package || true` (moved from `postinstall` so end users don't run it)

### Release workflow changes

- Adds npm publish step (only runs if `NPM_TOKEN` secret is set)
- Pre-releases (`alpha`/`beta`/`rc`) publish with `--tag next`
- Stable releases publish with `--tag latest`
- Release notes updated with `npx lettabot onboard` install instructions

### To activate

Add `NPM_TOKEN` secret to the repo (requires npm org access for `lettabot` or `@letta-ai/lettabot`).

Closes #174

## Test plan

- [x] `npm run build` passes
- [x] 392 tests pass
- [x] `npm pack --dry-run` shows 172 files / 925 KB (no source/tests)
- [x] Release workflow is backwards-compatible (npm step skipped without NPM_TOKEN)