### PR TITLE
feat: per-agent todo system with heartbeat integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,9 +370,12 @@ features:
   heartbeat:
     enabled: true
     intervalMin: 60    # Check every 60 minutes
+    skipRecentUserMin: 5  # Skip auto-heartbeats for N minutes after user message (0 disables)
 ```
 
 Heartbeats are background tasks where the agent can review pending work.
+If the user messaged recently, automatic heartbeats are skipped by default for 5 minutes (`skipRecentUserMin`).
+Set this to `0` to disable skipping. Manual `/heartbeat` bypasses the skip check.
 
 #### Custom Heartbeat Prompt
 
@@ -402,12 +405,14 @@ Via environment variable:
 
 ```bash
 HEARTBEAT_PROMPT="Review recent conversations" npm start
+# Optional: HEARTBEAT_SKIP_RECENT_USER_MIN=0 to disable recent-user skip
 ```
 
 Precedence: `prompt` (inline YAML) > `HEARTBEAT_PROMPT` (env var) > `promptFile` (file) > built-in default.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `features.heartbeat.skipRecentUserMin` | number | `5` | Skip auto-heartbeats for N minutes after a user message. Set `0` to disable. |
 | `features.heartbeat.prompt` | string | _(none)_ | Custom heartbeat prompt text |
 | `features.heartbeat.promptFile` | string | _(none)_ | Path to prompt file (relative to working dir) |
 

--- a/docs/cron-setup.md
+++ b/docs/cron-setup.md
@@ -114,7 +114,12 @@ features:
   heartbeat:
     enabled: true
     intervalMin: 60    # Default: 60 minutes
+    skipRecentUserMin: 5  # Skip auto-heartbeats for N minutes after user messages (0 disables)
 ```
+
+By default, automatic heartbeats are skipped for 5 minutes after a user message to avoid immediate follow-up noise.
+- Set `skipRecentUserMin: 0` to disable this skip behavior.
+- Manual `/heartbeat` always bypasses the skip check.
 
 ### Manual Trigger
 
@@ -127,6 +132,17 @@ You can trigger a heartbeat manually via the `/heartbeat` command in any channel
 3. If the agent wants to message you, it must use `lettabot-message send`
 
 This prevents unwanted messages while allowing proactive behavior when needed.
+
+### Heartbeat To-Dos
+
+Heartbeats include a `PENDING TO-DOS` section when actionable tasks exist. Tasks can come from:
+- `lettabot todo ...` CLI commands
+- The `manage_todo` tool
+- Built-in Letta Code todo tools (`TodoWrite`, `WriteTodos`, `write_todos`), which are synced into LettaBot's persistent todo store
+
+Only actionable tasks are shown in the heartbeat prompt:
+- `completed: false`
+- `snoozed_until` not set, or already in the past
 
 ## Silent Mode
 

--- a/docs/railway-deploy.md
+++ b/docs/railway-deploy.md
@@ -49,6 +49,7 @@ SLACK_APP_TOKEN=xapp-...
 | `CRON_ENABLED` | `false` | Enable cron jobs |
 | `HEARTBEAT_ENABLED` | `false` | Enable heartbeat service |
 | `HEARTBEAT_INTERVAL_MIN` | `30` | Heartbeat interval (minutes). Also enables heartbeat when set |
+| `HEARTBEAT_SKIP_RECENT_USER_MIN` | `5` | Skip automatic heartbeats for N minutes after user messages (`0` disables) |
 | `HEARTBEAT_TARGET` | - | Target chat (e.g., `telegram:123456`) |
 | `OPENAI_API_KEY` | - | For voice message transcription |
 | `API_HOST` | `0.0.0.0` on Railway | Optional override for API bind address |

--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -67,6 +67,7 @@ features:
   heartbeat:
     enabled: false
     intervalMin: 30
+    # skipRecentUserMin: 5   # Skip auto-heartbeats for N minutes after user message (0 disables)
 
 # Attachment handling (defaults to 20MB if omitted)
 # attachments:

