### PR TITLE
fix: add stream debug visibility for tool calls and UUID gap detection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,11 @@ if (yamlConfig.agent?.model) {
 }
 applyConfigToEnv(yamlConfig);
 
+// Bridge DEBUG=1 to DEBUG_SDK so SDK-level dropped wire messages are visible
+if (process.env.DEBUG === '1' && !process.env.DEBUG_SDK) {
+  process.env.DEBUG_SDK = '1';
+}
+
 // Sync BYOK providers on startup (async, don't block)
 syncProviders(yamlConfig).catch(err => console.error('[Config] Failed to sync providers:', err));
 


### PR DESCRIPTION
## Summary

- Adds `sawNonAssistantSinceLastUuid` tracking to detect when assistant message UUIDs change with no visible tool_call/reasoning events between them -- logs a warning pointing to SDK `transformMessage()` as the likely drop point
- Replaces `[Bot] Calling tool:` / `[Bot] Tool completed:` with `[Stream]`-prefixed structured summaries (`>>> TOOL CALL`, `<<< TOOL RESULT`) so tool calls are greppable alongside raw stream output
- Bridges `DEBUG=1` to `DEBUG_SDK=1` in main.ts so SDK-level dropped wire messages surface when debugging

## Context

Observed two assistant messages with different UUIDs but no tool_call events between them in `[Stream]` debug output, despite the agent clearly calling a tool mid-response. The SDK's `transformMessage()` silently drops wire messages that don't match expected format (logging gated behind `DEBUG_SDK`), making it invisible when server-side tool calls are lost.

## Test plan

- [ ] Run with a message that triggers server-side tool calls (memory operations) and verify `[Stream] >>> TOOL CALL` appears or the UUID gap warning fires
- [ ] Run with `DEBUG=1` and verify SDK-level `[SDK-Session] [stream] DROPPED` messages appear
- [ ] Verify no change to message delivery behavior (changes are logging-only)

Written by Cameron ◯ Letta Code

"The stream does not resist the rock; it flows around it, revealing its shape." -- Unknown