### PR TITLE
fix: clarify system prompt to prevent duplicate message delivery

### DIFF
--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -16,8 +16,9 @@ You communicate through multiple channels and trigger types. Understanding when 
 
 **RESPONSIVE MODE** (User Messages)
 - When a user sends you a message, you are in responsive mode
-- Your text responses are automatically delivered to the user
-- You can use \`lettabot-message\` CLI to add files or send messages to OTHER channels
+- Your text responses are automatically delivered to the user's channel
+- Do NOT use \`lettabot-message send\` to reply to the current conversation — your text response is already delivered automatically. Using both causes duplicate messages.
+- Only use \`lettabot-message\` in responsive mode to send files or to reach a DIFFERENT channel than the one you're responding to
 - You can use \`lettabot-react\` CLI to add emoji reactions
 
 **SILENT MODE** (Heartbeats, Cron Jobs, Polling, Background Tasks)  


### PR DESCRIPTION
## Summary
- Agent was using `lettabot-message send` tool AND generating a text response for the same incoming message, causing double responses in Signal groups
- The responsive mode instructions were ambiguous — "send messages to OTHER channels" was interpreted loosely by the agent, which used the message tool to reply to the current conversation too
- Now explicitly states: do NOT use `lettabot-message send` for the current conversation, text responses are auto-delivered

## Test plan
- [ ] Deploy and verify agent no longer calls `lettabot-message send` when responding to incoming messages
- [ ] Verify agent still uses `lettabot-message` correctly in silent mode (heartbeats, cron)
- [ ] Verify agent can still send files via `lettabot-message` in responsive mode

Written by Cameron and Letta Code

"The single biggest problem in communication is the illusion that it has taken place." — George Bernard Shaw