### PR TITLE
feat: support multiple Gmail accounts for polling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -387,15 +387,18 @@ polling:
   intervalMs: 60000            # Check every 60 seconds (default: 60000)
   gmail:
     enabled: true
-    account: user@example.com  # Gmail account to poll
+    accounts:                  # Gmail accounts to poll
+      - user@example.com
+      - other@example.com
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `polling.enabled` | boolean | auto | Master switch. Defaults to `true` if any sub-config is enabled |
 | `polling.intervalMs` | number | `60000` | Polling interval in milliseconds |
-| `polling.gmail.enabled` | boolean | auto | Enable Gmail polling. Auto-detected from `account` |
+| `polling.gmail.enabled` | boolean | auto | Enable Gmail polling. Auto-detected from `account` or `accounts` |
 | `polling.gmail.account` | string | - | Gmail account to poll for unread messages |
+| `polling.gmail.accounts` | string[] | - | Gmail accounts to poll for unread messages |
 
 ### Legacy config path
 
@@ -405,7 +408,9 @@ For backward compatibility, Gmail polling can also be configured under `integrat
 integrations:
   google:
     enabled: true
-    account: user@example.com
+    accounts:
+      - account: user@example.com
+        services: [gmail, calendar]
     pollIntervalSec: 60
 ```
 
@@ -415,7 +420,7 @@ The top-level `polling` section takes priority if both are present.
 
 | Env Variable | Polling Config Equivalent |
 |--------------|--------------------------|
-| `GMAIL_ACCOUNT` | `polling.gmail.account` |
+| `GMAIL_ACCOUNT` | `polling.gmail.account` (comma-separated list allowed) |
 | `POLLING_INTERVAL_MS` | `polling.intervalMs` |
 | `PORT` | `api.port` |
 | `API_HOST` | `api.host` |
@@ -479,7 +484,7 @@ Environment variables override config file values:
 | `WHATSAPP_SELF_CHAT_MODE` | `channels.whatsapp.selfChat` |
 | `SIGNAL_PHONE_NUMBER` | `channels.signal.phone` |
 | `OPENAI_API_KEY` | `transcription.apiKey` |
-| `GMAIL_ACCOUNT` | `polling.gmail.account` |
+| `GMAIL_ACCOUNT` | `polling.gmail.account` (comma-separated list allowed) |
 | `POLLING_INTERVAL_MS` | `polling.intervalMs` |
 
 See [SKILL.md](../SKILL.md) for complete environment variable reference.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -210,16 +210,26 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   }
 
   // Polling - top-level polling config (preferred)
