### PR TITLE
fix: exclude e2e tests from unit test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm run build && npm run test:run",
     "start": "node dist/main.js",
     "test": "vitest",
-    "test:run": "vitest run",
+    "test:run": "vitest run --exclude 'e2e/**'",
     "test:e2e": "vitest run e2e/",
     "skills": "tsx src/cli.ts skills",
     "skills:list": "tsx src/cli.ts skills list",


### PR DESCRIPTION
## Summary

Unit test job was discovering `e2e/*.e2e.test.ts` files and reporting them as "6 skipped" in PR checks, since `LETTA_API_KEY` isn't available in that job. This was cosmetic noise but made it look like something was broken.

One-line fix: add `--exclude 'e2e/**'` to `test:run` script. E2E tests continue to run separately via `test:e2e` in the dedicated CI job with secrets.

**Before:** 434 passed | 6 skipped
**After:** 434 passed | 0 skipped

## Test plan

- [x] `npm run test:run` shows 0 skipped
- [x] `npm run test:e2e` still discovers e2e tests (skips locally, runs in CI)