### PR TITLE
Add send-file directive and Discord/CLI file support

### DIFF
--- a/docs/cli-tools.md
+++ b/docs/cli-tools.md
@@ -10,6 +10,7 @@ Send a message to the most recent chat, or target a specific channel/chat.
 ```bash
 lettabot-message send --text "Hello from a background task"
 lettabot-message send --text "Hello" --channel slack --chat C123456
+lettabot-message send --file /tmp/report.pdf --text "Report attached" --channel discord --chat 123456789
 ```
 
 ## lettabot-react
@@ -34,3 +35,4 @@ Notes:
 - History fetch is not supported by the Telegram Bot API, Signal, or WhatsApp.
 - If you omit `--channel` or `--chat`, the CLI falls back to the last message target stored in `lettabot-agent.json`.
 - You need the channel-specific bot token set (`DISCORD_BOT_TOKEN` or `SLACK_BOT_TOKEN`).
+- File sending uses the API server and requires `LETTABOT_API_KEY` (supported: telegram, slack, discord, whatsapp).

--- a/docs/directives.md
+++ b/docs/directives.md
@@ -41,6 +41,20 @@ Adds an emoji reaction to a message.
   - Unicode emoji: direct characters like `👍`
 - `message` (optional) -- Target message ID. Defaults to the message that triggered the response.
 
+### `<send-file>`
+
+Sends a file or image to the same channel/chat as the triggering message.
+
+```xml
+<send-file path="/tmp/report.pdf" caption="Report attached" />
+<send-file path="/tmp/photo.png" kind="image" caption="Look!" />
+```
+
+**Attributes:**
+- `path` / `file` (required) -- Local file path on the LettaBot server
+- `caption` / `text` (optional) -- Caption text for the file
+- `kind` (optional) -- `image` or `file` (defaults to auto-detect based on extension)
+
 ### `<no-reply/>`
 
 Suppresses response delivery entirely. The agent's text is discarded.
@@ -66,13 +80,13 @@ Backslash-escaped quotes (common when LLMs generate XML inside a JSON context) a
 
 ## Channel Support
 
-| Channel   | `addReaction` | Notes |
-|-----------|:---:|-------|
-| Telegram  | Yes | Limited to Telegram's [allowed reaction set](https://core.telegram.org/bots/api#reactiontype) (~75 emoji) |
-| Slack     | Yes | Uses Slack emoji names (`:thumbsup:` style). Custom workspace emoji supported. |
-| Discord   | Yes | Unicode emoji and common aliases. Custom server emoji not yet supported. |
-| WhatsApp  | No  | Directive is skipped with a warning |
-| Signal    | No  | Directive is skipped with a warning |
+| Channel   | `addReaction` | `send-file` | Notes |
+|-----------|:---:|:---:|-------|
+| Telegram  | Yes | Yes | Reactions limited to Telegram's [allowed reaction set](https://core.telegram.org/bots/api#reactiontype). |
+| Slack     | Yes | Yes | Reactions use Slack emoji names (`:thumbsup:` style). |
+| Discord   | Yes | Yes | Custom server emoji not yet supported. |
+| WhatsApp  | No  | Yes | Reactions skipped with a warning. |
+| Signal    | No  | No  | Directive skipped with a warning. |
 
 When a channel doesn't implement `addReaction`, the directive is silently skipped and a warning is logged. This never blocks message delivery.
 
@@ -112,7 +126,7 @@ The parser (`src/core/directives.ts`) is designed to be extensible. Adding a new
 3. Add a parsing case in `parseChildDirectives()`
 4. Add an execution case in `executeDirectives()` in `bot.ts`
 
