### PR TITLE
Auto-bind to 0.0.0.0 on container platforms for health checks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -666,7 +666,7 @@ async function main() {
 
   // Start API server - uses gateway for delivery
   const apiPort = parseInt(process.env.PORT || '8080', 10);
-  const apiHost = process.env.API_HOST; // undefined = 127.0.0.1 (secure default)
+  const apiHost = process.env.API_HOST || (isContainerDeploy ? '0.0.0.0' : undefined); // Container platforms need 0.0.0.0 for health checks
   const apiCorsOrigin = process.env.API_CORS_ORIGIN; // undefined = same-origin only
   const apiServer = createApiServer(gateway, {
     port: apiPort,


### PR DESCRIPTION
## Summary

- When deploying to Railway (and other container platforms like Render, Fly), the API server binds to `127.0.0.1` by default, which prevents external health check probes from reaching the `/health` endpoint. This causes deployments to fail with health check timeouts.
- This leverages the existing `isContainerDeploy` detection (`RAILWAY_ENVIRONMENT`, `RENDER`, `FLY_APP_NAME`, `DOCKER_DEPLOY`) to automatically bind to `0.0.0.0` on container platforms, while preserving the secure localhost default for local development.
- `API_HOST` env var still takes precedence if explicitly set.

## The change

One line in `src/main.ts`:

```diff
- const apiHost = process.env.API_HOST; // undefined = 127.0.0.1 (secure default)
+ const apiHost = process.env.API_HOST || (isContainerDeploy ? '0.0.0.0' : undefined); // Container platforms need 0.0.0.0 for health checks
```

## Test plan

- [x] Verified fix on Railway: deployment went from FAILED (3 consecutive) to SUCCESS after this change
- [ ] Local development still binds to 127.0.0.1 (no `RAILWAY_ENVIRONMENT` set)
- [ ] Explicit `API_HOST` env var still overrides the auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)