### PR TITLE
fix: expose WhatsApp/Signal connection fields in per-agent config

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -228,6 +228,7 @@ export interface SlackConfig {
 
 export interface WhatsAppConfig {
   enabled: boolean;
+  sessionPath?: string;   // Auth/session directory (default: ./data/whatsapp-session)
   selfChat?: boolean;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
@@ -244,6 +245,9 @@ export interface WhatsAppConfig {
 export interface SignalConfig {
   enabled: boolean;
   phone?: string;
+  cliPath?: string;     // Path to signal-cli binary (default: "signal-cli")
+  httpHost?: string;    // Daemon HTTP host (default: "127.0.0.1")
+  httpPort?: number;    // Daemon HTTP port (default: 8090)
   selfChat?: boolean;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,7 +344,7 @@ function createChannelsForAgent(
       console.warn('[WhatsApp] Only use this if this is a dedicated bot number, not your personal WhatsApp.');
     }
     adapters.push(new WhatsAppAdapter({
-      sessionPath: process.env.WHATSAPP_SESSION_PATH || './data/whatsapp-session',
+      sessionPath: agentConfig.channels.whatsapp.sessionPath || process.env.WHATSAPP_SESSION_PATH || './data/whatsapp-session',
       dmPolicy: agentConfig.channels.whatsapp.dmPolicy || 'pairing',
       allowedUsers: agentConfig.channels.whatsapp.allowedUsers && agentConfig.channels.whatsapp.allowedUsers.length > 0
         ? agentConfig.channels.whatsapp.allowedUsers
@@ -365,9 +365,9 @@ function createChannelsForAgent(
     }
     adapters.push(new SignalAdapter({
       phoneNumber: agentConfig.channels.signal.phone,
-      cliPath: process.env.SIGNAL_CLI_PATH || 'signal-cli',
-      httpHost: process.env.SIGNAL_HTTP_HOST || '127.0.0.1',
-      httpPort: parseInt(process.env.SIGNAL_HTTP_PORT || '8090', 10),
+      cliPath: agentConfig.channels.signal.cliPath || process.env.SIGNAL_CLI_PATH || 'signal-cli',
+      httpHost: agentConfig.channels.signal.httpHost || process.env.SIGNAL_HTTP_HOST || '127.0.0.1',
+      httpPort: agentConfig.channels.signal.httpPort || parseInt(process.env.SIGNAL_HTTP_PORT || '8090', 10),
       dmPolicy: agentConfig.channels.signal.dmPolicy || 'pairing',
       allowedUsers: agentConfig.channels.signal.allowedUsers && agentConfig.channels.signal.allowedUsers.length > 0
         ? agentConfig.channels.signal.allowedUsers


### PR DESCRIPTION
## Summary

- WhatsApp `sessionPath` and Signal `cliPath`/`httpHost`/`httpPort` were only readable from env vars -- multi-agent setups collide on shared paths and ports
- Now configurable per-agent in YAML, with env var fallback for backwards compat

### Config example

```yaml
agents:
  - name: work-bot
    channels:
      whatsapp:
        enabled: true
        sessionPath: "./data/work-bot/whatsapp-session"
      signal:
        phone: "+1234567890"
        httpPort: 8090
  - name: personal-bot
    channels:
      whatsapp:
        enabled: true
        sessionPath: "./data/personal-bot/whatsapp-session"
      signal:
        phone: "+0987654321"
        httpPort: 8091
```

Fixes #220

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` passes (2 pre-existing failures in normalize.test.ts)
- [ ] Verify WhatsApp sessionPath from config takes priority over env var
- [ ] Verify Signal httpPort from config takes priority over env var
- [ ] Verify env var fallback still works when config fields omitted

Written by Cameron and Letta Code

"The secret of getting ahead is getting started." -- Mark Twain