-See issue [#240](https://github.com/letta-ai/lettabot/issues/240) for planned directives like `<send-file>`.
+See issue [#240](https://github.com/letta-ai/lettabot/issues/240) for planned directives.
 
 ## Source
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -12,6 +12,7 @@ import { isUserAllowed, upsertPairingRequest } from '../pairing/store.js';
 import { buildAttachmentPath, downloadToFile } from './attachments.js';
 import { HELP_TEXT } from '../core/commands.js';
 import { isGroupAllowed, isGroupUserAllowed, resolveGroupMode, resolveReceiveBotMessages, type GroupModeConfig } from './group-mode.js';
+import { basename } from 'node:path';
 
 // Dynamic import to avoid requiring Discord deps if not used
 let Client: typeof import('discord.js').Client;
@@ -344,6 +345,23 @@ Ask the bot owner to approve with:
     }
 
     const result = await (channel as { send: (content: string) => Promise<{ id: string }> }).send(msg.text);
+    return { messageId: result.id };
+  }
+
+  async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
+    if (!this.client) throw new Error('Discord not started');
+    const channel = await this.client.channels.fetch(file.chatId);
+    if (!channel || !channel.isTextBased() || !('send' in channel)) {
+      throw new Error(`Discord channel not found or not text-based: ${file.chatId}`);
+    }
+
+    const payload = {
+      content: file.caption || undefined,
+      files: [
+        { attachment: file.filePath, name: basename(file.filePath) },
+      ],
+    };
+    const result = await (channel as { send: (options: typeof payload) => Promise<{ id: string }> }).send(payload);
     return { messageId: result.id };
   }
 

