### PR TITLE
fix: centralize strict config loading and fail fast on invalid config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,8 @@
  */
 
 // Config loaded from lettabot.yaml
-import { loadConfig, applyConfigToEnv, serverModeLabel } from './config/index.js';
-const config = loadConfig();
+import { loadAppConfigOrExit, applyConfigToEnv, serverModeLabel } from './config/index.js';
+const config = loadAppConfigOrExit();
 applyConfigToEnv(config);
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';

--- a/src/cli/channel-management.ts
+++ b/src/cli/channel-management.ts
@@ -6,7 +6,7 @@
  */
 
 import * as p from '@clack/prompts';
-import { loadConfig, saveConfig, resolveConfigPath } from '../config/index.js';
+import { loadAppConfigOrExit, saveConfig, resolveConfigPath } from '../config/index.js';
 import { 
   CHANNELS, 
   getChannelHint, 
@@ -46,7 +46,7 @@ function getChannelDetails(id: ChannelId, channelConfig: any): string | undefine
 }
 
 function getChannelStatus(): ChannelStatus[] {
-  const config = loadConfig();
+  const config = loadAppConfigOrExit();
   
   return CHANNELS.map(ch => {
     const channelConfig = config.channels[ch.id as keyof typeof config.channels];
@@ -202,7 +202,7 @@ export async function addChannel(channelId?: string): Promise<void> {
     process.exit(1);
   }
   
-  const config = loadConfig();
+  const config = loadAppConfigOrExit();
   const existingConfig = config.channels[channelId as keyof typeof config.channels];
   
   // Get and run the setup function
@@ -230,7 +230,7 @@ export async function removeChannel(channelId?: string): Promise<void> {
     process.exit(1);
   }
   
-  const config = loadConfig();
+  const config = loadAppConfigOrExit();
   const channelConfig = config.channels[channelId as keyof typeof config.channels];
   
   if (!channelConfig?.enabled) {

--- a/src/cli/channels.ts
+++ b/src/cli/channels.ts
@@ -10,8 +10,8 @@
  */
 
 // Config loaded from lettabot.yaml
-import { loadConfig, applyConfigToEnv } from '../config/index.js';
-const config = loadConfig();
+import { loadAppConfigOrExit, applyConfigToEnv } from '../config/index.js';
+const config = loadAppConfigOrExit();
 applyConfigToEnv(config);
 
 // Types

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -7,8 +7,8 @@
  */
 
 // Config loaded from lettabot.yaml
-import { loadConfig, applyConfigToEnv } from '../config/index.js';
-const config = loadConfig();
+import { loadAppConfigOrExit, applyConfigToEnv } from '../config/index.js';
+const config = loadAppConfigOrExit();
 applyConfigToEnv(config);
 import { fetchHistory, isValidLimit, parseFetchArgs } from './history-core.js';
 import { loadLastTarget } from './shared.js';

--- a/src/cli/message.ts
+++ b/src/cli/message.ts
@@ -11,8 +11,8 @@
  */
 
 // Config loaded from lettabot.yaml
-import { loadConfig, applyConfigToEnv } from '../config/index.js';
-const config = loadConfig();
+import { loadAppConfigOrExit, applyConfigToEnv } from '../config/index.js';
+const config = loadAppConfigOrExit();
 applyConfigToEnv(config);
 import { existsSync, readFileSync } from 'node:fs';
 import { loadLastTarget } from './shared.js';

--- a/src/cli/react.ts
+++ b/src/cli/react.ts
@@ -10,8 +10,8 @@
  */
 
 // Config loaded from lettabot.yaml
-import { loadConfig, applyConfigToEnv } from '../config/index.js';
-const config = loadConfig();
+import { loadAppConfigOrExit, applyConfigToEnv } from '../config/index.js';
+const config = loadAppConfigOrExit();
 applyConfigToEnv(config);
 import { loadLastTarget } from './shared.js';
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export * from './io.js';
+export * from './runtime.js';

--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadAppConfigOrExit } from './runtime.js';
+import { didLoadFail } from './io.js';
+
+describe('loadAppConfigOrExit', () => {
+  it('should load valid config without exiting', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-runtime-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      writeFileSync(configPath, 'server:\n  mode: api\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+
+      const config = loadAppConfigOrExit(((code: number): never => {
+        throw new Error(`unexpected-exit:${code}`);
+      }));
+
+      expect(config.server.mode).toBe('api');
+      expect(didLoadFail()).toBe(false);
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should log and exit on invalid config', () => {
+    const originalEnv = process.env.LETTABOT_CONFIG;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'lettabot-runtime-test-'));
+    const configPath = join(tmpDir, 'lettabot.yaml');
+
+    try {
+      writeFileSync(configPath, 'server:\n  api: port: 6702\n', 'utf-8');
+      process.env.LETTABOT_CONFIG = configPath;
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const exit = (code: number): never => {
+        throw new Error(`exit:${code}`);
+      };
+
+      expect(() => loadAppConfigOrExit(exit)).toThrow('exit:1');
+      expect(didLoadFail()).toBe(true);
+      expect(errorSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('Failed to load'),
+        expect.anything()
+      );
+      expect(errorSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('Fix the errors above')
+      );
+
+      errorSpy.mockRestore();
+    } finally {
+      process.env.LETTABOT_CONFIG = originalEnv;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,0 +1,19 @@
+import type { LettaBotConfig } from './types.js';
+import { loadConfigStrict, resolveConfigPath } from './io.js';
+
+export type ExitFn = (code: number) => never;
+
+/**
+ * Load config for app/CLI entrypoints. On invalid config, print one
+ * consistent error and terminate.
+ */
+export function loadAppConfigOrExit(exitFn: ExitFn = process.exit): LettaBotConfig {
+  try {
+    return loadConfigStrict();
+  } catch (err) {
+    const configPath = resolveConfigPath();
+    console.error(`[Config] Failed to load ${configPath}:`, err);
+    console.error(`[Config] Fix the errors above in ${configPath} and restart.`);
+    return exitFn(1);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,23 +15,18 @@ import { loadOrGenerateApiKey } from './api/auth.js';
 
 // Load YAML config and apply to process.env (overrides .env values)
 import {
-  loadConfig,
+  loadAppConfigOrExit,
   applyConfigToEnv,
   syncProviders,
   resolveConfigPath,
-  didLoadFail,
   isDockerServerMode,
   serverModeLabel,
 } from './config/index.js';
 import { isLettaApiUrl } from './utils/server.js';
 import { getDataDir, getWorkingDir, hasRailwayVolume } from './utils/paths.js';
-const yamlConfig = loadConfig();
-if (didLoadFail()) {
-  console.warn(`[Config] Fix the errors above in ${resolveConfigPath()} and restart.`);
-} else {
-  const configSource = existsSync(resolveConfigPath()) ? resolveConfigPath() : 'defaults + environment variables';
-  console.log(`[Config] Loaded from ${configSource}`);
-}
+const yamlConfig = loadAppConfigOrExit();
+const configSource = existsSync(resolveConfigPath()) ? resolveConfigPath() : 'defaults + environment variables';
+console.log(`[Config] Loaded from ${configSource}`);
 if (yamlConfig.agents?.length) {
   console.log(`[Config] Mode: ${serverModeLabel(yamlConfig.server.mode)}, Agents: ${yamlConfig.agents.map(a => a.name).join(', ')}`);
 } else {

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -1258,8 +1258,8 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
   const env: Record<string, string> = {};
   
   // Load existing config if available
-  const { loadConfig, resolveConfigPath } = await import('./config/index.js');
-  const existingConfig = loadConfig();
+  const { loadAppConfigOrExit, resolveConfigPath } = await import('./config/index.js');
+  const existingConfig = loadAppConfigOrExit();
   const configPath = resolveConfigPath();
   const hasExistingConfig = existsSync(configPath);
   


### PR DESCRIPTION
## Summary
- add `loadConfigStrict()` and shared parse/validation in `src/config/io.ts`
- add centralized runtime helper `loadAppConfigOrExit()` in `src/config/runtime.ts`
- fail fast on invalid config across entrypoints (`main`, CLI entrypoints, onboarding, channel management)
- reject ambiguous config when both top-level `api` and `server.api` are present
- add tests for strict load behavior and runtime fail-fast behavior

Closes #279

## Testing
- npm run build
- npm run test:run
