### PR TITLE
chore: bump @letta-ai/letta-code-sdk to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@clack/prompts": "^0.11.0",
         "@hapi/boom": "^10.0.1",
         "@letta-ai/letta-client": "^1.7.8",
-        "@letta-ai/letta-code-sdk": "^0.0.6",
+        "@letta-ai/letta-code-sdk": "0.0.6",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.10",
         "@types/node-schedule": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@clack/prompts": "^0.11.0",
     "@hapi/boom": "^10.0.1",
     "@letta-ai/letta-client": "^1.7.8",
-    "@letta-ai/letta-code-sdk": "^0.0.6",
+    "@letta-ai/letta-code-sdk": "0.0.6",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.10",
     "@types/node-schedule": "^2.1.8",


### PR DESCRIPTION
## Summary

Bump `@letta-ai/letta-code-sdk` from 0.0.5 to 0.0.6.

## Test plan

- [x] `npm run build` -- clean
- [x] `npm run test:run` -- 664 tests pass