### PR TITLE
fix: resolve TS2349 build error in ask-user-question test

### DIFF
--- a/src/core/ask-user-question.test.ts
+++ b/src/core/ask-user-question.test.ts
@@ -154,10 +154,9 @@ describe('AskUserQuestion message interceptor', () => {
     });
 
     // Simulate handleMessage with empty text
-    if (pendingQuestionResolver) {
-      pendingQuestionResolver('');
-      pendingQuestionResolver = null;
-    }
+    // Non-null assertion needed: TS can't track the synchronous mutation from the Promise callback
+    pendingQuestionResolver!('');
+    pendingQuestionResolver = null;
 
     const answer = await answerPromise;
     expect(answer).toBe('');


### PR DESCRIPTION
## Summary
- CI on main is broken: `tsc` fails with `TS2349: This expression is not callable. Type 'never' has no call signatures.` at `src/core/ask-user-question.test.ts:158`
- TypeScript's control flow analysis can't track the synchronous mutation of `pendingQuestionResolver` from inside the Promise constructor callback, so it narrows the type to `never`
- Fix: use non-null assertion (`!`) since the Promise constructor runs synchronously

## Test plan
- [x] `npm run build` passes
- [x] All 374 tests pass

Written by Cameron and Letta Code

"It's not a bug -- it's an undocumented feature." — Anonymous