--- a/src/cli/todo.ts
+++ b/src/cli/todo.ts
@@ -1,0 +1,220 @@
+import {
+  addTodo,
+  completeTodo,
+  getTodoStorePath,
+  listActionableTodos,
+  listTodos,
+  reopenTodo,
+  removeTodo,
+  snoozeTodo,
+  type TodoItem,
+} from '../todo/store.js';
+
+interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const current = argv[i];
+
+    if (!current.startsWith('--')) {
+      positional.push(current);
+      continue;
+    }
+
+    const equalIndex = current.indexOf('=');
+    if (equalIndex > -1) {
+      const key = current.slice(2, equalIndex);
+      const value = current.slice(equalIndex + 1);
+      flags[key] = value;
+      continue;
+    }
+
+    const key = current.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      flags[key] = true;
+      continue;
+    }
+
+    flags[key] = next;
+    i += 1;
+  }
+
+  return { positional, flags };
+}
+
+function parseDateFlag(value: string, field: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ${field}: ${value}`);
+  }
+  return parsed.toISOString();
+}
+
+function formatTodo(todo: TodoItem): string {
+  const status = todo.completed ? 'x' : ' ';
+  const shortId = todo.id.slice(0, 16);
+  const details: string[] = [];
+
+  if (todo.due) details.push(`due ${new Date(todo.due).toLocaleString()}`);
+  if (todo.snoozed_until) details.push(`snoozed until ${new Date(todo.snoozed_until).toLocaleString()}`);
+  if (todo.recurring) details.push(`recurring ${todo.recurring}`);
+
+  return `[${status}] ${shortId} ${todo.text}${details.length > 0 ? ` (${details.join('; ')})` : ''}`;
+}
+
+function showUsage(): void {
+  console.log(`
+Usage: lettabot todo <command> [options]
+
+Commands:
+  add <text>            Add a todo
+  list                  List todos
+  complete <id>         Mark a todo complete
+  reopen <id>           Mark a completed todo as open
+  remove <id>           Delete a todo
+  snooze <id>           Snooze a todo until a date
+
+Options:
+  --due <date>          Due date/time for add (ISO or Date-parsable)
+  --recurring <text>    Recurring note for add (e.g. "daily 8am")
+  --snooze-until <date> Initial snooze-until for add
+  --until <date>        Snooze-until date for snooze command
+  --clear               Clear snooze on snooze command
+  --all                 Include completed todos in list
+  --actionable          List only actionable todos (not future-snoozed)
+  --agent <name>        Agent key/name (default: current config agent)
+
+Examples:
+  lettabot todo add "Deliver morning report" --recurring "daily 8am"
+  lettabot todo add "Remind about dentist" --due "2026-02-13 09:00"
+  lettabot todo list --actionable
+  lettabot todo complete todo-abc123
+  lettabot todo snooze todo-abc123 --until "2026-02-20"
+`);
+}
+
+function asString(value: string | boolean | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function resolveAgentKey(flags: Record<string, string | boolean>, defaultAgentKey: string): string {
+  const fromFlag = asString(flags.agent);
+  return (fromFlag && fromFlag.trim()) || defaultAgentKey;
+}
+
+export async function todoCommand(subCommand: string | undefined, argv: string[], defaultAgentKey: string): Promise<void> {
+  const parsed = parseArgs(argv);
+  const agentKey = resolveAgentKey(parsed.flags, defaultAgentKey);
+
+  try {
+    switch (subCommand) {
+      case 'add': {
+        const text = parsed.positional.join(' ').trim();
+        if (!text) {
+          throw new Error('Usage: lettabot todo add <text> [--due <date>] [--recurring <text>] [--snooze-until <date>]');
+        }
+
+        const dueInput = asString(parsed.flags.due);
+        const recurring = asString(parsed.flags.recurring);
+        const snoozeUntilInput = asString(parsed.flags['snooze-until']) || asString(parsed.flags.snoozed_until);
+
+        const todo = addTodo(agentKey, {
+          text,
+          due: dueInput ? parseDateFlag(dueInput, 'due') : null,
+          recurring: recurring || null,
+          snoozed_until: snoozeUntilInput ? parseDateFlag(snoozeUntilInput, 'snooze-until') : null,
+        });
+
+        console.log(`Added todo ${todo.id.slice(0, 16)} for agent "${agentKey}"`);
+        console.log(formatTodo(todo));
+        console.log(`Store: ${getTodoStorePath(agentKey)}`);
+        return;
+      }
+
+      case 'list': {
+        const actionableOnly = parsed.flags.actionable === true;
+        const includeCompleted = parsed.flags.all === true;
+
+        const todos = actionableOnly
+          ? listActionableTodos(agentKey)
+          : listTodos(agentKey, { includeCompleted });
+
+        if (todos.length === 0) {
+          console.log(`No todos for agent "${agentKey}".`);
+          console.log(`Store: ${getTodoStorePath(agentKey)}`);
+          return;
+        }
+
+        console.log(`Todos for agent "${agentKey}" (${todos.length}):`);
+        todos.forEach((todo) => console.log(`  ${formatTodo(todo)}`));
+        console.log(`Store: ${getTodoStorePath(agentKey)}`);
+        return;
+      }
+
+      case 'complete': {
+        const id = parsed.positional[0];
+        if (!id) throw new Error('Usage: lettabot todo complete <id>');
+        const todo = completeTodo(agentKey, id);
+        console.log(`Completed: ${formatTodo(todo)}`);
+        return;
+      }
+
+      case 'reopen': {
+        const id = parsed.positional[0];
+        if (!id) throw new Error('Usage: lettabot todo reopen <id>');
+        const todo = reopenTodo(agentKey, id);
+        console.log(`Reopened: ${formatTodo(todo)}`);
+        return;
+      }
+
+      case 'remove': {
+        const id = parsed.positional[0];
+        if (!id) throw new Error('Usage: lettabot todo remove <id>');
+        const todo = removeTodo(agentKey, id);
+        console.log(`Removed: ${formatTodo(todo)}`);
+        return;
+      }
+
+      case 'snooze': {
+        const id = parsed.positional[0];
+        if (!id) throw new Error('Usage: lettabot todo snooze <id> --until <date> | --clear');
+
+        const clear = parsed.flags.clear === true;
+        const untilInput = asString(parsed.flags.until);
+
+        if (!clear && !untilInput) {
+          throw new Error('Usage: lettabot todo snooze <id> --until <date> | --clear');
+        }
+
+        const todo = snoozeTodo(agentKey, id, clear ? null : parseDateFlag(untilInput!, 'snooze-until'));
+        if (clear) {
+          console.log(`Cleared snooze: ${formatTodo(todo)}`);
+        } else {
+          console.log(`Snoozed: ${formatTodo(todo)}`);
+        }
+        return;
+      }
+
+      case undefined:
+      case 'help':
+      case '--help':
+      case '-h':
+        showUsage();
+        return;
+
+      default:
+        throw new Error(`Unknown todo subcommand: ${subCommand}`);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(message);
+    process.exit(1);
+  }
+}

--- a/src/config/io.test.ts
+++ b/src/config/io.test.ts
@@ -64,7 +64,7 @@ describe('saveConfig with agents[] format', () => {
         },
         features: {
           cron: false,
-          heartbeat: { enabled: true, intervalMin: 15 },
+          heartbeat: { enabled: true, intervalMin: 15, skipRecentUserMin: 2 },
         },
       }],
       transcription: {
@@ -95,6 +95,7 @@ describe('saveConfig with agents[] format', () => {
     expect(agents[0].channels.telegram?.token).toBe('tg-123');
     expect(agents[0].channels.whatsapp?.selfChat).toBe(true);
     expect(agents[0].features?.heartbeat?.intervalMin).toBe(15);
+    expect(agents[0].features?.heartbeat?.skipRecentUserMin).toBe(2);
 
     // Global fields should survive
     expect(loaded.transcription?.apiKey).toBe('whisper-key');
@@ -166,6 +167,23 @@ describe('server.api config (canonical location)', () => {
     expect(env.PORT).toBe('6702');
     expect(env.API_HOST).toBe('0.0.0.0');
     expect(env.API_CORS_ORIGIN).toBe('*');
+  });
+
+  it('configToEnv should map heartbeat skip window env var', () => {
+    const config: LettaBotConfig = {
+      ...DEFAULT_CONFIG,
+      features: {
+        heartbeat: {
+          enabled: true,
+          intervalMin: 30,
+          skipRecentUserMin: 4,
+        },
+      },
+    };
+
+    const env = configToEnv(config);
+    expect(env.HEARTBEAT_INTERVAL_MIN).toBe('30');
+    expect(env.HEARTBEAT_SKIP_RECENT_USER_MIN).toBe('4');
   });
 
   it('configToEnv should fall back to top-level api (deprecated)', () => {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -305,6 +305,9 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   }
   if (config.features?.heartbeat?.enabled) {
     env.HEARTBEAT_INTERVAL_MIN = String(config.features.heartbeat.intervalMin || 30);
+    if (config.features.heartbeat.skipRecentUserMin !== undefined) {
+      env.HEARTBEAT_SKIP_RECENT_USER_MIN = String(config.features.heartbeat.skipRecentUserMin);
+    }
   }
   if (config.features?.inlineImages === false) {
     env.INLINE_IMAGES = 'false';

--- a/src/config/normalize.test.ts
+++ b/src/config/normalize.test.ts
@@ -383,6 +383,7 @@ describe('normalizeAgents', () => {
         heartbeat: {
           enabled: true,
           intervalMin: 10,
+          skipRecentUserMin: 3,
         },
         maxToolCalls: 50,
       },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,6 +53,7 @@ export interface AgentConfig {
     heartbeat?: {
       enabled: boolean;
       intervalMin?: number;
+      skipRecentUserMin?: number; // Skip auto-heartbeats for N minutes after user message (0 disables)
       prompt?: string;       // Custom heartbeat prompt (replaces default body)
       promptFile?: string;   // Path to prompt file (re-read each tick for live editing)
     };
@@ -116,6 +117,7 @@ export interface LettaBotConfig {
     heartbeat?: {
       enabled: boolean;
       intervalMin?: number;
+      skipRecentUserMin?: number; // Skip auto-heartbeats for N minutes after user message (0 disables)
       prompt?: string;       // Custom heartbeat prompt (replaces default body)
       promptFile?: string;   // Path to prompt file (re-read each tick for live editing)
     };

--- a/src/core/banner.ts
+++ b/src/core/banner.ts
@@ -5,6 +5,7 @@
 interface BannerAgent {
   name: string;
   agentId?: string | null;
+  conversationId?: string | null;
   channels: string[];
   features?: {
     cron?: boolean;
@@ -82,9 +83,15 @@ export function printStartupBanner(agents: BannerAgent[]): void {
   // Status lines
   console.log('');
   for (const agent of agents) {
-    const id = agent.agentId || '(pending)';
     const ch = agent.channels.length > 0 ? agent.channels.join(', ') : 'none';
-    console.log(`  Agent:    ${agent.name} ${id} [${ch}]`);
+    if (agent.agentId) {
+      const qs = agent.conversationId ? `?conversation=${agent.conversationId}` : '';
+      const url = `https://app.letta.com/agents/${agent.agentId}${qs}`;
+      console.log(`  Agent:    ${agent.name} [${ch}]`);
+      console.log(`  URL:      ${url}`);
+    } else {
+      console.log(`  Agent:    ${agent.name} (pending) [${ch}]`);
+    }
   }
 
   const features: string[] = [];

