### PR TITLE
fix: TS compilation errors from #283 squash merge

### DIFF
--- a/src/channels/signal/group-gating.ts
+++ b/src/channels/signal/group-gating.ts
@@ -8,6 +8,7 @@ import { isGroupAllowed, isGroupUserAllowed, resolveGroupMode, type GroupMode } 
 
 export interface SignalGroupConfig {
   mode?: GroupMode;
+  allowedUsers?: string[];
   requireMention?: boolean;  // @deprecated legacy alias
 }
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -58,7 +58,7 @@ export class TelegramAdapter implements ChannelAdapter {
    * Apply group gating for a message context.
    * Returns null if the message should be dropped, or message metadata if it should proceed.
    */
-  private applyGroupGating(ctx: { chat: { type: string; id: number; title?: string }; message?: { text?: string; entities?: { type: string; offset: number; length: number }[] } }): { isGroup: boolean; groupName?: string; wasMentioned: boolean; isListeningMode?: boolean } | null {
+  private applyGroupGating(ctx: { chat: { type: string; id: number; title?: string }; from?: { id: number }; message?: { text?: string; entities?: { type: string; offset: number; length: number }[] } }): { isGroup: boolean; groupName?: string; wasMentioned: boolean; isListeningMode?: boolean } | null {
     const chatType = ctx.chat.type;
     const isGroup = chatType === 'group' || chatType === 'supergroup';
     const groupName = isGroup && 'title' in ctx.chat ? ctx.chat.title : undefined;


### PR DESCRIPTION
## Summary

- Adds `allowedUsers` to `SignalGroupConfig` (Signal had its own interface that didn't extend `GroupModeConfig`)
- Adds `from?: { id: number }` to Telegram `applyGroupGating` ctx type (needed for senderId access)

Both were missed in the squash merge of #283 because the worktree had the types correct but the squash combined commits and the intermediate types weren't preserved.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 425 unit tests pass

Written by Cameron ◯ Letta Code

"Make the common case easy, and the uncommon case possible." -- Larry Wall