### PR TITLE
fix: support server.api config, preserve api across onboard, fix load error logging

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,6 +23,10 @@ For global installs (`npm install -g`), either:
 server:
   mode: cloud                    # 'cloud' or 'selfhosted'
   apiKey: letta_...              # Required for cloud mode
+  api:
+    port: 8080                   # Default: 8080 (or PORT env var)
+    # host: 0.0.0.0             # Uncomment for Docker/Railway
+    # corsOrigin: https://my.app # Uncomment for cross-origin access
 
 # Agent settings (single agent mode)
 # For multiple agents, use `agents:` array instead -- see Multi-Agent section
@@ -87,11 +91,6 @@ attachments:
   maxMB: 20
   maxAgeDays: 14
 
-# API server (health checks, CLI messaging)
-api:
-  port: 8080                     # Default: 8080 (or PORT env var)
-  # host: 0.0.0.0               # Uncomment for Docker/Railway
-  # corsOrigin: https://my.app   # Uncomment for cross-origin access
 ```
 
 ## Server Configuration
@@ -226,7 +225,7 @@ agents:
       cron: true
 ```
 
-The `server:`, `transcription:`, `attachments:`, and `api:` sections remain at the top level (shared across all agents).
+The `server:` (including `server.api:`), `transcription:`, and `attachments:` sections remain at the top level (shared across all agents).
 
 ### Known limitations
 
@@ -449,9 +448,9 @@ The top-level `polling` section takes priority if both are present.
 |--------------|--------------------------|
 | `GMAIL_ACCOUNT` | `polling.gmail.account` (comma-separated list allowed) |
 | `POLLING_INTERVAL_MS` | `polling.intervalMs` |
-| `PORT` | `api.port` |
-| `API_HOST` | `api.host` |
-| `API_CORS_ORIGIN` | `api.corsOrigin` |
+| `PORT` | `server.api.port` |
+| `API_HOST` | `server.api.host` |
+| `API_CORS_ORIGIN` | `server.api.corsOrigin` |
 
 ## Transcription Configuration
 
@@ -478,18 +477,25 @@ Attachments are stored in `/tmp/lettabot/attachments/`.
 
 The built-in API server provides health checks, CLI messaging, and a chat endpoint for programmatic agent access.
 