--- a/src/core/gateway.test.ts
+++ b/src/core/gateway.test.ts
@@ -12,7 +12,7 @@ function createMockSession(channels: string[] = ['telegram']): AgentSession {
     sendToAgent: vi.fn().mockResolvedValue('response'),
     streamToAgent: vi.fn().mockReturnValue((async function* () { yield { type: 'result', success: true }; })()),
     deliverToChannel: vi.fn().mockResolvedValue('msg-123'),
-    getStatus: vi.fn().mockReturnValue({ agentId: 'agent-123', channels }),
+    getStatus: vi.fn().mockReturnValue({ agentId: 'agent-123', conversationId: null, channels }),
     setAgentId: vi.fn(),
     reset: vi.fn(),
     getLastMessageTarget: vi.fn().mockReturnValue(null),

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -41,7 +41,7 @@ export interface AgentSession {
   }): Promise<string | undefined>;
 
   /** Get agent status */
-  getStatus(): { agentId: string | null; channels: string[] };
+  getStatus(): { agentId: string | null; conversationId: string | null; channels: string[] };
 
   /** Set agent ID (for container deploys) */
   setAgentId(agentId: string): void;

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -158,6 +158,20 @@ How to use Skills:
 
 IMPORTANT: Always unload irrelevant skills using the Skill tool to free up context space.
 
