### PR TITLE
docs: add npm run update script and recommend npm ci

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,8 +16,10 @@ Get LettaBot running in 5 minutes.
 ```bash
 git clone https://github.com/letta-ai/lettabot.git
 cd lettabot
-npm install
+npm ci
 ```
+
+> **Note:** Always use `npm ci` (not `npm install`) to avoid modifying the lockfile, which would block future `git pull` updates.
 
 ### 2. Create a Telegram Bot
 
@@ -94,6 +96,16 @@ To limit who can use your bot, set `ALLOWED_USERS`:
 # Find your Telegram user ID by messaging @userinfobot
 ALLOWED_USERS=123456789,987654321
 ```
+
+## Updating
+
+Pull the latest changes and rebuild:
+
+```bash
+npm run update
+```
+
+This resets the lockfile, pulls from git, installs dependencies, and rebuilds. If you've modified source files locally, stash them first with `git stash`.
 
 ## Next Steps
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "skills:status": "tsx src/cli.ts skills status",
     "cron": "tsx src/cron/cli.ts",
     "pairing": "tsx src/cli.ts pairing",
+    "update": "git checkout -- package-lock.json && git pull && npm ci && npm run build",
     "skill:install": "npx clawdhub install --dir ~/.letta/skills",
     "skill:search": "npx clawdhub search",
     "skill:list": "npx clawdhub list --dir ~/.letta/skills",


### PR DESCRIPTION
## Summary

- Add `npm run update` script: resets lockfile, pulls, installs, builds in one command
- Change getting-started docs to recommend `npm ci` over `npm install`
- Add "Updating" section to getting-started docs

Fixes the common issue where `npm install` dirties `package-lock.json`, then `git pull` refuses to merge.

## Test plan

- [x] `npm run build` passes
- [ ] `npm run update` works on a dirty-lockfile repo