### PR TITLE
feat: configurable name/emoji prefix for agent messages in group chats

### DIFF
--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -15,6 +15,7 @@ server:
 
 agent:
   name: LettaBot
+  # displayName: "💜 Signo"  # Prefix outbound messages (useful in multi-agent group chats)
   # Note: model is configured on the Letta agent server-side.
   # Select a model during `lettabot onboard` or change it with `lettabot model set <handle>`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "lettabot",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lettabot",
-      "version": "1.0.0",
-      "hasInstallScript": true,
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.11.0",
@@ -36,6 +35,7 @@
       "bin": {
         "lettabot": "dist/cli.js",
         "lettabot-channels": "dist/cli/channels.js",
+        "lettabot-history": "dist/cli/history.js",
         "lettabot-message": "dist/cli/message.js",
         "lettabot-react": "dist/cli/react.js",
         "lettabot-schedule": "dist/cron/cli.js"
@@ -43,6 +43,9 @@
       "devDependencies": {
         "@types/update-notifier": "^6.0.8",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "optionalDependencies": {
         "@slack/bolt": "^4.6.0",

--- a/src/config/normalize.test.ts
+++ b/src/config/normalize.test.ts
@@ -332,4 +332,46 @@ describe('normalizeAgents', () => {
     expect(agents[0].polling).toEqual(config.polling);
     expect(agents[0].integrations).toEqual(config.integrations);
   });
+
+  it('should pass through displayName', () => {
+    const config: LettaBotConfig = {
+      server: { mode: 'cloud' },
+      agent: {
+        name: 'Signo',
+        displayName: '💜 Signo',
+      },
+      channels: {
+        telegram: { enabled: true, token: 'test-token' },
+      },
+    };
+
+    const agents = normalizeAgents(config);
+
+    expect(agents[0].displayName).toBe('💜 Signo');
+  });
+
+  it('should pass through displayName in multi-agent config', () => {
+    const agentsArray: AgentConfig[] = [
+      {
+        name: 'Signo',
+        displayName: '💜 Signo',
+        channels: { telegram: { enabled: true, token: 't1' } },
+      },
+      {
+        name: 'DevOps',
+        displayName: '👾 DevOps',
+        channels: { discord: { enabled: true, token: 'd1' } },
+      },
+    ];
+
+    const config = {
+      server: { mode: 'cloud' as const },
+      agents: agentsArray,
+    } as LettaBotConfig;
+
+    const agents = normalizeAgents(config);
+
+    expect(agents[0].displayName).toBe('💜 Signo');
+    expect(agents[1].displayName).toBe('👾 DevOps');
+  });
 });

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,6 +15,8 @@ export interface AgentConfig {
   name: string;
   /** Use existing agent ID (skip creation) */
   id?: string;
+  /** Display name prefixed to outbound messages (e.g. "💜 Signo") */
+  displayName?: string;
   /** Model for initial agent creation */
   model?: string;
   /** Channels this agent connects to */
@@ -62,6 +64,7 @@ export interface LettaBotConfig {
   agent: {
     id?: string;
     name: string;
+    displayName?: string;
     // model is configured on the Letta agent server-side, not in config
     // Kept as optional for backward compat (ignored if present in existing configs)
     model?: string;
@@ -325,6 +328,7 @@ export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
   return [{
     name: agentName,
     id,
+    displayName: config.agent?.displayName,
     model,
     channels,
     features: config.features,

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -133,6 +133,19 @@ export class LettaBot implements AgentSession {
   }
 
   // =========================================================================
+  // Response prefix (for multi-agent group chat identification)
+  // =========================================================================
+
+  /**
+   * Prepend configured displayName prefix to outbound agent responses.
+   * Returns text unchanged if no prefix is configured.
+   */
+  private prefixResponse(text: string): string {
+    if (!this.config.displayName) return text;
+    return `${this.config.displayName}: ${text}`;
+  }
+
+  // =========================================================================
   // Session options (shared by processMessage and sendToAgent)
   // =========================================================================
 
@@ -609,10 +622,11 @@ export class LettaBot implements AgentSession {
         }
         if (response.trim()) {
           try {
+            const prefixed = this.prefixResponse(response);
             if (messageId) {
-              await adapter.editMessage(msg.chatId, messageId, response);
+              await adapter.editMessage(msg.chatId, messageId, prefixed);
             } else {
-              await adapter.sendMessage({ chatId: msg.chatId, text: response, threadId: msg.threadId });
+              await adapter.sendMessage({ chatId: msg.chatId, text: prefixed, threadId: msg.threadId });
             }
             sentAnyMessage = true;
           } catch {
@@ -682,10 +696,11 @@ export class LettaBot implements AgentSession {
             const streamText = stripActionsBlock(response).trim();
             if (canEdit && !mayBeHidden && streamText.length > 0 && Date.now() - lastUpdate > 500) {
               try {
+                const prefixedStream = this.prefixResponse(streamText);
                 if (messageId) {
-                  await adapter.editMessage(msg.chatId, messageId, streamText);
+                  await adapter.editMessage(msg.chatId, messageId, prefixedStream);
                 } else {
-                  const result = await adapter.sendMessage({ chatId: msg.chatId, text: streamText, threadId: msg.threadId });
+                  const result = await adapter.sendMessage({ chatId: msg.chatId, text: prefixedStream, threadId: msg.threadId });
                   messageId = result.messageId;
                   sentAnyMessage = true;
                 }
@@ -788,18 +803,19 @@ export class LettaBot implements AgentSession {
 
       // Send final response
       if (response.trim()) {
+        const prefixedFinal = this.prefixResponse(response);
         try {
           if (messageId) {
-            await adapter.editMessage(msg.chatId, messageId, response);
+            await adapter.editMessage(msg.chatId, messageId, prefixedFinal);
           } else {
-            await adapter.sendMessage({ chatId: msg.chatId, text: response, threadId: msg.threadId });
+            await adapter.sendMessage({ chatId: msg.chatId, text: prefixedFinal, threadId: msg.threadId });
           }
           sentAnyMessage = true;
           this.store.resetRecoveryAttempts();
         } catch {
           // Edit failed -- send as new message so user isn't left with truncated text
           try {
-            await adapter.sendMessage({ chatId: msg.chatId, text: response, threadId: msg.threadId });
+            await adapter.sendMessage({ chatId: msg.chatId, text: prefixedFinal, threadId: msg.threadId });
             sentAnyMessage = true;
             this.store.resetRecoveryAttempts();
           } catch (retryError) {
@@ -952,7 +968,7 @@ export class LettaBot implements AgentSession {
     }
 
     if (options.text) {
-      const result = await adapter.sendMessage({ chatId, text: options.text });
+      const result = await adapter.sendMessage({ chatId, text: this.prefixResponse(options.text) });
       return result.messageId;
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -124,6 +124,9 @@ export interface BotConfig {
   agentName?: string; // Name for the agent (set via API after creation)
   allowedTools: string[];
 
+  // Display
+  displayName?: string; // Prefix outbound messages (e.g. "💜 Signo")
+
   // Skills
   skills?: SkillsConfig;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -487,6 +487,7 @@ async function main() {
       workingDir: globalConfig.workingDir,
       agentName: agentConfig.name,
       allowedTools: globalConfig.allowedTools,
+      displayName: agentConfig.displayName,
       maxToolCalls: agentConfig.features?.maxToolCalls,
       skills: {
         cronEnabled: agentConfig.features?.cron ?? globalConfig.cronEnabled,


### PR DESCRIPTION
## Summary

Add optional `displayName` field to agent config. When set, outbound agent responses are prefixed for identification in multi-agent group chats.

```yaml
# Single agent
agent:
  name: Signo
  displayName: "💜 Signo"

# Multi-agent
agents:
  - name: Signo
    displayName: "💜 Signo"
  - name: DevOps
    displayName: "👾 DevOps"
```

Messages become: `💜 Signo: Roll call`

- Only prefixes agent responses, not system/error messages
- No prefix by default (backward compatible)
- Works across all channels (plain text prefix)
- Applied at all delivery points: streaming chunks, final responses, and tool-initiated sends

Closes #252

## Test plan

- [x] `npm run build` -- clean (0 errors)
- [x] `npm run test:run` -- 544 tests pass
- [x] New tests for `normalizeAgents` with displayName (single + multi-agent)
- [x] Manual: configure displayName, verify prefix appears in messages

## Files changed

- `src/config/types.ts` -- Add `displayName` to `AgentConfig` and `LettaBotConfig.agent`, pass through in `normalizeAgents`
- `src/core/types.ts` -- Add `displayName` to `BotConfig`
- `src/main.ts` -- Wire config through to `LettaBot` constructor
- `src/core/bot.ts` -- `prefixResponse()` helper, applied at 4 delivery points
- `src/config/normalize.test.ts` -- 2 new tests
- `lettabot.example.yaml` -- Document new option