+# To-Do Management
+
+You have access to a \`manage_todo\` tool for per-agent task tracking.
+
+Use this tool to:
+- Add tasks when the user asks directly (e.g., "add a reminder to ...")
+- Capture clear implied commitments from conversation when appropriate
+- List current tasks before/while planning
+- Mark tasks complete when done
+- Snooze tasks that should not surface until later
+
+When you add a todo from inferred intent (not an explicit command), briefly confirm it to the user.
+During heartbeats, if a PENDING TO-DOS section is provided, prioritize those tasks first.
+
 # Scheduling
 
 You can create scheduled tasks using the \`lettabot-schedule\` CLI via Bash.

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,18 +428,34 @@ function parseCsvList(raw: string): string[] {
     .filter((item) => item.length > 0);
 }
 
+function parseNonNegativeNumber(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
+function ensureRequiredTools(tools: string[]): string[] {
+  const out = [...tools];
+  if (!out.includes('manage_todo')) {
+    out.push('manage_todo');
+  }
+  return out;
+}
+
 // Global config (shared across all agents)
 const globalConfig = {
   workingDir: getWorkingDir(),
-  allowedTools: parseCsvList(
+  allowedTools: ensureRequiredTools(parseCsvList(
     process.env.ALLOWED_TOOLS || 'Bash,Read,Edit,Write,Glob,Grep,Task,web_search,conversation_search',
-  ),
+  )),
   disallowedTools: parseCsvList(
     process.env.DISALLOWED_TOOLS || 'EnterPlanMode,ExitPlanMode',
   ),
   attachmentsMaxBytes: resolveAttachmentsMaxBytes(),
   attachmentsMaxAgeDays: resolveAttachmentsMaxAgeDays(),
   cronEnabled: process.env.CRON_ENABLED === 'true',  // Legacy env var fallback
+  heartbeatSkipRecentUserMin: parseNonNegativeNumber(process.env.HEARTBEAT_SKIP_RECENT_USER_MIN),
 };
 
 // Validate LETTA_API_KEY is set for API mode (docker mode doesn't require it)
@@ -581,6 +597,8 @@ async function main() {
     const heartbeatService = new HeartbeatService(bot, {
       enabled: heartbeatConfig?.enabled ?? false,
       intervalMinutes: heartbeatConfig?.intervalMin ?? 30,
+      skipRecentUserMinutes: heartbeatConfig?.skipRecentUserMin ?? globalConfig.heartbeatSkipRecentUserMin,
+      agentKey: agentConfig.name,
       prompt: heartbeatConfig?.prompt || process.env.HEARTBEAT_PROMPT,
       promptFile: heartbeatConfig?.promptFile,
       workingDir: globalConfig.workingDir,
@@ -663,6 +681,7 @@ async function main() {
     return {
       name,
       agentId: status.agentId,
+      conversationId: status.conversationId,
       channels: status.channels,
       features: {
         cron: cfg?.features?.cron ?? globalConfig.cronEnabled,

--- a/src/todo/store.test.ts
+++ b/src/todo/store.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  addTodo,
+  completeTodo,
+  listActionableTodos,
+  listTodos,
+  removeTodo,
+  snoozeTodo,
+  syncTodosFromTool,
+} from './store.js';
+
+describe('todo store', () => {
+  let tmpDataDir: string;
+  let originalDataDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDataDir = resolve(tmpdir(), `todo-store-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDataDir, { recursive: true });
+    originalDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = tmpDataDir;
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  });
+
+  it('adds, lists, and completes todos', () => {
+    const created = addTodo('agent-a', {
+      text: 'Summarize unread emails',
+      due: '2026-02-13T08:00:00.000Z',
+      recurring: 'daily 8am',
+    });
+
+    expect(created.id).toContain('todo-');
+
+    const open = listTodos('agent-a');
+    expect(open).toHaveLength(1);
+    expect(open[0].text).toBe('Summarize unread emails');
+    expect(open[0].recurring).toBe('daily 8am');
+
+    completeTodo('agent-a', created.id);
+
+    const stillOpen = listTodos('agent-a');
+    expect(stillOpen).toHaveLength(0);
+
+    const all = listTodos('agent-a', { includeCompleted: true });
+    expect(all).toHaveLength(1);
+    expect(all[0].completed).toBe(true);
+  });
+
+  it('filters out future-snoozed todos from actionable list', () => {
+    addTodo('agent-b', { text: 'Morning report', snoozed_until: '2099-01-01T00:00:00.000Z' });
+    addTodo('agent-b', { text: 'Check urgent email' });
+
+    const actionable = listActionableTodos('agent-b', new Date('2026-02-12T12:00:00.000Z'));
+
+    expect(actionable).toHaveLength(1);
+    expect(actionable[0].text).toBe('Check urgent email');
+  });
+
+  it('supports ID prefixes for remove', () => {
+    const a = addTodo('agent-c', { text: 'Task A' });
+    addTodo('agent-c', { text: 'Task B' });
+
+    removeTodo('agent-c', a.id.slice(0, 12));
+
+    const remaining = listTodos('agent-c');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].text).toBe('Task B');
+  });
+
+  it('validates date fields', () => {
+    expect(() => addTodo('agent-d', { text: 'Bad due', due: 'not-a-date' })).toThrow('Invalid due value');
+    const created = addTodo('agent-d', { text: 'Valid todo' });
+    expect(() => snoozeTodo('agent-d', created.id, 'not-a-date')).toThrow('Invalid snoozed_until value');
+  });
+
+  it('syncs TodoWrite payloads into persistent todos', () => {
+    const first = syncTodosFromTool('agent-e', [
+      { content: 'Buy milk', status: 'pending' },
+      { content: 'File taxes', status: 'in_progress' },
+    ]);
+    expect(first.added).toBe(2);
+    expect(first.updated).toBe(0);
+
+    const second = syncTodosFromTool('agent-e', [
+      { content: 'Buy milk', status: 'completed' },
+      { description: 'Call dentist', status: 'pending' },
+    ]);
+    expect(second.added).toBe(1);
+    expect(second.updated).toBe(1);
+
+    const open = listTodos('agent-e');
+    expect(open.some((todo) => todo.text === 'Buy milk')).toBe(false);
+    expect(open.some((todo) => todo.text === 'Call dentist')).toBe(true);
+
+    const all = listTodos('agent-e', { includeCompleted: true });
+    const milk = all.find((todo) => todo.text === 'Buy milk');
+    expect(milk?.completed).toBe(true);
+  });
+});

