### PR TITLE
feat: unified group modes (open/listen/mention-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,16 @@ At least one channel is required. Telegram is the easiest to start with.
 
 ### Group Settings (Optional)
 
-Configure group batching and listening mode in `lettabot.yaml`:
+Configure group batching and per-group response modes in `lettabot.yaml`:
 
 ```yaml
 channels:
   slack:
     groupDebounceSec: 5
     instantGroups: ["C0123456789"]
-    listeningGroups: ["C0987654321"] # observe only, reply on mention
+    groups:
+      "*": { mode: open }
+      "C0987654321": { mode: listen } # observe only, reply on mention
 ```
 
 See `SKILL.md` for the full environment variable list and examples.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,30 @@ channels:
 
 The deprecated `groupPollIntervalMin` (minutes) still works for backward compatibility but `groupDebounceSec` takes priority.
 
+### Group Modes
+
+Use `groups.<id>.mode` to control how each group/channel behaves:
+
+- `open`: process and respond to all messages (default behavior)
+- `listen`: process all messages for context/memory, only respond when mentioned
+- `mention-only`: drop group messages unless the bot is mentioned
+
+You can also use `*` as a wildcard default:
+
+```yaml
+channels:
+  telegram:
+    groups:
+      "*": { mode: listen }
+      "-1001234567890": { mode: open }
+      "-1009876543210": { mode: mention-only }
+```
+
+Deprecated formats are still supported and auto-normalized with warnings:
+
+- `listeningGroups: ["id"]` -> `groups: { "id": { mode: listen } }`
+- `groups: { "id": { requireMention: true/false } }` -> `mode: mention-only/open`
+
 ### DM Policies
 
 **Note:** For WhatsApp/Signal with `selfChat: true` (personal number), dmPolicy is ignored - only you can message via "Message Yourself" / "Note to Self".

--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -38,27 +38,25 @@ channels:
     dmPolicy: pairing  # 'pairing', 'allowlist', or 'open'
     # groupPollIntervalMin: 5       # Batch interval for group messages (default: 10)
     # instantGroups: ["-100123456"] # Groups that bypass batching
-    # listeningGroups: ["-100123456"] # Groups where bot observes but only replies when @mentioned
-    # Group access control (which groups can interact, mention requirement):
+    # Group access + response mode:
     # groups:
-    #   "*": { requireMention: true }              # Default: only respond when @mentioned
-    #   "-1001234567890": { requireMention: false } # This group gets all messages
+    #   "*": { mode: listen }                      # Observe all groups; only reply when @mentioned
+    #   "-1001234567890": { mode: open }           # This group gets all messages
+    #   "-1009876543210": { mode: mention-only }   # Drop unless @mentioned
     # mentionPatterns: ["hey bot"]                  # Additional regex patterns for mention detection
   # slack:
   #   enabled: true
   #   appToken: xapp-...
   #   botToken: xoxb-...
-  #   listeningGroups: ["C0123456789"]  # Channels where bot observes only
-  #   # groups:
-  #   #   "*": { requireMention: true }  # Default: only respond when @mentioned
-  #   #   "C0123456789": { requireMention: false }
+  #   groups:
+  #     "*": { mode: listen }
+  #     "C0123456789": { mode: open }
   # discord:
   #   enabled: true
   #   token: YOUR-DISCORD-BOT-TOKEN
-  #   listeningGroups: ["1234567890123456789"]  # Server/channel IDs where bot observes only
-  #   # groups:
-  #   #   "*": { requireMention: true }  # Default: only respond when @mentioned
-  #   #   "1234567890123456789": { requireMention: false }  # Server or channel ID
+  #   groups:
+  #     "*": { mode: listen }
+  #     "1234567890123456789": { mode: open }  # Server or channel ID
   # whatsapp:
   #   enabled: true
   #   selfChat: false

--- a/src/channels/group-mode.test.ts
+++ b/src/channels/group-mode.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { isGroupAllowed, resolveGroupMode, type GroupsConfig } from './group-mode.js';
+
+describe('group-mode helpers', () => {
+  describe('isGroupAllowed', () => {
+    it('allows when groups config is missing', () => {
+      expect(isGroupAllowed(undefined, ['group-1'])).toBe(true);
+    });
+
+    it('allows when groups config is empty', () => {
+      expect(isGroupAllowed({}, ['group-1'])).toBe(true);
+    });
+
+    it('allows via wildcard', () => {
+      const groups: GroupsConfig = { '*': { mode: 'mention-only' } };
+      expect(isGroupAllowed(groups, ['group-1'])).toBe(true);
+    });
+
+    it('allows when any provided key matches', () => {
+      const groups: GroupsConfig = { 'server-1': { mode: 'open' } };
+      expect(isGroupAllowed(groups, ['chat-1', 'server-1'])).toBe(true);
+    });
+
+    it('rejects when no keys match and no wildcard', () => {
+      const groups: GroupsConfig = { 'group-2': { mode: 'open' } };
+      expect(isGroupAllowed(groups, ['group-1'])).toBe(false);
+    });
+  });
+
+  describe('resolveGroupMode', () => {
+    it('returns fallback when groups config is missing', () => {
+      expect(resolveGroupMode(undefined, ['group-1'], 'open')).toBe('open');
+    });
+
+    it('uses specific key before wildcard', () => {
+      const groups: GroupsConfig = {
+        '*': { mode: 'mention-only' },
+        'group-1': { mode: 'open' },
+      };
+      expect(resolveGroupMode(groups, ['group-1'], 'open')).toBe('open');
+    });
+
+    it('uses wildcard when no specific key matches', () => {
+      const groups: GroupsConfig = { '*': { mode: 'listen' } };
+      expect(resolveGroupMode(groups, ['group-1'], 'open')).toBe('listen');
+    });
+
+    it('maps legacy requireMention=true to mention-only', () => {
+      const groups: GroupsConfig = { 'group-1': { requireMention: true } };
+      expect(resolveGroupMode(groups, ['group-1'], 'open')).toBe('mention-only');
+    });
+
+    it('maps legacy requireMention=false to open', () => {
+      const groups: GroupsConfig = { 'group-1': { requireMention: false } };
+      expect(resolveGroupMode(groups, ['group-1'], 'mention-only')).toBe('open');
+    });
+
+    it('defaults to mention-only for explicit empty group entries', () => {
+      const groups: GroupsConfig = { 'group-1': {} };
+      expect(resolveGroupMode(groups, ['group-1'], 'open')).toBe('mention-only');
+    });
+
+    it('defaults to mention-only for wildcard empty entry', () => {
+      const groups: GroupsConfig = { '*': {} };
+      expect(resolveGroupMode(groups, ['group-1'], 'open')).toBe('mention-only');
+    });
+
+    it('uses first matching key in priority order', () => {
+      const groups: GroupsConfig = {
+        'chat-1': { mode: 'listen' },
+        'server-1': { mode: 'open' },
+      };
+      expect(resolveGroupMode(groups, ['chat-1', 'server-1'], 'mention-only')).toBe('listen');
+      expect(resolveGroupMode(groups, ['chat-2', 'server-1'], 'mention-only')).toBe('open');
+    });
+  });
+});

--- a/src/channels/group-mode.ts
+++ b/src/channels/group-mode.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared group mode helpers across channel adapters.
+ */
+
+export type GroupMode = 'open' | 'listen' | 'mention-only';
+
+export interface GroupModeConfig {
+  mode?: GroupMode;
+  /**
+   * @deprecated Use mode: "mention-only" (true) or "open" (false).
+   */
+  requireMention?: boolean;
+}
+
+export type GroupsConfig = Record<string, GroupModeConfig>;
+
+function coerceMode(config?: GroupModeConfig): GroupMode | undefined {
+  if (!config) return undefined;
+  if (config.mode === 'open' || config.mode === 'listen' || config.mode === 'mention-only') {
+    return config.mode;
+  }
+  if (typeof config.requireMention === 'boolean') {
+    return config.requireMention ? 'mention-only' : 'open';
+  }
+  // For explicitly configured group entries with no mode, default safely.
+  return 'mention-only';
+}
+
+/**
+ * Whether a group/channel is allowed by groups config.
+ *
+ * If no groups config exists, this returns true (open allowlist).
+ */
+export function isGroupAllowed(groups: GroupsConfig | undefined, keys: string[]): boolean {
+  if (!groups) return true;
+  if (Object.keys(groups).length === 0) return true;
+  if (Object.hasOwn(groups, '*')) return true;
+  return keys.some((key) => Object.hasOwn(groups, key));
+}
+
+/**
+ * Resolve effective mode for a group/channel.
+ *
+ * Priority:
+ * 1. First matching key in provided order
+ * 2. Wildcard "*"
+ * 3. Fallback (default: "open")
+ */
+export function resolveGroupMode(
+  groups: GroupsConfig | undefined,
+  keys: string[],
+  fallback: GroupMode = 'open',
+): GroupMode {
+  if (groups) {
+    for (const key of keys) {
+      const mode = coerceMode(groups[key]);
+      if (mode) return mode;
+    }
+    const wildcardMode = coerceMode(groups['*']);
+    if (wildcardMode) return wildcardMode;
+  }
+  return fallback;
+}

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -21,10 +21,9 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { copyFile, stat, access } from 'node:fs/promises';
 import { constants } from 'node:fs';
+import type { GroupModeConfig } from './group-mode.js';
 
-export interface SignalGroupConfig {
-  requireMention?: boolean;  // Default: true (only respond when mentioned)
-}
+export interface SignalGroupConfig extends GroupModeConfig {}
 
 export interface SignalConfig {
   phoneNumber: string;        // Bot's phone number (E.164 format, e.g., +15551234567)
@@ -762,8 +761,9 @@ This code expires in 1 hour.`;
       
       const isGroup = chatId.startsWith('group:');
       
-      // Apply group gating - only respond when mentioned (unless configured otherwise)
+      // Apply group gating mode
       let wasMentioned: boolean | undefined;
+      let isListeningMode = false;
       if (isGroup && groupInfo?.groupId) {
         const mentions = dataMessage?.mentions || syncMessage?.mentions;
         const quote = dataMessage?.quote || syncMessage?.quote;
@@ -784,6 +784,7 @@ This code expires in 1 hour.`;
         }
         
         wasMentioned = gatingResult.wasMentioned;
+        isListeningMode = gatingResult.mode === 'listen' && !wasMentioned;
         if (wasMentioned) {
           console.log(`[Signal] Bot mentioned via ${gatingResult.method}`);
         }
@@ -798,6 +799,7 @@ This code expires in 1 hour.`;
         isGroup,
         groupName: groupInfo?.groupName,
         wasMentioned,
+        isListeningMode,
         attachments: collectedAttachments.length > 0 ? collectedAttachments : undefined,
       };
       

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -11,6 +11,7 @@ import { basename } from 'node:path';
 import { buildAttachmentPath, downloadToFile } from './attachments.js';
 import { parseCommand, HELP_TEXT } from '../core/commands.js';
 import { markdownToSlackMrkdwn } from './slack-format.js';
+import { isGroupAllowed, resolveGroupMode, type GroupMode, type GroupModeConfig } from './group-mode.js';
 
 // Dynamic import to avoid requiring Slack deps if not used
 let App: typeof import('@slack/bolt').App;
@@ -22,7 +23,7 @@ export interface SlackConfig {
   allowedUsers?: string[]; // Slack user IDs (e.g., U01234567)
   attachmentsDir?: string;
   attachmentsMaxBytes?: number;
-  groups?: Record<string, { requireMention?: boolean }>;  // Per-channel settings
+  groups?: Record<string, GroupModeConfig>;  // Per-channel settings
 }
 
 export class SlackAdapter implements ChannelAdapter {
@@ -130,14 +131,15 @@ export class SlackAdapter implements ChannelAdapter {
         // Determine if this is a group/channel (not a DM)
         // DMs have channel IDs starting with 'D', channels start with 'C'
         const isGroup = !channelId.startsWith('D');
+        let mode: GroupMode = 'open';
 
-        // Group gating: config-based allowlist + mention requirement
-        if (isGroup && this.config.groups) {
+        // Group gating: config-based allowlist + mode
+        if (isGroup) {
           if (!this.isChannelAllowed(channelId)) {
             return; // Channel not in allowlist -- silent drop
           }
-          const requireMention = this.resolveRequireMention(channelId);
-          if (requireMention) {
+          mode = this.resolveChannelMode(channelId);
+          if (mode === 'mention-only') {
             // Non-mention message in channel that requires mentions.
             // The app_mention handler will process actual @mentions.
             return;
@@ -156,6 +158,7 @@ export class SlackAdapter implements ChannelAdapter {
           isGroup,
           groupName: isGroup ? channelId : undefined,  // Would need conversations.info for name
           wasMentioned: false, // Regular messages; app_mention handles mentions
+          isListeningMode: mode === 'listen',
           attachments,
         });
       }
@@ -306,20 +309,12 @@ export class SlackAdapter implements ChannelAdapter {
 
   /** Check if a channel is allowed by the groups config allowlist */
   private isChannelAllowed(channelId: string): boolean {
-    const groups = this.config.groups;
-    if (!groups) return true;
-    const allowlistEnabled = Object.keys(groups).length > 0;
-    if (!allowlistEnabled) return true;
-    return Object.hasOwn(groups, '*') || Object.hasOwn(groups, channelId);
+    return isGroupAllowed(this.config.groups, [channelId]);
   }
 
-  /** Resolve requireMention for a channel (specific > wildcard > default true) */
-  private resolveRequireMention(channelId: string): boolean {
-    const groups = this.config.groups;
-    if (!groups) return true;
-    const groupConfig = groups[channelId];
-    const wildcardConfig = groups['*'];
-    return groupConfig?.requireMention ?? wildcardConfig?.requireMention ?? true;
+  /** Resolve group mode for a channel (specific > wildcard > open). */
+  private resolveChannelMode(channelId: string): GroupMode {
+    return resolveGroupMode(this.config.groups, [channelId], 'open');
   }
 
   async sendTypingIndicator(_chatId: string): Promise<void> {

--- a/src/channels/whatsapp/inbound/group-gating.test.ts
+++ b/src/channels/whatsapp/inbound/group-gating.test.ts
@@ -73,12 +73,12 @@ describe('applyGroupGating', () => {
         }),
       }));
 
-      // No allowlist = allowed (but mention still required by default)
+      // No allowlist = allowed (open mode)
       expect(result.shouldProcess).toBe(true);
     });
   });
 
-  describe('requireMention setting', () => {
+  describe('mode resolution', () => {
     it('allows when mentioned and requireMention=true', () => {
       const result = applyGroupGating(createParams({
         groupsConfig: { '*': { requireMention: true } },
@@ -117,7 +117,7 @@ describe('applyGroupGating', () => {
       expect(result.wasMentioned).toBe(false);
     });
 
-    it('defaults to requireMention=true when not specified', () => {
+    it('defaults to mention-only when group entry has no mode', () => {
       const result = applyGroupGating(createParams({
         groupsConfig: { '*': {} }, // No requireMention specified
         msg: createMessage({
@@ -126,7 +126,21 @@ describe('applyGroupGating', () => {
       }));
 
       expect(result.shouldProcess).toBe(false);
+      expect(result.mode).toBe('mention-only');
       expect(result.reason).toBe('mention-required');
+    });
+
+    it('supports listen mode', () => {
+      const result = applyGroupGating(createParams({
+        groupsConfig: { '*': { mode: 'listen' } },
+        msg: createMessage({
+          body: 'hello everyone',
+        }),
+      }));
+
+      expect(result.shouldProcess).toBe(true);
+      expect(result.mode).toBe('listen');
+      expect(result.wasMentioned).toBe(false);
     });
   });
 

--- a/src/channels/whatsapp/index.ts
+++ b/src/channels/whatsapp/index.ts
@@ -754,6 +754,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
 
       // Apply group gating (mention detection + allowlist)
       let wasMentioned = false;
+      let isListeningMode = false;
       if (isGroup) {
         const gatingResult = applyGroupGating({
           msg: extracted,
@@ -771,6 +772,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
         }
 
         wasMentioned = gatingResult.wasMentioned ?? false;
+        isListeningMode = gatingResult.mode === 'listen' && !wasMentioned;
       }
 
       // Set mention status for agent context
@@ -814,6 +816,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
           isGroup,
           groupName: extracted.groupSubject,
           wasMentioned: extracted.wasMentioned,
+          isListeningMode,
           replyToUser: extracted.replyContext?.senderE164,
           attachments: extracted.attachments,
         });

--- a/src/channels/whatsapp/types.ts
+++ b/src/channels/whatsapp/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DmPolicy } from "../../pairing/types.js";
+import type { GroupModeConfig } from "../group-mode.js";
 import type {
   WASocket,
   WAMessage,
@@ -51,9 +52,7 @@ export interface WhatsAppConfig {
   mentionPatterns?: string[];
 
   /** Per-group settings (JID or "*" for defaults) */
-  groups?: Record<string, {
-    requireMention?: boolean;  // Default: true
-  }>;
+  groups?: Record<string, GroupModeConfig>;
 }
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -145,6 +145,16 @@ export interface ProviderConfig {
   apiKey: string;
 }
 
+export type GroupMode = 'open' | 'listen' | 'mention-only';
+
+export interface GroupConfig {
+  mode?: GroupMode;
+  /**
+   * @deprecated Use mode: "mention-only" (true) or "open" (false).
+   */
+  requireMention?: boolean;
+}
+
 export interface TelegramConfig {
   enabled: boolean;
   token?: string;
@@ -153,9 +163,9 @@ export interface TelegramConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group chat IDs that bypass batching
-  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
+  listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
   mentionPatterns?: string[];     // Regex patterns for mention detection (e.g., ["@mybot"])
-  groups?: Record<string, { requireMention?: boolean }>;  // Per-group settings, "*" for defaults
+  groups?: Record<string, GroupConfig>;  // Per-group settings, "*" for defaults
 }
 
 export interface SlackConfig {
@@ -167,8 +177,8 @@ export interface SlackConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Channel IDs that bypass batching
-  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
-  groups?: Record<string, { requireMention?: boolean }>;  // Per-channel settings, "*" for defaults
+  listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
+  groups?: Record<string, GroupConfig>;  // Per-channel settings, "*" for defaults
 }
 
 export interface WhatsAppConfig {
@@ -179,11 +189,11 @@ export interface WhatsAppConfig {
   groupPolicy?: 'open' | 'disabled' | 'allowlist';
   groupAllowFrom?: string[];
   mentionPatterns?: string[];
-  groups?: Record<string, { requireMention?: boolean }>;
+  groups?: Record<string, GroupConfig>;
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group JIDs that bypass batching
-  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
+  listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
 }
 
 export interface SignalConfig {
@@ -194,11 +204,11 @@ export interface SignalConfig {
   allowedUsers?: string[];
   // Group gating
   mentionPatterns?: string[];  // Regex patterns for mention detection (e.g., ["@bot"])
-  groups?: Record<string, { requireMention?: boolean }>;  // Per-group settings, "*" for defaults
+  groups?: Record<string, GroupConfig>;  // Per-group settings, "*" for defaults
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group IDs that bypass batching
-  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
+  listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
 }
 
 export interface DiscordConfig {
@@ -209,8 +219,8 @@ export interface DiscordConfig {
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching
-  listeningGroups?: string[];     // Group IDs where bot only observes (replies only when mentioned)
-  groups?: Record<string, { requireMention?: boolean }>;  // Per-guild/channel settings, "*" for defaults
+  listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
+  groups?: Record<string, GroupConfig>;  // Per-guild/channel settings, "*" for defaults
 }
 
 export interface GoogleAccountConfig {
@@ -238,6 +248,93 @@ export const DEFAULT_CONFIG: LettaBotConfig = {
   channels: {},
 };
 
+type ChannelWithLegacyGroupFields = {
+  groups?: Record<string, GroupConfig>;
+  listeningGroups?: string[];
+};
+
+const warnedGroupConfigDeprecations = new Set<string>();
+
+function warnGroupConfigDeprecation(path: string, detail: string): void {
+  const key = `${path}:${detail}`;
+  if (warnedGroupConfigDeprecations.has(key)) return;
+  warnedGroupConfigDeprecations.add(key);
+  console.warn(`[Config] WARNING: ${path} ${detail}`);
+}
+
+function normalizeLegacyGroupFields(
+  channel: ChannelWithLegacyGroupFields | undefined,
+  path: string,
+): void {
+  if (!channel) return;
+
+  const hadOriginalGroups = !!(
+    channel.groups &&
+    typeof channel.groups === 'object' &&
+    Object.keys(channel.groups).length > 0
+  );
+
+  const groups: Record<string, GroupConfig> = channel.groups && typeof channel.groups === 'object'
+    ? { ...channel.groups }
+    : {};
+  const modeDerivedFromRequireMention = new Set<string>();
+
+  let sawLegacyRequireMention = false;
+  for (const [groupId, value] of Object.entries(groups)) {
+    const group = value && typeof value === 'object' ? { ...value } : {};
+    const hasLegacyRequireMention = typeof group.requireMention === 'boolean';
+    if (hasLegacyRequireMention) {
+      sawLegacyRequireMention = true;
+    }
+    if (!group.mode && hasLegacyRequireMention) {
+      group.mode = group.requireMention ? 'mention-only' : 'open';
+      modeDerivedFromRequireMention.add(groupId);
+    }
+    if ('requireMention' in group) {
+      delete group.requireMention;
+    }
+    groups[groupId] = group;
+  }
+  if (sawLegacyRequireMention) {
+    warnGroupConfigDeprecation(
+      `${path}.groups.<id>.requireMention`,
+      'is deprecated. Use groups.<id>.mode: "mention-only" | "open" | "listen".'
+    );
+  }
+
+  const legacyListeningGroups = Array.isArray(channel.listeningGroups)
+    ? channel.listeningGroups.map((id) => String(id).trim()).filter(Boolean)
+    : [];
+
+  if (legacyListeningGroups.length > 0) {
+    warnGroupConfigDeprecation(
+      `${path}.listeningGroups`,
+      'is deprecated. Use groups.<id>.mode: "listen".'
+    );
+    for (const id of legacyListeningGroups) {
+      const existing = groups[id] ? { ...groups[id] } : {};
+      if (!existing.mode || modeDerivedFromRequireMention.has(id)) {
+        existing.mode = 'listen';
+      } else if (existing.mode !== 'listen') {
+        warnGroupConfigDeprecation(
+          `${path}.groups.${id}.mode`,
+          `is "${existing.mode}" while ${path}.listeningGroups also includes "${id}". Keeping mode "${existing.mode}".`
+        );
+      }
+      groups[id] = existing;
+    }
+
+    // Legacy listeningGroups never restricted other groups.
+    // Add wildcard open when there was no explicit groups config.
+    if (!hadOriginalGroups && !groups['*']) {
+      groups['*'] = { mode: 'open' };
+    }
+  }
+
+  channel.groups = Object.keys(groups).length > 0 ? groups : undefined;
+  delete channel.listeningGroups;
+}
+
 /**
  * Normalize config to multi-agent format.
  *
@@ -246,25 +343,35 @@ export const DEFAULT_CONFIG: LettaBotConfig = {
  * Channels with `enabled: false` are dropped during normalization.
  */
 export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
-  const normalizeChannels = (channels?: AgentConfig['channels']): AgentConfig['channels'] => {
+  const normalizeChannels = (channels?: AgentConfig['channels'], sourcePath = 'channels'): AgentConfig['channels'] => {
     const normalized: AgentConfig['channels'] = {};
     if (!channels) return normalized;
 
     if (channels.telegram?.enabled !== false && channels.telegram?.token) {
-      normalized.telegram = channels.telegram;
+      const telegram = { ...channels.telegram };
+      normalizeLegacyGroupFields(telegram, `${sourcePath}.telegram`);
+      normalized.telegram = telegram;
     }
     if (channels.slack?.enabled !== false && channels.slack?.botToken && channels.slack?.appToken) {
-      normalized.slack = channels.slack;
+      const slack = { ...channels.slack };
+      normalizeLegacyGroupFields(slack, `${sourcePath}.slack`);
+      normalized.slack = slack;
     }
     // WhatsApp has no credential to check (uses QR pairing), so just check enabled
     if (channels.whatsapp?.enabled) {
-      normalized.whatsapp = channels.whatsapp;
+      const whatsapp = { ...channels.whatsapp };
+      normalizeLegacyGroupFields(whatsapp, `${sourcePath}.whatsapp`);
+      normalized.whatsapp = whatsapp;
     }
     if (channels.signal?.enabled !== false && channels.signal?.phone) {
-      normalized.signal = channels.signal;
+      const signal = { ...channels.signal };
+      normalizeLegacyGroupFields(signal, `${sourcePath}.signal`);
+      normalized.signal = signal;
     }
     if (channels.discord?.enabled !== false && channels.discord?.token) {
-      normalized.discord = channels.discord;
+      const discord = { ...channels.discord };
+      normalizeLegacyGroupFields(discord, `${sourcePath}.discord`);
+      normalized.discord = discord;
     }
 
     return normalized;
@@ -272,9 +379,9 @@ export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
 
   // Multi-agent mode: normalize channels for each configured agent
   if (config.agents && config.agents.length > 0) {
-    return config.agents.map(agent => ({
+    return config.agents.map((agent, index) => ({
       ...agent,
-      channels: normalizeChannels(agent.channels),
+      channels: normalizeChannels(agent.channels, `agents[${index}].channels`),
     }));
   }
 
@@ -284,7 +391,7 @@ export function normalizeAgents(config: LettaBotConfig): AgentConfig[] {
   const id = config.agent?.id;
 
   // Filter out disabled/misconfigured channels
-  const channels = normalizeChannels(config.channels);
+  const channels = normalizeChannels(config.channels, 'channels');
 
   // Env var fallback for container deploys without lettabot.yaml (e.g. Railway)
   // Helper: parse comma-separated env var into string array (or undefined)

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -374,11 +374,13 @@ export class LettaBot implements AgentSession {
       ? msg.batchedMessages[0]
       : msg;
 
-    // Check if this group is in listening mode
-    const isListening = this.listeningGroupIds.has(`${msg.channel}:${msg.chatId}`)
-      || (msg.serverId && this.listeningGroupIds.has(`${msg.channel}:${msg.serverId}`));
-    if (isListening && !msg.wasMentioned) {
-      effective.isListeningMode = true;
+    // Legacy listeningGroups fallback (new mode-based configs set isListeningMode in adapters)
+    if (effective.isListeningMode === undefined) {
+      const isListening = this.listeningGroupIds.has(`${msg.channel}:${msg.chatId}`)
+        || (msg.serverId && this.listeningGroupIds.has(`${msg.channel}:${msg.serverId}`));
+      if (isListening && !msg.wasMentioned) {
+        effective.isListeningMode = true;
+      }
     }
 
     this.messageQueue.push({ msg: effective, adapter });

--- a/src/core/group-batcher.ts
+++ b/src/core/group-batcher.ts
@@ -91,6 +91,8 @@ export class GroupBatcher {
       isGroup: true,
       groupName: last.groupName,
       wasMentioned: messages.some((m) => m.wasMentioned),
+      // Preserve listening-mode intent only if every message in the batch is non-mentioned listen mode.
+      isListeningMode: messages.every((m) => m.isListeningMode === true) ? true : undefined,
       isBatch: true,
       batchedMessages: messages,
     };

--- a/src/main.ts
+++ b/src/main.ts
@@ -315,6 +315,8 @@ function createChannelsForAgent(
       selfChatMode,
       attachmentsDir,
       attachmentsMaxBytes,
+      groups: agentConfig.channels.whatsapp.groups,
+      mentionPatterns: agentConfig.channels.whatsapp.mentionPatterns,
     }));
   }
 
@@ -336,6 +338,8 @@ function createChannelsForAgent(
       selfChatMode,
       attachmentsDir,
       attachmentsMaxBytes,
+      groups: agentConfig.channels.signal.groups,
+      mentionPatterns: agentConfig.channels.signal.mentionPatterns,
     }));
   }
 


### PR DESCRIPTION
## Summary

- Consolidates `listeningGroups` and `groups.requireMention` into a single `groups` config with explicit `mode` per group (`open`, `listen`, `mention-only`)
- Backward compatible: legacy formats auto-normalize with deprecation warnings
- Shared `group-mode.ts` module with `isGroupAllowed`/`resolveGroupMode` helpers used by all 5 channel adapters
- Default: `mention-only` for configured group entries (safe), `open` when no groups config exists
- Listening mode now set at adapter level; `bot.ts` retains legacy fallback
- YAML large-ID fix extended to `groups` map keys (Discord snowflakes)
- Unit tests for group-mode helpers + updated all gating tests (676/676 pass)
- Updated docs, README, and example config

Closes #266

## Test plan

- [x] `npm run test:run` passes (676 tests)
- [x] `npm run build` passes
- [ ] Manual: verify legacy `listeningGroups` config normalizes with deprecation warning
- [ ] Manual: verify `groups: { "*": { mode: listen } }` suppresses responses unless mentioned

Written by Cameron and Letta Code

"Perfection is achieved not when there is nothing more to add, but when there is nothing left to take away." -- Antoine de Saint-Exupery