### PR TITLE
feat: display tool calls and reasoning in channel output

### DIFF
--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -74,6 +74,10 @@ features:
     intervalMin: 30
     # skipRecentUserMin: 5   # Skip auto-heartbeats for N minutes after user message (0 disables)
   # memfs: true   # Enable memory filesystem (git-backed context repository). Syncs memory blocks to local files.
+  # display:
+  #   showToolCalls: false       # Show tool invocations in chat (e.g. "Using tool: Read (file_path: ...)")
+  #   showReasoning: false       # Show agent reasoning/thinking in chat
+  #   reasoningMaxChars: 0        # Truncate reasoning to N chars (0 = no limit, default)
 
 # Attachment handling (defaults to 20MB if omitted)
 # attachments:

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -26,6 +26,18 @@ export function serverModeLabel(mode?: ServerMode): string {
 }
 
 /**
+ * Display configuration for tool calls and reasoning in channel output.
+ */
+export interface DisplayConfig {
+  /** Show tool invocations in channel output (default: false) */
+  showToolCalls?: boolean;
+  /** Show agent reasoning/thinking in channel output (default: false) */
+  showReasoning?: boolean;
+  /** Truncate reasoning to N characters (default: 0 = no limit) */
+  reasoningMaxChars?: number;
+}
+
+/**
  * Configuration for a single agent in multi-agent mode.
  * Each agent has its own name, channels, and features.
  */
@@ -65,6 +77,7 @@ export interface AgentConfig {
     };
     memfs?: boolean;          // Enable memory filesystem (git-backed context repository) for SDK sessions
     maxToolCalls?: number;
+    display?: DisplayConfig;
   };
   /** Polling config */
   polling?: PollingYamlConfig;
@@ -138,6 +151,7 @@ export interface LettaBotConfig {
     inlineImages?: boolean;   // Send images directly to the LLM (default: true). Set false to only send file paths.
     memfs?: boolean;          // Enable memory filesystem (git-backed context repository) for SDK sessions
     maxToolCalls?: number;  // Abort if agent calls this many tools in one turn (default: 100)
+    display?: DisplayConfig;  // Show tool calls / reasoning in channel output
   };
 
   // Polling - system-level background checks (Gmail, etc.)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -128,6 +128,11 @@ export interface BotConfig {
 
   // Display
   displayName?: string; // Prefix outbound messages (e.g. "💜 Signo")
+  display?: {
+    showToolCalls?: boolean;      // Show tool invocations in channel output
+    showReasoning?: boolean;      // Show agent reasoning/thinking in channel output
+    reasoningMaxChars?: number;   // Truncate reasoning to N chars (default: 0 = no limit)
+  };
 
   // Skills
   skills?: SkillsConfig;

--- a/src/main.ts
+++ b/src/main.ts
@@ -531,6 +531,7 @@ async function main() {
       displayName: agentConfig.displayName,
       maxToolCalls: agentConfig.features?.maxToolCalls,
       memfs: resolvedMemfs,
+      display: agentConfig.features?.display,
       conversationMode: agentConfig.conversations?.mode || 'shared',
       heartbeatConversation: agentConfig.conversations?.heartbeat || 'last-active',
       skills: {


### PR DESCRIPTION
## Summary

- Adds configurable display of agent tool invocations and reasoning/thinking blocks directly in channel messages (Telegram, Slack, Discord, etc.)
- Both features are **off by default** and controlled via the `features.display` config section
- Tool calls render as `> **Tool:** name (key: value, ...)` with abbreviated parameters
- Reasoning blocks accumulate during streaming and flush as blockquotes when the stream transitions to the next message type
- Reasoning can be truncated via `reasoningMaxChars` to avoid flooding channels

### Config example

```yaml
features:
  display:
    showToolCalls: true
    showReasoning: true
    reasoningMaxChars: 500
```

### Files changed

- `src/config/types.ts` -- `DisplayConfig` interface + wired into `AgentConfig.features` and `LettaBotConfig.features`
- `src/core/types.ts` -- Added `display` to `BotConfig`
- `src/core/bot.ts` -- Streaming loop integration: reasoning buffer, tool call display, three new helpers (`formatToolCallDisplay`, `abbreviateToolInput`, `formatReasoningDisplay`)
- `src/main.ts` -- Wire `features.display` into LettaBot constructor
- `lettabot.example.yaml` -- Documented config options (commented out)

### Known limitation

Full tool call visibility requires [letta-code-sdk #38](https://github.com/letta-ai/letta-code-sdk/pull/38) to be merged -- the SDK currently drops `approval_request_message` events from the stream, so tools that go through the approval flow won't emit `tool_call` events until that fix lands.

Closes #48

## Test plan

- [ ] Enable `showToolCalls: true` and verify tool invocations appear in channel
- [ ] Enable `showReasoning: true` and verify reasoning blocks appear as blockquotes
- [ ] Test `reasoningMaxChars` truncation
- [ ] Verify both default to off (no display when config omitted)
- [ ] Verify suppression during listen mode (suppressDelivery guard)
- [ ] Test with SDK #38 merged to confirm approval_request_message tool calls display

Written by Cameron and Letta Code

"The real voyage of discovery consists not in seeking new landscapes,
but in having new eyes." -- Marcel Proust