--- a/src/cli/message.ts
+++ b/src/cli/message.ts
@@ -254,6 +254,7 @@ async function sendCommand(args: string[]): Promise<void> {
   let kind: 'image' | 'file' | undefined = undefined;
   let channel = '';
   let chatId = '';
+  const fileCapableChannels = new Set(['telegram', 'slack', 'discord', 'whatsapp']);
 
   // Parse args
   for (let i = 0; i < args.length; i++) {
@@ -306,16 +307,16 @@ async function sendCommand(args: string[]): Promise<void> {
   }
 
   try {
-    // Use API for WhatsApp (unified multipart endpoint)
-    if (channel === 'whatsapp') {
+    if (filePath) {
+      if (!fileCapableChannels.has(channel)) {
+        throw new Error(`File sending not supported for ${channel}. Supported: telegram, slack, discord, whatsapp`);
+      }
       await sendViaApi(channel, chatId, { text, filePath, kind });
-    } else if (filePath) {
-      // Other channels with files - not yet implemented via API
-      throw new Error(`File sending for ${channel} requires API (currently only WhatsApp supported via API)`);
-    } else {
-      // Other channels with text only - direct API calls
-      await sendToChannel(channel, chatId, text);
+      return;
     }
+
+    // Text-only: direct platform APIs (WhatsApp uses API internally)
+    await sendToChannel(channel, chatId, text);
   } catch (error) {
     console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
     process.exit(1);
@@ -357,11 +358,12 @@ Environment variables:
   SLACK_BOT_TOKEN         Required for Slack
   DISCORD_BOT_TOKEN       Required for Discord
   SIGNAL_PHONE_NUMBER     Required for Signal (text only, no files)
-  LETTABOT_API_KEY        Required for WhatsApp (text and files)
+  LETTABOT_API_KEY        Required for file sending (telegram, slack, discord, whatsapp) and WhatsApp text
   LETTABOT_API_URL        API server URL (default: http://localhost:8080)
   SIGNAL_CLI_REST_API_URL Signal daemon URL (default: http://127.0.0.1:8090)
 
-Note: WhatsApp uses the API server. Other channels use direct platform APIs.
+Note: File sending uses the API server for supported channels (telegram, slack, discord, whatsapp).
+      Text-only messages use direct platform APIs (WhatsApp uses API).
 `);
 }
 

--- a/src/core/directives.test.ts
+++ b/src/core/directives.test.ts
@@ -61,6 +61,28 @@ describe('parseDirectives', () => {
     ]);
   });
 
+  it('parses send-file directive with path and caption', () => {
+    const result = parseDirectives('<actions><send-file path="/tmp/report.pdf" caption="Report" /></actions>');
+    expect(result.cleanText).toBe('');
+    expect(result.directives).toEqual([
+      { type: 'send-file', path: '/tmp/report.pdf', caption: 'Report' },
+    ]);
+  });
+
+  it('parses send-file directive with file alias and kind', () => {
+    const result = parseDirectives('<actions><send-file file="photo.png" kind="image" /></actions>');
+    expect(result.cleanText).toBe('');
+    expect(result.directives).toEqual([
+      { type: 'send-file', path: 'photo.png', kind: 'image' },
+    ]);
+  });
+
+  it('ignores send-file directive without path or file attribute', () => {
+    const result = parseDirectives('<actions><send-file caption="Missing" /></actions>');
+    expect(result.cleanText).toBe('');
+    expect(result.directives).toEqual([]);
+  });
+
   it('ignores react directive without emoji attribute', () => {
     const result = parseDirectives('<actions><react message="123" /></actions>');
     expect(result.cleanText).toBe('');

--- a/src/core/directives.ts
+++ b/src/core/directives.ts
@@ -22,8 +22,15 @@ export interface ReactDirective {
   messageId?: string;
 }
 
+export interface SendFileDirective {
+  type: 'send-file';
+  path: string;
+  caption?: string;
+  kind?: 'image' | 'file';
+}
+
 // Union type — extend with more directive types later
-export type Directive = ReactDirective;
+export type Directive = ReactDirective | SendFileDirective;
 
 export interface ParseResult {
   cleanText: string;
@@ -40,7 +47,7 @@ const ACTIONS_BLOCK_REGEX = /^\s*<actions>([\s\S]*?)<\/actions>/;
  * Match self-closing child directive tags inside the actions block.
  * Captures the tag name and the full attributes string.
  */
-const CHILD_DIRECTIVE_REGEX = /<(react)\b([^>]*)\/>/g;
+const CHILD_DIRECTIVE_REGEX = /<(react|send-file)\b([^>]*)\/>/g;
 
 /**
  * Parse a single attribute string like: emoji="eyes" message="123"
@@ -79,6 +86,23 @@ function parseChildDirectives(block: string): Directive[] {
           ...(attrs.message ? { messageId: attrs.message } : {}),
         });
       }
+      continue;
+    }
+
+    if (tagName === 'send-file') {
+      const attrs = parseAttributes(attrString);
+      const path = attrs.path || attrs.file;
+      if (!path) continue;
+      const caption = attrs.caption || attrs.text;
+      const kind = attrs.kind === 'image' || attrs.kind === 'file'
+        ? attrs.kind
+        : undefined;
+      directives.push({
+        type: 'send-file',
+        path,
+        ...(caption ? { caption } : {}),
+        ...(kind ? { kind } : {}),
+      });
     }
   }
 

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -45,7 +45,7 @@ lettabot-react add --emoji :eyes:
 # Add a reaction to a specific message
 lettabot-react add --emoji :eyes: --channel telegram --chat 123456789 --message 987654321
 
-# Note: File sending supported on telegram, slack, whatsapp (via API)
+# Note: File sending supported on telegram, slack, discord, whatsapp (via API)
 # Signal does not support files or reactions
 
 # Discover channel IDs (Discord and Slack)
@@ -103,6 +103,7 @@ This sends "Great idea!" and reacts with thumbsup.
 
 - \`<react emoji="eyes" />\` -- react to the message you are responding to. Emoji names (eyes, thumbsup, heart, fire, tada, clap) or unicode.
 - \`<react emoji="fire" message="123" />\` -- react to a specific message by ID.
+- \`<send-file path="/path/to/file.png" kind="image" caption="..." />\` -- send a file or image to the same channel/chat.
 
 ### Actions-only response
 


### PR DESCRIPTION
## Summary\n- add <send-file> directive parsing/execution with kind inference\n- implement Discord sendFile adapter support\n- allow lettabot-message to send files for telegram/slack/discord/whatsapp via API\n- update docs and system prompt\n\n## Testing\n- npx vitest src/core/directives.test.ts\n\nCloses #306