### PR TITLE
chore: bump @letta-ai/letta-code-sdk to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@clack/prompts": "^0.11.0",
         "@hapi/boom": "^10.0.1",
         "@letta-ai/letta-client": "^1.7.8",
-        "@letta-ai/letta-code-sdk": "^0.1.0",
+        "@letta-ai/letta-code-sdk": "^0.1.1",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.10",
         "@types/node-schedule": "^2.1.8",
@@ -1264,9 +1264,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.15.3.tgz",
-      "integrity": "sha512-aR2eGIuVt5JKEtThIaeQZ3E7V+ZNmp9mdUgE0xTNPfaZvWGA8JLSuvO113nwcILCoCRrznWGU4A4E8xwHTqjLA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.15.4.tgz",
+      "integrity": "sha512-glTQmsCG2LMYEFfPqNx0JXkkcMUYNkpxgyEHlFyj43oSkYb08A0GEHNbiTySsouLtNyhROqCSfG+7fksitgDNg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1284,12 +1284,12 @@
       }
     },
     "node_modules/@letta-ai/letta-code-sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.0.tgz",
-      "integrity": "sha512-BrbjU7AoWsVMozrnoy9Stp8MLywljZ0dIXUhCehBUyD/lm0QFD//4RR9FE+2usYEtPKJb/T3z3BQy9LGxUYnXQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.1.tgz",
+      "integrity": "sha512-Pp659R8i/hB6aApM5viMzMy5dnSRjLvfYoaHmlrjpLSRSV1g0tcxLoX8tLPt4Jtr7zs569b93IwjQS8D3A+NxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@letta-ai/letta-code": "0.15.3"
+        "@letta-ai/letta-code": "0.15.4"
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/@isaacs/cliui": {
@@ -1326,12 +1326,12 @@
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/glob": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
-      "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.4.tgz",
+      "integrity": "sha512-KACie1EOs9BIOMtenFaxwmYODWA3/fTfGSUnLhMJpXRntu1g+uL/Xvub5f8SCTppvo9q62Qy4LeOoUiaL54G5A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.0",
+        "minimatch": "^10.2.1",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -1367,9 +1367,9 @@
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@clack/prompts": "^0.11.0",
     "@hapi/boom": "^10.0.1",
     "@letta-ai/letta-client": "^1.7.8",
-    "@letta-ai/letta-code-sdk": "^0.1.0",
+    "@letta-ai/letta-code-sdk": "^0.1.1",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.10",
     "@types/node-schedule": "^2.1.8",


### PR DESCRIPTION
## Summary
- bump `@letta-ai/letta-code-sdk` from `^0.1.0` to `^0.1.1`
- refresh `package-lock.json` to resolve the new SDK release

## Validation
- `npm run test:run`
  - 37 test files passed
  - 459 tests passed
