### PR TITLE
fix: replace unhelpful error messages with actionable guidance

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -906,7 +906,7 @@ export class LettaBot implements AgentSession {
       if (!suppressDelivery) {
         await adapter.sendMessage({
           chatId: msg.chatId,
-          text: '(Session recovery failed after multiple attempts. Try: lettabot reset-conversation)',
+          text: `(I had trouble processing that -- the session hit a stuck state and automatic recovery failed after ${this.store.recoveryAttempts} attempt(s). Please try sending your message again. If this keeps happening, /reset will clear the conversation for this channel.)`,
           threadId: msg.threadId,
         });
       }
@@ -1244,7 +1244,7 @@ export class LettaBot implements AgentSession {
           console.error('[Bot] Stream received NO DATA - possible stuck state');
           await adapter.sendMessage({ 
             chatId: msg.chatId, 
-            text: '(Session interrupted. Try: lettabot reset-conversation)', 
+            text: '(No response received -- the connection may have dropped or the server may be busy. Please try again. If this persists, /reset will start a fresh conversation.)', 
             threadId: msg.threadId 
           });
         } else {
@@ -1252,10 +1252,9 @@ export class LettaBot implements AgentSession {
           if (hadToolActivity) {
             console.log('[Bot] Agent had tool activity but no assistant message - likely sent via tool');
           } else {
-            const convIdShort = this.store.conversationId?.slice(0, 8) || 'none';
             await adapter.sendMessage({ 
               chatId: msg.chatId, 
-              text: `(No response. Conversation: ${convIdShort}... Try: lettabot reset-conversation)`, 
+              text: '(The agent processed your message but didn\'t produce a visible response. This can happen with certain prompts. Try rephrasing or sending again.)', 
               threadId: msg.threadId 
             });
           }


### PR DESCRIPTION
## Summary

- Replaces three user-facing error messages in `bot.ts` that all said "Try: lettabot reset-conversation" with messages that actually explain what happened and suggest retrying first
- Uses `/reset` (in-chat slash command, per-channel aware) instead of the CLI command `lettabot reset-conversation` as a last resort
- Drops the meaningless truncated conversation ID from user-facing error text (still logged server-side)

### Before / After

| Condition | Before | After |
|---|---|---|
| Recovery failure (stuck approvals) | `Session recovery failed after multiple attempts. Try: lettabot reset-conversation` | Explains stuck state, shows attempt count, suggests retry first, `/reset` as fallback |
| No data received (stream empty) | `Session interrupted. Try: lettabot reset-conversation` | Explains connection may have dropped, suggests retry, `/reset` if persistent |
| No visible response (data but no assistant content) | `No response. Conversation: abc123... Try: lettabot reset-conversation` | Explains agent processed but produced no visible output, suggests rephrasing -- no reset suggestion since it's a content issue |

### Principles

1. Retry is always the first suggestion (most errors are transient)
2. Explain what happened so users have a mental model
3. `/reset` only as last resort, never the primary action
4. Never reference CLI commands from chat error messages

## Test plan

- [ ] Trigger each error path and verify the new message appears
- [ ] Verify `/reset` works as the suggested fallback in each channel

Written by Cameron and Letta Code

"Error messages are a user interface too." -- Steve Krug