### PR TITLE
fix(core): harden session lifecycle around init/send failures

### DIFF
--- a/src/core/sdk-session-contract.test.ts
+++ b/src/core/sdk-session-contract.test.ts
@@ -19,16 +19,19 @@ describe('SDK session contract', () => {
   let originalDataDir: string | undefined;
   let originalAgentId: string | undefined;
   let originalRailwayMount: string | undefined;
+  let originalSessionTimeout: string | undefined;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'lettabot-sdk-contract-'));
     originalDataDir = process.env.DATA_DIR;
     originalAgentId = process.env.LETTA_AGENT_ID;
     originalRailwayMount = process.env.RAILWAY_VOLUME_MOUNT_PATH;
+    originalSessionTimeout = process.env.LETTA_SESSION_TIMEOUT_MS;
 
     process.env.DATA_DIR = dataDir;
     process.env.LETTA_AGENT_ID = 'agent-contract-test';
     delete process.env.RAILWAY_VOLUME_MOUNT_PATH;
+    delete process.env.LETTA_SESSION_TIMEOUT_MS;
 
     vi.clearAllMocks();
   });
@@ -42,6 +45,9 @@ describe('SDK session contract', () => {
 
     if (originalRailwayMount === undefined) delete process.env.RAILWAY_VOLUME_MOUNT_PATH;
     else process.env.RAILWAY_VOLUME_MOUNT_PATH = originalRailwayMount;
+
+    if (originalSessionTimeout === undefined) delete process.env.LETTA_SESSION_TIMEOUT_MS;
+    else process.env.LETTA_SESSION_TIMEOUT_MS = originalSessionTimeout;
 
     rmSync(dataDir, { recursive: true, force: true });
   });
@@ -79,5 +85,83 @@ describe('SDK session contract', () => {
     expect(mockSession.send).toHaveBeenNthCalledWith(1, 'first message');
     expect(mockSession.send).toHaveBeenNthCalledWith(2, 'second message');
     expect(mockSession.stream).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes session if initialize times out before first send', async () => {
+    process.env.LETTA_SESSION_TIMEOUT_MS = '5';
+
+    const mockSession = {
+      initialize: vi.fn(() => new Promise<never>(() => {})),
+      send: vi.fn(async (_message: unknown) => undefined),
+      stream: vi.fn(() =>
+        (async function* () {
+          yield { type: 'result', success: true };
+        })()
+      ),
+      close: vi.fn(() => undefined),
+      agentId: 'agent-contract-test',
+      conversationId: 'conversation-contract-test',
+    };
+
+    vi.mocked(createSession).mockReturnValue(mockSession as never);
+    vi.mocked(resumeSession).mockReturnValue(mockSession as never);
+
+    const bot = new LettaBot({
+      workingDir: join(dataDir, 'working'),
+      allowedTools: [],
+    });
+
+    await expect(bot.sendToAgent('will timeout')).rejects.toThrow('Session initialize (key=shared) timed out after 5ms');
+    expect(mockSession.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates retry session when fallback send fails after conversation-missing error', async () => {
+    const missingConversation = new Error('conversation not found');
+    const retryFailure = new Error('network down');
+
+    const firstSession = {
+      initialize: vi.fn(async () => undefined),
+      send: vi.fn(async () => {
+        throw missingConversation;
+      }),
+      stream: vi.fn(() =>
+        (async function* () {
+          yield { type: 'result', success: true };
+        })()
+      ),
+      close: vi.fn(() => undefined),
+      agentId: 'agent-contract-test',
+      conversationId: 'conversation-contract-test-1',
+    };
+
+    const secondSession = {
+      initialize: vi.fn(async () => undefined),
+      send: vi.fn(async () => {
+        throw retryFailure;
+      }),
+      stream: vi.fn(() =>
+        (async function* () {
+          yield { type: 'result', success: true };
+        })()
+      ),
+      close: vi.fn(() => undefined),
+      agentId: 'agent-contract-test',
+      conversationId: 'conversation-contract-test-2',
+    };
+
+    vi.mocked(createSession)
+      .mockReturnValueOnce(firstSession as never)
+      .mockReturnValueOnce(secondSession as never);
+    vi.mocked(resumeSession).mockReturnValue(firstSession as never);
+
+    const bot = new LettaBot({
+      workingDir: join(dataDir, 'working'),
+      allowedTools: [],
+    });
+
+    await expect(bot.sendToAgent('trigger fallback')).rejects.toThrow('network down');
+    expect(firstSession.close).toHaveBeenCalledTimes(1);
+    expect(secondSession.close).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createSession)).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- add session timeout guards for initialize/send using `LETTA_SESSION_TIMEOUT_MS` (default 60s)
- close invalid sessions when initialize fails to avoid leaked subprocesses
- invalidate retry session if fallback send fails after conversation-missing recovery
- persist result state before yielding `result` to avoid consumer early-break gaps
- add regression tests for init-timeout cleanup and retry-send invalidation

## Validation
- npm run test -- src/core/sdk-session-contract.test.ts
- npm run test -- src/core/bot-delivery.test.ts src/core/ask-user-question.test.ts src/core/listening-mode.test.ts src/core/commands.test.ts
- npm run build
