### PR TITLE
feat: configurable displayName prefix for agent messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,7 @@ The default config uses `agent:` and `channels:` at the top level for a single a
 |--------|------|-------------|
 | `agent.id` | string | Use existing agent (skips creation) |
 | `agent.name` | string | Name for new agent |
+| `agent.displayName` | string | Prefix outbound messages (e.g. `"💜 Signo"`) |
 
 > **Note:** The model is configured on the Letta agent server-side, not in the config file.
 > Use `lettabot model show` to see the current model and `lettabot model set <handle>` to change it.
@@ -146,6 +147,7 @@ server:
 
 agents:
   - name: work-assistant
+    # displayName: "🔧 Work"    # Optional: prefix outbound messages
     model: claude-sonnet-4
     # id: agent-abc123           # Optional: use existing agent
     channels:
@@ -184,6 +186,7 @@ Each entry in `agents:` accepts:
 |--------|------|----------|-------------|
 | `name` | string | Yes | Agent name (used for display, creation, and state isolation) |
 | `id` | string | No | Use existing agent ID (skips creation) |
+| `displayName` | string | No | Prefix outbound messages (e.g. `"💜 Signo"`) |
 | `model` | string | No | Model for agent creation |
 | `channels` | object | No | Channel configs (same schema as top-level `channels:`). At least one agent must have channels. |
 | `features` | object | No | Per-agent features (cron, heartbeat, maxToolCalls) |

--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -15,6 +15,7 @@ server:
 
 agent:
   name: LettaBot
+  # displayName: "💜 Signo"  # Prefix outbound messages (useful in multi-agent group chats)
   # Note: model is configured on the Letta agent server-side.
   # Select a model during `lettabot onboard` or change it with `lettabot model set <handle>`.
 

--- a/src/config/normalize.test.ts
+++ b/src/config/normalize.test.ts
@@ -332,4 +332,46 @@ describe('normalizeAgents', () => {
     expect(agents[0].polling).toEqual(config.polling);
     expect(agents[0].integrations).toEqual(config.integrations);
   });
+
+  it('should pass through displayName', () => {
+    const config: LettaBotConfig = {
+      server: { mode: 'cloud' },
+      agent: {
+        name: 'Signo',
+        displayName: '💜 Signo',
+      },
+      channels: {
+        telegram: { enabled: true, token: 'test-token' },
+      },
+    };
+
+    const agents = normalizeAgents(config);
+
+    expect(agents[0].displayName).toBe('💜 Signo');
+  });
+
+  it('should pass through displayName in multi-agent config', () => {
+    const agentsArray: AgentConfig[] = [
+      {
+        name: 'Signo',
+        displayName: '💜 Signo',
+        channels: { telegram: { enabled: true, token: 't1' } },
+      },
+      {
+        name: 'DevOps',
+        displayName: '👾 DevOps',
+        channels: { discord: { enabled: true, token: 'd1' } },
+      },
+    ];
+
+    const config = {
+      server: { mode: 'cloud' as const },
+      agents: agentsArray,
+    } as LettaBotConfig;
+
+    const agents = normalizeAgents(config);
+
+    expect(agents[0].displayName).toBe('💜 Signo');
+    expect(agents[1].displayName).toBe('👾 DevOps');
+  });
 });

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,6 +15,8 @@ export interface AgentConfig {
   name: string;
   /** Use existing agent ID (skip creation) */
   id?: string;
+  /** Display name prefixed to outbound messages (e.g. "💜 Signo") */
+  displayName?: string;
   /** Model for initial agent creation */
   model?: string;
   /** Channels this agent connects to */
@@ -62,6 +64,7 @@ export interface LettaBotConfig {
   agent: {
     id?: string;
     name: string;
+    displayName?: string;
     // model is configured on the Letta agent server-side, not in config
     // Kept as optional for backward compat (ignored if present in existing configs)
     model?: string;
@@ -330,6 +333,7 @@ export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
   return [{
     name: agentName,
     id,
+    displayName: config.agent?.displayName,
     model,
     channels,
     features: config.features,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -125,6 +125,9 @@ export interface BotConfig {
   agentName?: string; // Name for the agent (set via API after creation)
   allowedTools: string[];
 
+  // Display
+  displayName?: string; // Prefix outbound messages (e.g. "💜 Signo")
+
   // Skills
   skills?: SkillsConfig;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -472,6 +472,7 @@ async function main() {
       workingDir: globalConfig.workingDir,
       agentName: agentConfig.name,
       allowedTools: globalConfig.allowedTools,
+      displayName: agentConfig.displayName,
       maxToolCalls: agentConfig.features?.maxToolCalls,
       skills: {
         cronEnabled: agentConfig.features?.cron ?? globalConfig.cronEnabled,


### PR DESCRIPTION
## Summary

Add optional `displayName` field to agent config. When set, outbound agent responses are prefixed for identification in multi-agent group chats.

```yaml
agent:
  name: Signo
  displayName: "💜 Signo"
```

Messages become: `💜 Signo: Roll call`

- Only prefixes agent responses, not system/error messages
- No prefix by default (backward compatible)
- Works across all channels (plain text prefix)
- Applied at all delivery points: streaming chunks, final responses, and tool-initiated sends

Closes #252

## Test plan

- [x] `npm run build` -- clean
- [x] `npm run test:run` -- 544 tests pass
- [x] New tests for `normalizeAgents` with displayName (single + multi-agent)
- [x] Manual: configure displayName, verify prefix appears in messages

## Files changed

- `src/config/types.ts` -- Add `displayName` to `AgentConfig` and `LettaBotConfig.agent`, pass through in `normalizeAgents`
- `src/core/types.ts` -- Add `displayName` to `BotConfig`
- `src/main.ts` -- Wire config through to `LettaBot` constructor
- `src/core/bot.ts` -- `prefixResponse()` helper, applied at 4 delivery points
- `src/config/normalize.test.ts` -- 2 new tests
- `docs/configuration.md` -- Document `displayName` in both single and multi-agent tables
- `lettabot.example.yaml` -- Document new option