+Configure it under `server.api:` in your `lettabot.yaml`:
+
 ```yaml
-api:
-  port: 9090          # Default: 8080
-  host: 0.0.0.0       # Default: 127.0.0.1 (localhost only)
-  corsOrigin: "*"      # Default: same-origin only
+server:
+  mode: selfhosted
+  baseUrl: http://localhost:8283
+  api:
+    port: 9090          # Default: 8080
+    host: 0.0.0.0       # Default: 127.0.0.1 (localhost only)
+    corsOrigin: "*"      # Default: same-origin only
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `api.port` | number | `8080` | Port for the API/health server |
-| `api.host` | string | `127.0.0.1` | Bind address. Use `0.0.0.0` for Docker/Railway |
-| `api.corsOrigin` | string | _(none)_ | CORS origin header for cross-origin access |
+| `server.api.port` | number | `8080` | Port for the API/health server |
+| `server.api.host` | string | `127.0.0.1` | Bind address. Use `0.0.0.0` for Docker/Railway |
+| `server.api.corsOrigin` | string | _(none)_ | CORS origin header for cross-origin access |
+
+> **Note:** Top-level `api:` is still accepted for backward compatibility but deprecated. Move it under `server:` to avoid warnings.
 
 ### Chat Endpoint
 

--- a/src/config/io.test.ts
+++ b/src/config/io.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import YAML from 'yaml';
-import { saveConfig, loadConfig } from './io.js';
-import { normalizeAgents } from './types.js';
+import { saveConfig, loadConfig, configToEnv, didLoadFail } from './io.js';
+import { normalizeAgents, DEFAULT_CONFIG } from './types.js';
 import type { LettaBotConfig } from './types.js';
 
 describe('saveConfig with agents[] format', () => {
@@ -147,5 +147,231 @@ describe('saveConfig with agents[] format', () => {
     expect(parsed.providers).toHaveLength(1);
     expect(parsed.providers[0].name).toBe('anthropic');
     expect(parsed.agents[0].providers).toBeUndefined();
+  });
+});
+
+describe('server.api config (canonical location)', () => {
+  it('configToEnv should read port from server.api', () => {
+    const config: LettaBotConfig = {
+      ...DEFAULT_CONFIG,
+      server: {
+        mode: 'selfhosted',
+        baseUrl: 'http://localhost:6701',
+        api: { port: 6702, host: '0.0.0.0', corsOrigin: '*' },
+      },
+    };
+
+    const env = configToEnv(config);
+
+    expect(env.PORT).toBe('6702');
+    expect(env.API_HOST).toBe('0.0.0.0');
+    expect(env.API_CORS_ORIGIN).toBe('*');
+  });
+
+  it('configToEnv should fall back to top-level api (deprecated)', () => {
+    const config: LettaBotConfig = {
+      ...DEFAULT_CONFIG,
+      server: { mode: 'selfhosted', baseUrl: 'http://localhost:6701' },
+      api: { port: 8081 },
+    };
+
+    const env = configToEnv(config);
+
+    expect(env.PORT).toBe('8081');
+  });
+
+  it('server.api should take precedence over top-level api', () => {
+    const config: LettaBotConfig = {
+      ...DEFAULT_CONFIG,
+      server: {
+        mode: 'selfhosted',
+        baseUrl: 'http://localhost:6701',
+        api: { port: 9090 },
+      },
+      api: { port: 8081 },
+    };
+
+    const env = configToEnv(config);
+
+    expect(env.PORT).toBe('9090');
+  });
+
+  it('should not set PORT when no api config is present', () => {
+    const config: LettaBotConfig = {
+      ...DEFAULT_CONFIG,
+      server: { mode: 'selfhosted', baseUrl: 'http://localhost:6701' },
+    };
+
+    const env = configToEnv(config);
+
+    expect(env.PORT).toBeUndefined();
+  });
+
+  it('server.api should survive save/load roundtrip in YAML', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-api-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      const config = {
+        server: {
+          mode: 'selfhosted' as const,
+          baseUrl: 'http://localhost:6701',
+          api: { port: 6702, host: '0.0.0.0' },
+        },
+        agents: [{
+          name: 'TestBot',
+          channels: {},
+        }],
+      };
+
+      saveConfig(config, configPath);
+
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed = YAML.parse(raw);
+
+      // server.api should be in the YAML under server
+      expect(parsed.server.api).toBeDefined();
+      expect(parsed.server.api.port).toBe(6702);
+      expect(parsed.server.api.host).toBe('0.0.0.0');
+
+      // Should NOT have top-level api
+      expect(parsed.api).toBeUndefined();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('didLoadFail', () => {
+  it('should return false initially', () => {
+    // loadConfig hasn't been called with a bad file, so it should be false
+    // (or whatever state it was left in from previous test)
+    // Call loadConfig with a valid env to reset
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-fail-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      writeFileSync(configPath, 'server:\n  mode: cloud\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+      loadConfig();
+      expect(didLoadFail()).toBe(false);
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should return true after a parse error', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-fail-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      // Write invalid YAML
+      writeFileSync(configPath, 'server:\n  api: port: 6702\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+
+      // Suppress console output during test
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = loadConfig();
+
+      expect(didLoadFail()).toBe(true);
+      // Should return default config on failure
+      expect(config.server.mode).toBe(DEFAULT_CONFIG.server.mode);
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should reset to false on successful load after a failure', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-fail-test-'));
+    const badPath = join(tmpDir, 'bad.yaml');
+    const goodPath = join(tmpDir, 'good.yaml');
+
+    try {
+      // First: load bad file
+      writeFileSync(badPath, 'server:\n  api: port: 6702\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = badPath;
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      loadConfig();
+      expect(didLoadFail()).toBe(true);
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+
+      // Then: load good file
+      writeFileSync(goodPath, 'server:\n  mode: selfhosted\n  baseUrl: http://localhost:6701\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = goodPath;
+      loadConfig();
+      expect(didLoadFail()).toBe(false);
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadConfig deprecation warning for top-level api', () => {
+  it('should warn when top-level api is present without server.api', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-deprecation-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      writeFileSync(configPath, 'server:\n  mode: cloud\napi:\n  port: 9090\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = loadConfig();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Top-level `api:` is deprecated')
+      );
+      // The top-level api should still be loaded
+      expect(config.api?.port).toBe(9090);
+
+      warnSpy.mockRestore();
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should not warn when server.api is used (canonical location)', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-deprecation-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      writeFileSync(configPath, 'server:\n  mode: selfhosted\n  baseUrl: http://localhost:6701\n  api:\n    port: 6702\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const config = loadConfig();
+
+      // Should NOT have deprecated warning
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Top-level `api:` is deprecated')
+      );
+      // server.api should be loaded
+      expect(config.server.api?.port).toBe(6702);
+      // top-level api should be undefined
+      expect(config.api).toBeUndefined();
+
+      warnSpy.mockRestore();
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -56,6 +56,12 @@ export interface LettaBotConfig {
     baseUrl?: string;
     // Only for cloud mode
     apiKey?: string;
+    // API server config (port, host, CORS) — canonical location
+    api?: {
+      port?: number;       // Default: 8080 (or PORT env var)
+      host?: string;       // Default: 127.0.0.1 (secure). Use '0.0.0.0' for Docker/Railway
+      corsOrigin?: string; // CORS origin. Default: same-origin only
+    };
   };
 
   // Multi-agent configuration
@@ -117,6 +123,7 @@ export interface LettaBotConfig {
   };
 
   // API server (health checks, CLI messaging)
+  /** @deprecated Use server.api instead */
   api?: {
     port?: number;       // Default: 8080 (or PORT env var)
     host?: string;       // Default: 127.0.0.1 (secure). Use '0.0.0.0' for Docker/Railway

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,12 +14,16 @@ import { createApiServer } from './api/server.js';
 import { loadOrGenerateApiKey } from './api/auth.js';
 
 // Load YAML config and apply to process.env (overrides .env values)
-import { loadConfig, applyConfigToEnv, syncProviders, resolveConfigPath } from './config/index.js';
+import { loadConfig, applyConfigToEnv, syncProviders, resolveConfigPath, didLoadFail } from './config/index.js';
 import { isLettaCloudUrl } from './utils/server.js';
 import { getDataDir, getWorkingDir, hasRailwayVolume } from './utils/paths.js';
 const yamlConfig = loadConfig();
-const configSource = existsSync(resolveConfigPath()) ? resolveConfigPath() : 'defaults + environment variables';
-console.log(`[Config] Loaded from ${configSource}`);
+if (didLoadFail()) {
+  console.warn(`[Config] Fix the errors above in ${resolveConfigPath()} and restart.`);
+} else {
+  const configSource = existsSync(resolveConfigPath()) ? resolveConfigPath() : 'defaults + environment variables';
+  console.log(`[Config] Loaded from ${configSource}`);
+}
 if (yamlConfig.agents?.length) {
   console.log(`[Config] Mode: ${yamlConfig.server.mode}, Agents: ${yamlConfig.agents.map(a => a.name).join(', ')}`);
 } else {


### PR DESCRIPTION
## Summary

Fixes three compounding bugs reported by a Discord user who couldn't configure a custom API port:

- **`server.api` is now the canonical config location** for API server settings (port, host, CORS). Users naturally nest `api:` under `server:` -- this now works. Top-level `api:` is still accepted with a deprecation warning. `server.api` takes precedence when both exist.
- **Onboarding no longer silently drops `api` and `attachments`** when saving config. Both interactive and non-interactive save paths now preserve unmanaged top-level fields from the existing config.
- **Misleading "Loaded from" log fixed** -- when YAML parsing fails, the log no longer says "Loaded from lettabot.yaml". A `didLoadFail()` flag enables accurate status reporting without changing 17+ `loadConfig()` call sites.

### Before

```yaml
# User puts api under server (intuitive) -- silently ignored, defaults to 8080
server:
  mode: selfhosted
  baseUrl: http://localhost:6701
  api:
    port: 6702
```

### After

```yaml
# Now works as expected -- server.api is the canonical location
server:
  mode: selfhosted
  baseUrl: http://localhost:6701
  api:
    port: 6702
```

## Test plan

- [x] 10 new unit tests covering all three fixes (384/384 passing)
- [x] `configToEnv` reads from `server.api` 
- [x] `configToEnv` falls back to top-level `api` (backward compat)
- [x] `server.api` takes precedence over top-level `api`
- [x] `server.api` survives YAML save/load roundtrip
- [x] `didLoadFail()` returns true after parse error, false after success
- [x] Deprecation warning fires for top-level `api:` only
- [x] No warning when using `server.api` (canonical)
- [ ] Manual: verify onboarding preserves `server.api` across re-onboard

Written by Cameron ◯ Letta Code

"The map is not the territory, but a good map sure helps you find port 6702."