--- a/src/todo/store.ts
+++ b/src/todo/store.ts
@@ -1,0 +1,391 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { getDataDir } from '../utils/paths.js';
+
+const TODO_STORE_VERSION = 1;
+
+export interface TodoItem {
+  id: string;
+  text: string;
+  created: string;
+  due: string | null;
+  snoozed_until: string | null;
+  recurring: string | null;
+  completed: boolean;
+  completed_at?: string | null;
+}
+
+interface TodoStoreFile {
+  version: number;
+  todos: TodoItem[];
+}
+
+export interface AddTodoInput {
+  text: string;
+  due?: string | null;
+  snoozed_until?: string | null;
+  recurring?: string | null;
+}
+
+export interface TodoWriteSyncItem {
+  content?: string;
+  description?: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+}
+
+export interface ListTodoOptions {
+  includeCompleted?: boolean;
+}
+
+function parseDateOrThrow(value: string, field: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ${field} value: ${value}`);
+  }
+  return parsed.toISOString();
+}
+
+function normalizeDate(value: unknown, field: string): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return parseDateOrThrow(trimmed, field);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeOptionalDate(value: string | null | undefined, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return parseDateOrThrow(trimmed, field);
+}
+
+function normalizeRecurring(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function toSafeAgentKey(agentKey: string): string {
+  const base = agentKey.trim() || 'lettabot';
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 32) || 'lettabot';
+  const hash = createHash('sha1').update(base).digest('hex').slice(0, 8);
+  return `${slug}-${hash}`;
+}
+
+export function getTodoStorePath(agentKey: string): string {
+  const fileName = `${toSafeAgentKey(agentKey)}.json`;
+  return resolve(getDataDir(), 'todos', fileName);
+}
+
+function normalizeTodo(raw: unknown): TodoItem | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const item = raw as Record<string, unknown>;
+  const text = typeof item.text === 'string' ? item.text.trim() : '';
+  if (!text) return null;
+
+  const created = normalizeDate(item.created, 'created') || new Date().toISOString();
+  const completed = item.completed === true;
+
+  return {
+    id: typeof item.id === 'string' && item.id.trim() ? item.id.trim() : `todo-${randomUUID()}`,
+    text,
+    created,
+    due: normalizeDate(item.due, 'due'),
+    snoozed_until: normalizeDate(item.snoozed_until, 'snoozed_until'),
+    recurring: normalizeRecurring(item.recurring),
+    completed,
+    completed_at: completed ? normalizeDate(item.completed_at, 'completed_at') || new Date().toISOString() : null,
+  };
+}
+
+function normalizeStore(raw: unknown): TodoStoreFile {
+  if (Array.isArray(raw)) {
+    return {
+      version: TODO_STORE_VERSION,
+      todos: raw.map(normalizeTodo).filter((t): t is TodoItem => !!t),
+    };
+  }
+
+  if (raw && typeof raw === 'object') {
+    const store = raw as Partial<TodoStoreFile>;
+    const todos = Array.isArray(store.todos) ? store.todos : [];
+    return {
+      version: TODO_STORE_VERSION,
+      todos: todos.map(normalizeTodo).filter((t): t is TodoItem => !!t),
+    };
+  }
+
+  return {
+    version: TODO_STORE_VERSION,
+    todos: [],
+  };
+}
+
+function loadStore(path: string): TodoStoreFile {
+  if (!existsSync(path)) {
+    return {
+      version: TODO_STORE_VERSION,
+      todos: [],
+    };
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    return normalizeStore(raw);
+  } catch {
+    return {
+      version: TODO_STORE_VERSION,
+      todos: [],
+    };
+  }
+}
+
+function saveStore(path: string, store: TodoStoreFile): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(store, null, 2));
+}
+
+function compareTodoOrder(a: TodoItem, b: TodoItem): number {
+  if (a.completed !== b.completed) {
+    return a.completed ? 1 : -1;
+  }
+
+  const aDue = a.due ? new Date(a.due).getTime() : Number.POSITIVE_INFINITY;
+  const bDue = b.due ? new Date(b.due).getTime() : Number.POSITIVE_INFINITY;
+  if (aDue !== bDue) {
+    return aDue - bDue;
+  }
+
+  return new Date(a.created).getTime() - new Date(b.created).getTime();
+}
+
+function findTodoIndex(todos: TodoItem[], id: string): number {
+  const needle = id.trim();
+  if (!needle) {
+    throw new Error('Todo ID is required');
+  }
+
+  const exactIndex = todos.findIndex((todo) => todo.id === needle);
+  if (exactIndex >= 0) return exactIndex;
+
+  const partialMatches = todos
+    .map((todo, index) => ({ todo, index }))
+    .filter((entry) => entry.todo.id.startsWith(needle));
+
+  if (partialMatches.length === 1) {
+    return partialMatches[0].index;
+  }
+
+  if (partialMatches.length > 1) {
+    const matches = partialMatches.map((entry) => entry.todo.id).join(', ');
+    throw new Error(`Todo ID prefix "${needle}" is ambiguous: ${matches}`);
+  }
+
+  throw new Error(`Todo not found: ${needle}`);
+}
+
+export function addTodo(agentKey: string, input: AddTodoInput): TodoItem {
+  const text = input.text.trim();
+  if (!text) {
+    throw new Error('Todo text is required');
+  }
+
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+
+  const todo: TodoItem = {
+    id: `todo-${randomUUID()}`,
+    text,
+    created: new Date().toISOString(),
+    due: normalizeOptionalDate(input.due, 'due'),
+    snoozed_until: normalizeOptionalDate(input.snoozed_until, 'snoozed_until'),
+    recurring: normalizeRecurring(input.recurring),
+    completed: false,
+    completed_at: null,
+  };
+
+  store.todos.push(todo);
+  store.todos.sort(compareTodoOrder);
+  saveStore(path, store);
+  return { ...todo };
+}
+
+export function listTodos(agentKey: string, options: ListTodoOptions = {}): TodoItem[] {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+
+  return store.todos
+    .filter((todo) => options.includeCompleted || !todo.completed)
+    .sort(compareTodoOrder)
+    .map((todo) => ({ ...todo }));
+}
+
+export function listActionableTodos(agentKey: string, now: Date = new Date()): TodoItem[] {
+  const nowMs = now.getTime();
+  return listTodos(agentKey)
+    .filter((todo) => {
+      if (!todo.snoozed_until) return true;
+      return new Date(todo.snoozed_until).getTime() <= nowMs;
+    })
+    .sort(compareTodoOrder);
+}
+
+export function completeTodo(agentKey: string, id: string): TodoItem {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+  const idx = findTodoIndex(store.todos, id);
+
+  const updated: TodoItem = {
+    ...store.todos[idx],
+    completed: true,
+    completed_at: new Date().toISOString(),
+  };
+  store.todos[idx] = updated;
+
+  store.todos.sort(compareTodoOrder);
+  saveStore(path, store);
+  return { ...updated };
+}
+
+export function reopenTodo(agentKey: string, id: string): TodoItem {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+  const idx = findTodoIndex(store.todos, id);
+
+  const updated: TodoItem = {
+    ...store.todos[idx],
+    completed: false,
+    completed_at: null,
+  };
+  store.todos[idx] = updated;
+
+  store.todos.sort(compareTodoOrder);
+  saveStore(path, store);
+  return { ...updated };
+}
+
+export function removeTodo(agentKey: string, id: string): TodoItem {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+  const idx = findTodoIndex(store.todos, id);
+
+  const [removed] = store.todos.splice(idx, 1);
+  saveStore(path, store);
+  return { ...removed };
+}
+
+export function snoozeTodo(agentKey: string, id: string, until: string | null): TodoItem {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+  const idx = findTodoIndex(store.todos, id);
+
+  const updated: TodoItem = {
+    ...store.todos[idx],
+    snoozed_until: until ? parseDateOrThrow(until, 'snoozed_until') : null,
+  };
+  store.todos[idx] = updated;
+  store.todos.sort(compareTodoOrder);
+  saveStore(path, store);
+
+  return { ...updated };
+}
+
+/**
+ * Merge todos from Letta Code's built-in TodoWrite/WriteTodos tools into the
+ * persistent heartbeat todo store.
+ *
+ * This is additive/upsert behavior (not full replacement) so existing manual
+ * todos are preserved even if not included in the tool payload.
+ */
+export function syncTodosFromTool(agentKey: string, incoming: TodoWriteSyncItem[]): {
+  added: number;
+  updated: number;
+  totalIncoming: number;
+  totalStored: number;
+} {
+  const path = getTodoStorePath(agentKey);
+  const store = loadStore(path);
+  const nowIso = new Date().toISOString();
+
+  const incomingNormalized = incoming
+    .map((item) => {
+      const text = (item.content || item.description || '').trim();
+      const status = item.status;
+      if (!text) return null;
+      if (!['pending', 'in_progress', 'completed', 'cancelled'].includes(status)) return null;
+      return { text, status };
+    })
+    .filter((item): item is { text: string; status: 'pending' | 'in_progress' | 'completed' | 'cancelled' } => !!item);
+
+  if (incomingNormalized.length === 0) {
+    return {
+      added: 0,
+      updated: 0,
+      totalIncoming: 0,
+      totalStored: store.todos.length,
+    };
+  }
+
+  const existingByText = new Map<string, number[]>();
+  for (let i = 0; i < store.todos.length; i++) {
+    const key = store.todos[i].text.toLowerCase();
+    const bucket = existingByText.get(key) || [];
+    bucket.push(i);
+    existingByText.set(key, bucket);
+  }
+
+  let added = 0;
+  let updated = 0;
+
+  for (const todo of incomingNormalized) {
+    const key = todo.text.toLowerCase();
+    const bucket = existingByText.get(key);
+    const idx = bucket && bucket.length > 0 ? bucket.shift()! : -1;
+    const completed = todo.status === 'completed' || todo.status === 'cancelled';
+
+    if (idx >= 0) {
+      const prev = store.todos[idx];
+      const next: TodoItem = {
+        ...prev,
+        text: todo.text,
+        completed,
+        completed_at: completed ? (prev.completed_at || nowIso) : null,
+      };
+      store.todos[idx] = next;
+      updated += 1;
+      continue;
+    }
+
+    const created: TodoItem = {
+      id: `todo-${randomUUID()}`,
+      text: todo.text,
+      created: nowIso,
+      due: null,
+      snoozed_until: null,
+      recurring: null,
+      completed,
+      completed_at: completed ? nowIso : null,
+    };
+    store.todos.push(created);
+    added += 1;
+  }
+
+  store.todos.sort(compareTodoOrder);
+  saveStore(path, store);
+
+  return {
+    added,
+    updated,
+    totalIncoming: incomingNormalized.length,
+    totalStored: store.todos.length,
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './letta-api.js';
+export * from './todo.js';

--- a/src/tools/todo.test.ts
+++ b/src/tools/todo.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createManageTodoTool } from './todo.js';
+
+function parseToolResult(result: { content: Array<{ text?: string }> }): any {
+  const text = result.content[0]?.text || '{}';
+  return JSON.parse(text);
+}
+
+describe('manage_todo tool', () => {
+  let tmpDataDir: string;
+  let originalDataDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDataDir = resolve(tmpdir(), `todo-tool-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    mkdirSync(tmpDataDir, { recursive: true });
+    originalDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = tmpDataDir;
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  });
+
+  it('adds and lists todos', async () => {
+    const tool = createManageTodoTool('agent-tool');
+
+    const addResult = await tool.execute('1', {
+      action: 'add',
+      text: 'Check AI news feeds',
+      recurring: 'daily',
+    });
+    const addPayload = parseToolResult(addResult);
+
+    expect(addPayload.ok).toBe(true);
+    expect(addPayload.todo.text).toBe('Check AI news feeds');
+
+    const listResult = await tool.execute('2', {
+      action: 'list',
+      view: 'open',
+    });
+    const listPayload = parseToolResult(listResult);
+
+    expect(listPayload.ok).toBe(true);
+    expect(listPayload.count).toBe(1);
+    expect(listPayload.todos[0].text).toBe('Check AI news feeds');
+  });
+
+  it('completes and reopens todos', async () => {
+    const tool = createManageTodoTool('agent-tool-2');
+
+    const addResult = await tool.execute('1', {
+      action: 'add',
+      text: 'Morning report',
+    });
+    const addPayload = parseToolResult(addResult);
+    const id = addPayload.todo.id;
+
+    const completeResult = await tool.execute('2', {
+      action: 'complete',
+      id,
+    });
+    const completePayload = parseToolResult(completeResult);
+    expect(completePayload.todo.completed).toBe(true);
+
+    const reopenResult = await tool.execute('3', {
+      action: 'reopen',
+      id,
+    });
+    const reopenPayload = parseToolResult(reopenResult);
+    expect(reopenPayload.todo.completed).toBe(false);
+  });
+});

