### PR TITLE
fix: create new conversation when no stored conversation ID exists (#245)

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -199,7 +199,10 @@ export class LettaBot implements AgentSession {
     }
     if (this.store.agentId) {
       process.env.LETTA_AGENT_ID = this.store.agentId;
-      return resumeSession(this.store.agentId, opts);
+      // Create a new conversation instead of resuming the default.
+      // This handles the case where the default conversation was deleted
+      // or never created (e.g., after migrations).
+      return createSession(this.store.agentId, opts);
     }
 
     // Create new agent -- persist immediately so we don't orphan it on later failures


### PR DESCRIPTION
## Summary

When an agent ID is configured but no conversation ID is stored, LettaBot previously tried to resume the agent's default conversation via `resumeSession()`. If that default conversation was deleted or never created (e.g., after migrations), the CLI exited with "Conversation default not found" and the bot never replied to messages.

The fix changes `getSession()` to call `createSession()` instead of `resumeSession()` when there's no stored conversation ID, ensuring a new conversation is always created in this case.

## Changes

- **src/core/bot.ts**: Changed `resumeSession(this.store.agentId, opts)` to `createSession(this.store.agentId, opts)` in `getSession()` method when there's an agent ID but no stored conversation ID.

## Test plan

- [x] All existing unit tests pass (545 tests)
- [x] Fix addresses the root cause described in the issue

👾 Generated with [Letta Code](https://letta.com)