### PR TITLE
fix: read heartbeat target from per-agent config

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -56,6 +56,7 @@ export interface AgentConfig {
       skipRecentUserMin?: number; // Skip auto-heartbeats for N minutes after user message (0 disables)
       prompt?: string;       // Custom heartbeat prompt (replaces default body)
       promptFile?: string;   // Path to prompt file (re-read each tick for live editing)
+      target?: string;       // Delivery target ("telegram:123", "slack:C123", etc.)
     };
     maxToolCalls?: number;
   };
@@ -120,6 +121,7 @@ export interface LettaBotConfig {
       skipRecentUserMin?: number; // Skip auto-heartbeats for N minutes after user message (0 disables)
       prompt?: string;       // Custom heartbeat prompt (replaces default body)
       promptFile?: string;   // Path to prompt file (re-read each tick for live editing)
+      target?: string;       // Delivery target ("telegram:123", "slack:C123", etc.)
     };
     inlineImages?: boolean;   // Send images directly to the LLM (default: true). Set false to only send file paths.
     maxToolCalls?: number;  // Abort if agent calls this many tools in one turn (default: 100)

--- a/src/main.ts
+++ b/src/main.ts
@@ -605,7 +605,7 @@ async function main() {
       prompt: heartbeatConfig?.prompt || process.env.HEARTBEAT_PROMPT,
       promptFile: heartbeatConfig?.promptFile,
       workingDir: globalConfig.workingDir,
-      target: parseHeartbeatTarget(process.env.HEARTBEAT_TARGET),
+      target: parseHeartbeatTarget(heartbeatConfig?.target) || parseHeartbeatTarget(process.env.HEARTBEAT_TARGET),
     });
     if (heartbeatConfig?.enabled) {
       heartbeatService.start();


### PR DESCRIPTION
## Summary

- Heartbeat `target` was only read from `HEARTBEAT_TARGET` env var, so all agents shared the same delivery target
- Now reads from per-agent config first (`features.heartbeat.target`), with env var fallback for backwards compatibility
- Added `target?: string` field to both heartbeat config types in `types.ts`

### Config example

```yaml
agents:
  - name: work-bot
    features:
      heartbeat:
        enabled: true
        intervalMin: 30
        target: "slack:C1234567890"
  - name: personal-bot
    features:
      heartbeat:
        enabled: true
        target: "telegram:123456789"
```

Fixes #221

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` passes (2 pre-existing failures in normalize.test.ts)
- [ ] Verify heartbeat fires to per-agent target when configured
- [ ] Verify env var fallback still works when no per-agent target set

Written by Cameron and Letta Code

"Do not wait to strike till the iron is hot, but make it hot by striking." -- William Butler Yeats