### PR TITLE
feat: show version and commit hash in startup banner

### DIFF
--- a/src/core/banner.ts
+++ b/src/core/banner.ts
@@ -2,6 +2,30 @@
  * Startup banner with LETTABOT block text and loom ASCII art.
  */
 
+import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+/** Read version from package.json and git commit hash. */
+function getVersionString(): string {
+  let version = 'unknown';
+  try {
+    const pkg = require('../../package.json');
+    version = pkg.version || version;
+  } catch {}
+
+  let commit = '';
+  try {
+    commit = execSync('git rev-parse --short HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {}
+
+  return commit ? `v${version} (${commit})` : `v${version}`;
+}
+
 interface BannerAgent {
   name: string;
   agentId?: string | null;
@@ -81,7 +105,9 @@ export function printStartupBanner(agents: BannerAgent[]): void {
   }
 
   // Status lines
+  const versionStr = getVersionString();
   console.log('');
+  console.log(`  Version:  ${versionStr}`);
   for (const agent of agents) {
     const ch = agent.channels.length > 0 ? agent.channels.join(', ') : 'none';
     if (agent.agentId) {


### PR DESCRIPTION
## Summary
- Adds a `Version:` line to the boot status section showing the package.json version and short git commit hash (e.g. `v0.2.0 (b79d705)`)
- Uses `createRequire` + `execSync` with try/catch wrappers so it degrades gracefully in environments without git or when package.json isn't resolvable
- Single file change to `src/core/banner.ts`, no new dependencies

## Test plan
- [ ] Run `npm run dev` and verify the `Version:  v0.2.0 (4c5cf27)` line appears in the boot banner between the loom box and Agent lines
- [ ] Verify it compiles cleanly with `npx tsc --noEmit`
- [ ] Test graceful degradation: temporarily break the git command path and confirm it falls back to `v0.2.0` without a hash

Written by Cameron and Letta Code

"The version is the fingerprint of the weave." -- lettabot