### PR TITLE
fix: Telegram messages truncated when MarkdownV2 edit fails

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -501,8 +501,14 @@ export class TelegramAdapter implements ChannelAdapter {
   
   async editMessage(chatId: string, messageId: string, text: string): Promise<void> {
     const { markdownToTelegramV2 } = await import('./telegram-format.js');
-    const formatted = await markdownToTelegramV2(text);
-    await this.bot.api.editMessageText(chatId, Number(messageId), formatted, { parse_mode: 'MarkdownV2' });
+    try {
+      const formatted = await markdownToTelegramV2(text);
+      await this.bot.api.editMessageText(chatId, Number(messageId), formatted, { parse_mode: 'MarkdownV2' });
+    } catch (e) {
+      // If MarkdownV2 fails, fall back to plain text (mirrors sendMessage fallback)
+      console.warn('[Telegram] MarkdownV2 edit failed, falling back to raw text:', e);
+      await this.bot.api.editMessageText(chatId, Number(messageId), text);
+    }
   }
 
   async addReaction(chatId: string, messageId: string, emoji: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **`editMessage()` now has MarkdownV2 fallback** -- `sendMessage()` already had try/catch with plain-text fallback, but `editMessage()` was bare. When the agent generates markdown tables or complex formatting that fails MarkdownV2 conversion, the edit now retries with raw text instead of throwing.
- **Final send retries on edit failure** -- Previously, if the final `editMessage()` threw, the catch block only retried when `messageId` was unset (i.e., only for `sendMessage` failures). Now it always falls back to sending a new message with the complete response, so the user isn't left with a truncated streaming edit.
- **Streaming edit errors are logged** -- The silent `catch {}` in the streaming edit loop now logs warnings, making Railway log debugging possible when mid-stream edits fail.

## Context

Observed on Railway: agent generated a response with a markdown table. Streaming edits worked for the initial simple text, but once the table syntax entered the response, MarkdownV2 conversion failed. All subsequent edits failed silently, and the final edit also threw -- but the retry logic was guarded by `!messageId`, so no fallback fired. User saw a truncated message ending at `| Topic`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 420 unit tests pass
- [ ] Deploy to Railway, have agent generate a markdown table response, verify full message delivered

Written by Cameron ◯ Letta Code

"If you want to go fast, go alone. If you want to go far, go together." - African Proverb