### PR TITLE
fix: clear WhatsApp typing indicator after response

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -22,6 +22,7 @@ export interface ChannelAdapter {
   sendMessage(msg: OutboundMessage): Promise<{ messageId: string }>;
   editMessage(chatId: string, messageId: string, text: string): Promise<void>;
   sendTypingIndicator(chatId: string): Promise<void>;
+  stopTypingIndicator?(chatId: string): Promise<void>;
 
   // Capabilities (optional)
   supportsEditing?(): boolean;

--- a/src/channels/whatsapp/index.ts
+++ b/src/channels/whatsapp/index.ts
@@ -47,6 +47,7 @@ import {
   sendWhatsAppMessage,
   sendWhatsAppFile,
   sendTypingIndicator,
+  stopTypingIndicator,
   sendReadReceipt,
   type LidMapper,
 } from "./outbound.js";
@@ -1016,6 +1017,11 @@ export class WhatsAppAdapter implements ChannelAdapter {
   async sendTypingIndicator(chatId: string): Promise<void> {
     if (!this.sock) return;
     await sendTypingIndicator(this.sock, chatId);
+  }
+
+  async stopTypingIndicator(chatId: string): Promise<void> {
+    if (!this.sock) return;
+    await stopTypingIndicator(this.sock, chatId);
   }
 }
 

--- a/src/channels/whatsapp/outbound.ts
+++ b/src/channels/whatsapp/outbound.ts
@@ -169,6 +169,24 @@ export async function sendTypingIndicator(
 }
 
 /**
+ * Stop typing indicator for a chat.
+ * Sends "paused" presence to immediately clear the "typing..." indicator
+ * instead of waiting for WhatsApp's built-in timeout (~15-25s).
+ */
+export async function stopTypingIndicator(
+  sock: import("@whiskeysockets/baileys").WASocket,
+  chatId: string
+): Promise<void> {
+  if (!sock) return;
+
+  try {
+    await sock.sendPresenceUpdate("paused", chatId);
+  } catch {
+    // Ignore presence errors
+  }
+}
+
+/**
  * Send read receipt for a message.
  *
  * @param sock - Baileys socket instance

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -725,6 +725,7 @@ export class LettaBot implements AgentSession {
         }
       } finally {
         clearInterval(typingInterval);
+        adapter.stopTypingIndicator?.(msg.chatId)?.catch(() => {});
       }
       
       // Handle no-reply marker


### PR DESCRIPTION
## Summary

- Adds `stopTypingIndicator?()` to the `ChannelAdapter` interface (optional)
- WhatsApp adapter implements it by sending a `"paused"` presence update via Baileys
- `bot.ts` calls it in the `finally` block after stream processing completes

## Problem

WhatsApp's "typing..." indicator lingered for 15-25 seconds after the bot finished responding. Other platforms (Telegram, Slack) auto-clear their typing indicator on message send, but WhatsApp requires an explicit presence update to dismiss it.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 453 unit tests pass
- [ ] Verify on WhatsApp: typing indicator clears immediately after response

Written by Cameron ◯ Letta Code

"First, solve the problem. Then, write the code." - John Johnson