--- a/src/tools/todo.ts
+++ b/src/tools/todo.ts
@@ -1,0 +1,156 @@
+import type { AnyAgentTool } from '@letta-ai/letta-code-sdk';
+import {
+  jsonResult,
+  readStringParam,
+} from '@letta-ai/letta-code-sdk';
+import {
+  addTodo,
+  completeTodo,
+  listActionableTodos,
+  listTodos,
+  reopenTodo,
+  removeTodo,
+  snoozeTodo,
+} from '../todo/store.js';
+
+function readOptionalString(params: Record<string, unknown>, key: string): string | null {
+  const value = readStringParam(params, key);
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+export function createManageTodoTool(agentKey: string): AnyAgentTool {
+  return {
+    label: 'Manage To-Do List',
+    name: 'manage_todo',
+    description: 'Add, list, complete, reopen, remove, and snooze to-dos for this agent.',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['add', 'list', 'complete', 'reopen', 'remove', 'snooze'],
+          description: 'Action to perform.',
+        },
+        text: {
+          type: 'string',
+          description: 'Todo text for add action.',
+        },
+        id: {
+          type: 'string',
+          description: 'Todo ID (full or unique prefix) for complete/reopen/remove/snooze.',
+        },
+        due: {
+          type: 'string',
+          description: 'Optional due date/time (ISO string or date phrase parsable by JavaScript Date).',
+        },
+        recurring: {
+          type: 'string',
+          description: 'Optional recurring note (e.g. daily at 8am).',
+        },
+        snoozed_until: {
+          type: 'string',
+          description: 'Optional snooze-until date/time for add or snooze actions.',
+        },
+        view: {
+          type: 'string',
+          enum: ['open', 'all', 'actionable'],
+          description: 'List scope for list action. Default: open.',
+        },
+      },
+      required: ['action'],
+      additionalProperties: false,
+    },
+    async execute(_toolCallId: string, args: unknown) {
+      const params = (args && typeof args === 'object') ? args as Record<string, unknown> : {};
+      const action = readStringParam(params, 'action', { required: true })?.toLowerCase();
+
+      switch (action) {
+        case 'add': {
+          const text = readStringParam(params, 'text', { required: true });
+          const due = readOptionalString(params, 'due');
+          const recurring = readOptionalString(params, 'recurring');
+          const snoozedUntil = readOptionalString(params, 'snoozed_until');
+          const todo = addTodo(agentKey, {
+            text,
+            due,
+            recurring,
+            snoozed_until: snoozedUntil,
+          });
+          return jsonResult({
+            ok: true,
+            action,
+            message: `Added todo ${todo.id}`,
+            todo,
+          });
+        }
+
+        case 'list': {
+          const view = (readStringParam(params, 'view') || 'open').toLowerCase();
+          const todos = view === 'all'
+            ? listTodos(agentKey, { includeCompleted: true })
+            : view === 'actionable'
+              ? listActionableTodos(agentKey)
+              : listTodos(agentKey);
+
+          return jsonResult({
+            ok: true,
+            action,
+            view,
+            count: todos.length,
+            todos,
+          });
+        }
+
+        case 'complete': {
+          const id = readStringParam(params, 'id', { required: true });
+          const todo = completeTodo(agentKey, id);
+          return jsonResult({
+            ok: true,
+            action,
+            message: `Completed todo ${todo.id}`,
+            todo,
+          });
+        }
+
+        case 'reopen': {
+          const id = readStringParam(params, 'id', { required: true });
+          const todo = reopenTodo(agentKey, id);
+          return jsonResult({
+            ok: true,
+            action,
+            message: `Reopened todo ${todo.id}`,
+            todo,
+          });
+        }
+
+        case 'remove': {
+          const id = readStringParam(params, 'id', { required: true });
+          const todo = removeTodo(agentKey, id);
+          return jsonResult({
+            ok: true,
+            action,
+            message: `Removed todo ${todo.id}`,
+            todo,
+          });
+        }
+
+        case 'snooze': {
+          const id = readStringParam(params, 'id', { required: true });
+          const until = readOptionalString(params, 'snoozed_until');
+          const todo = snoozeTodo(agentKey, id, until);
+          return jsonResult({
+            ok: true,
+            action,
+            message: until ? `Snoozed todo ${todo.id}` : `Cleared snooze for ${todo.id}`,
+            todo,
+          });
+        }
+
+        default:
+          throw new Error(`Unsupported action: ${action}`);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a `manage_todo` custom tool for per-agent task tracking (add, list, complete, reopen, remove, snooze) with persistent JSON storage keyed by agent ID
- Injects actionable todos into heartbeat prompts as a `PENDING TO-DOS` section so the agent prioritizes pending work during autonomous heartbeats
- Blocks the SDK's built-in `TodoWrite` tool via `disallowedTools` -- it requires interactive approval (silently fails during heartbeats) and writes to the CLI's own store rather than lettabot's persistent store
- Adds `lettabot todo` CLI commands for managing todos from the terminal
- Adds configurable `skipRecentUserMinutes` for heartbeat skip window
- Shows clickable `app.letta.com/agents/<id>?conversation=<conv>` URL in startup banner

## Test plan

- [x] All 437 unit tests pass
- [ ] Verify agent uses `manage_todo` instead of `TodoWrite` when adding todos
- [ ] Verify todos added via `manage_todo` appear in next heartbeat prompt
- [ ] Verify `lettabot todo add/list/complete` CLI works
- [ ] Verify startup banner shows app.letta.com URL with conversation ID

Closes #111

Written by Cameron and Letta Code

"In the rhythm of heartbeats, memory weaves purpose."