-  if (config.polling?.gmail?.enabled && config.polling.gmail.account) {
-    env.GMAIL_ACCOUNT = config.polling.gmail.account;
+  if (config.polling?.gmail?.enabled) {
+    const accounts = config.polling.gmail.accounts !== undefined
+      ? config.polling.gmail.accounts
+      : (config.polling.gmail.account ? [config.polling.gmail.account] : []);
+    if (accounts.length > 0) {
+      env.GMAIL_ACCOUNT = accounts.join(',');
+    }
   }
   if (config.polling?.intervalMs) {
     env.POLLING_INTERVAL_MS = String(config.polling.intervalMs);
   }
 
   // Integrations - Google (legacy path for Gmail polling, lower priority)
-  if (!env.GMAIL_ACCOUNT && config.integrations?.google?.enabled && config.integrations.google.account) {
-    env.GMAIL_ACCOUNT = config.integrations.google.account;
+  if (!env.GMAIL_ACCOUNT && config.integrations?.google?.enabled) {
+    const legacyAccounts = config.integrations.google.accounts
+      ? config.integrations.google.accounts.map(a => a.account)
+      : (config.integrations.google.account ? [config.integrations.google.account] : []);
+    if (legacyAccounts.length > 0) {
+      env.GMAIL_ACCOUNT = legacyAccounts.join(',');
+    }
   }
   if (!env.POLLING_INTERVAL_MS && config.integrations?.google?.pollIntervalSec) {
     env.POLLING_INTERVAL_MS = String(config.integrations.google.pollIntervalSec * 1000);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -131,6 +131,7 @@ export interface PollingYamlConfig {
   gmail?: {
     enabled?: boolean;    // Enable Gmail polling
     account?: string;     // Gmail account to poll (e.g., user@example.com)
+    accounts?: string[];  // Multiple Gmail accounts to poll
   };
 }
 
@@ -200,9 +201,15 @@ export interface DiscordConfig {
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching
 }
 
+export interface GoogleAccountConfig {
+  account: string;
+  services?: string[];  // e.g., ['gmail', 'calendar', 'drive', 'contacts', 'docs', 'sheets']
+}
+
 export interface GoogleConfig {
   enabled: boolean;
   account?: string;
+  accounts?: GoogleAccountConfig[];
   services?: string[];  // e.g., ['gmail', 'calendar', 'drive', 'contacts', 'docs', 'sheets']
   pollIntervalSec?: number;  // Polling interval in seconds (default: 60)
 }

--- a/src/polling/service.test.ts
+++ b/src/polling/service.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { parseGmailAccounts } from './service.js';
+
+describe('parseGmailAccounts', () => {
+  it('returns empty array for undefined', () => {
+    expect(parseGmailAccounts(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseGmailAccounts('')).toEqual([]);
+  });
+
+  it('parses single account string', () => {
+    expect(parseGmailAccounts('user@gmail.com')).toEqual(['user@gmail.com']);
+  });
+
+  it('parses comma-separated string', () => {
+    expect(parseGmailAccounts('a@gmail.com,b@gmail.com')).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+
+  it('trims whitespace', () => {
+    expect(parseGmailAccounts('  a@gmail.com , b@gmail.com  ')).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+
+  it('deduplicates accounts', () => {
+    expect(parseGmailAccounts('a@gmail.com,a@gmail.com,b@gmail.com')).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+
+  it('skips empty segments', () => {
+    expect(parseGmailAccounts('a@gmail.com,,b@gmail.com,')).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+
+  it('accepts string array', () => {
+    expect(parseGmailAccounts(['a@gmail.com', 'b@gmail.com'])).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+
+  it('deduplicates string array', () => {
+    expect(parseGmailAccounts(['a@gmail.com', 'a@gmail.com'])).toEqual(['a@gmail.com']);
+  });
+
+  it('trims string array values', () => {
+    expect(parseGmailAccounts([' a@gmail.com ', ' b@gmail.com '])).toEqual(['a@gmail.com', 'b@gmail.com']);
+  });
+});

--- a/src/polling/service.ts
+++ b/src/polling/service.ts
@@ -10,12 +10,28 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AgentSession } from '../core/interfaces.js';
 
+/**
+ * Parse Gmail accounts from a string (comma-separated) or string array.
+ * Deduplicates and trims whitespace.
+ */
+export function parseGmailAccounts(raw?: string | string[]): string[] {
+  if (!raw) return [];
+  const values = Array.isArray(raw) ? raw : raw.split(',');
+  const seen = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+  }
+  return Array.from(seen);
+}
+
 export interface PollingConfig {
   intervalMs: number;  // Polling interval in milliseconds
   workingDir: string;  // For persisting state
   gmail?: {
     enabled: boolean;
-    account: string;
+    accounts: string[];
   };
 }
 
@@ -24,8 +40,8 @@ export class PollingService {
   private bot: AgentSession;
   private config: PollingConfig;
   
-  // Track seen email IDs to detect new emails (persisted to disk)
-  private seenEmailIds: Set<string> = new Set();
+  // Track seen email IDs per account to detect new emails (persisted to disk)
+  private seenEmailIdsByAccount: Map<string, Set<string>> = new Map();
   private seenEmailsPath: string;
   
   constructor(bot: AgentSession, config: PollingConfig) {
@@ -42,8 +58,28 @@ export class PollingService {
     try {
       if (existsSync(this.seenEmailsPath)) {
         const data = JSON.parse(readFileSync(this.seenEmailsPath, 'utf-8'));
-        this.seenEmailIds = new Set(data.ids || []);
-        console.log(`[Polling] Loaded ${this.seenEmailIds.size} seen email IDs`);
+
+        // New per-account format: { accounts: { "email": { ids: [...] } } }
+        if (data && typeof data === 'object' && data.accounts && typeof data.accounts === 'object') {
+          for (const [account, accountData] of Object.entries(data.accounts)) {
+            const ids = Array.isArray((accountData as { ids?: string[] }).ids)
+              ? (accountData as { ids?: string[] }).ids!
+              : [];
+            this.seenEmailIdsByAccount.set(account, new Set(ids));
+          }
+          console.log(`[Polling] Loaded seen email IDs for ${this.seenEmailIdsByAccount.size} account(s)`);
+          return;
+        }
+
+        // Legacy single-account format: { ids: [...] }
+        if (data && Array.isArray(data.ids)) {
+          const accounts = this.config.gmail?.accounts || [];
+          const targetAccount = accounts[0];
+          if (targetAccount) {
+            this.seenEmailIdsByAccount.set(targetAccount, new Set(data.ids));
+            console.log(`[Polling] Migrated legacy seen emails to ${targetAccount}`);
+          }
+        }
       }
     } catch (e) {
       console.error('[Polling] Failed to load seen emails:', e);
@@ -55,9 +91,17 @@ export class PollingService {
    */
   private saveSeenEmails(): void {
     try {
+      const accounts: Record<string, { ids: string[]; updatedAt: string }> = {};
+      const now = new Date().toISOString();
+      for (const [account, ids] of this.seenEmailIdsByAccount.entries()) {
+        accounts[account] = {
+          ids: Array.from(ids),
+          updatedAt: now,
+        };
+      }
       writeFileSync(this.seenEmailsPath, JSON.stringify({
-        ids: Array.from(this.seenEmailIds),
-        updatedAt: new Date().toISOString(),
+        accounts,
+        updatedAt: now,
       }, null, 2));
     } catch (e) {
       console.error('[Polling] Failed to save seen emails:', e);
@@ -74,7 +118,13 @@ export class PollingService {
     }
     
     const enabledPollers: string[] = [];
-    if (this.config.gmail?.enabled) enabledPollers.push('Gmail');
+    if (this.config.gmail?.enabled) {
+      if (this.config.gmail.accounts.length > 0) {
+        enabledPollers.push(`Gmail (${this.config.gmail.accounts.length} account${this.config.gmail.accounts.length === 1 ? '' : 's'})`);
+      } else {
+        console.log('[Polling] Gmail enabled but no accounts configured');
+      }
+    }
     
     if (enabledPollers.length === 0) {
       console.log('[Polling] No pollers enabled');
@@ -106,16 +156,21 @@ export class PollingService {
    */
   private async poll(): Promise<void> {
     if (this.config.gmail?.enabled) {
-      await this.pollGmail();
+      for (const account of this.config.gmail.accounts) {
+        await this.pollGmail(account);
+      }
     }
   }
   
   /**
    * Poll Gmail for new unread messages
    */
-  private async pollGmail(): Promise<void> {
-    const account = this.config.gmail?.account;
+  private async pollGmail(account: string): Promise<void> {
     if (!account) return;
+    if (!this.seenEmailIdsByAccount.has(account)) {
+      this.seenEmailIdsByAccount.set(account, new Set());
+    }
+    const seenEmailIds = this.seenEmailIdsByAccount.get(account)!;
     
     try {
       // Check for unread emails (use longer window to catch any we might have missed)
@@ -130,7 +185,7 @@ export class PollingService {
       });
       
       if (result.status !== 0) {
-        console.log(`[Polling] 📧 Gmail check failed: ${result.stderr || 'unknown error'}`);
+        console.log(`[Polling] Gmail check failed for ${account}: ${result.stderr || 'unknown error'}`);
         return;
       }
       
@@ -147,7 +202,7 @@ export class PollingService {
         const id = line.split(/\s+/)[0]; // First column is ID
         if (id) {
           currentEmailIds.add(id);
-          if (!this.seenEmailIds.has(id)) {
+          if (!seenEmailIds.has(id)) {
             newEmails.push(line);
           }
         }
@@ -155,17 +210,17 @@ export class PollingService {
       
       // Add new IDs to seen set (don't replace - we want to remember all seen emails)
       for (const id of currentEmailIds) {
-        this.seenEmailIds.add(id);
+        seenEmailIds.add(id);
       }
       this.saveSeenEmails();
       
       // Only notify if there are NEW emails we haven't seen before
       if (newEmails.length === 0) {
-        console.log(`[Polling] 📧 No new emails (${currentEmailIds.size} unread total)`);
+        console.log(`[Polling] No new emails for ${account} (${currentEmailIds.size} unread total)`);
         return;
       }
       
-      console.log(`[Polling] 📧 Found ${newEmails.length} NEW email(s)!`);
+      console.log(`[Polling] Found ${newEmails.length} NEW email(s) for ${account}!`);
       
       // Build output with header + new emails only
       const header = lines[0];
@@ -179,7 +234,7 @@ export class PollingService {
         '║  To send a message, use: lettabot-message send --text "..."    ║',
         '╚════════════════════════════════════════════════════════════════╝',
         '',
-        `[email] ${newEmails.length} new unread email(s):`,
+        `[email] ${newEmails.length} new unread email(s) for ${account}:`,
         '',
         newEmailsOutput,
         '',
@@ -189,11 +244,11 @@ export class PollingService {
       const response = await this.bot.sendToAgent(message);
       
       // Log response but do NOT auto-deliver (silent mode)
-      console.log(`[Polling] 📧 Agent finished (SILENT MODE)`);
+      console.log(`[Polling] Agent finished (SILENT MODE)`);
       console.log(`  - Response: ${response?.slice(0, 100)}${(response?.length || 0) > 100 ? '...' : ''}`);
       console.log(`  - (Response NOT auto-delivered - agent uses lettabot-message CLI)`)
     } catch (e) {
-      console.error('[Polling] 📧 Gmail error:', e);
+      console.error(`[Polling] Gmail error for ${account}:`, e);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Multi-account Gmail polling with per-account seen email tracking
- Updated onboarding flow: multi-select existing accounts + add new, per-account service selection
- Config resolution: `polling.gmail.accounts` > `integrations.google.accounts` (legacy) > `GMAIL_ACCOUNT` env (comma-separated)

Based on @jasoncarreira's work in #214, rebased onto current main with cleanup:
- Extracted `parseGmailAccounts()` to `polling/service.ts` (exported, testable)
- Added 10 unit tests for account parsing (dedup, trimming, comma-separated, array input)
- Simplified legacy `configToEnv` filtering
- Legacy `seen-emails.json` auto-migrates to per-account format

## Config

```yaml
polling:
  gmail:
    accounts:
      - user@example.com
      - other@example.com
```

Or via env: `GMAIL_ACCOUNT=user@example.com,other@example.com`

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 463 unit tests pass (10 new for `parseGmailAccounts`)
- [ ] Manual test: multi-account Gmail polling with gog CLI

Closes #214.

Written by Cameron ◯ Letta Code

"Good artists copy, great artists steal." - Pablo Picasso