### PR TITLE
fix: proactive orphaned approval cleanup to prevent limping agent

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -141,6 +141,8 @@ export class LettaBot implements AgentSession {
   // channel (and optionally heartbeat) gets its own subprocess.
   private sessions: Map<string, Session> = new Map();
   private currentCanUseTool: CanUseToolCallback | undefined;
+  /** Set when the previous run ended with a suspiciously short turn or error, triggering proactive approval cleanup on the next message. */
+  private needsApprovalCheck = false;
   // Stable callback wrapper so the Session options never change, but we can
   // swap out the per-message handler before each send().
   private readonly sessionCanUseTool: CanUseToolCallback = async (toolName, toolInput) => {
@@ -486,6 +488,23 @@ export class LettaBot implements AgentSession {
     const convId = convKey === 'shared'
       ? this.store.conversationId
       : this.store.getConversationId(convKey);
+
+    // Proactive approval cleanup: if the previous turn was suspicious, check for
+    // orphaned approvals before sending. This catches the "limping agent" pattern
+    // where orphaned approvals cause each turn to bail out early without a hard error.
+    if (this.needsApprovalCheck && this.store.agentId && convId) {
+      this.needsApprovalCheck = false;
+      try {
+        const result = await recoverOrphanedConversationApproval(this.store.agentId, convId);
+        if (result.recovered) {
+          console.log(`[Bot] Pre-message cleanup: ${result.details}`);
+          this.invalidateSession(convKey);
+          session = await this.ensureSessionForKey(convKey);
+        }
+      } catch (err) {
+        console.warn('[Bot] Pre-message approval check failed:', err instanceof Error ? err.message : err);
+      }
+    }
 
     // Send message with fallback chain
     try {
@@ -1176,6 +1195,15 @@ export class LettaBot implements AgentSession {
               const err = streamMsg.error || 'unknown error';
               const reason = streamMsg.stopReason ? ` [${streamMsg.stopReason}]` : '';
               response = `(Agent run failed: ${err}${reason}. Try sending your message again.)`;
+            }
+
+            // Flag for proactive approval cleanup on the next message.
+            // Triggers when the turn ended with an error, or completed with
+            // suspiciously few tool calls (< 3 assistant messages suggests the
+            // agent bailed out early, possibly due to orphaned approvals).
+            const assistantCount = msgTypeCounts.assistant || 0;
+            if (isTerminalError || (streamMsg.success && assistantCount > 0 && assistantCount < 3)) {
+              this.needsApprovalCheck = true;
             }
             
             break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,7 +166,7 @@ import { collectGroupBatchingConfig } from './core/group-batching-config.js';
 import { CronService } from './cron/service.js';
 import { HeartbeatService } from './cron/heartbeat.js';
 import { PollingService, parseGmailAccounts } from './polling/service.js';
-import { agentExists, findAgentByName, ensureNoToolApprovals } from './tools/letta-api.js';
+import { agentExists, findAgentByName, ensureNoToolApprovals, recoverOrphanedConversationApproval } from './tools/letta-api.js';
 // Skills are now installed to agent-scoped location after agent creation (see bot.ts)
 
 // Check if config exists (skip in Railway/Docker where env vars are used directly)
@@ -567,11 +567,22 @@ async function main() {
       console.log(`[Agent:${agentConfig.name}] No agent found - will create on first message`);
     }
     
-    // Disable tool approvals
+    // Disable tool approvals and clear any orphaned approval requests from previous session
     if (initialStatus.agentId) {
       ensureNoToolApprovals(initialStatus.agentId).catch(err => {
         console.warn(`[Agent:${agentConfig.name}] Failed to check tool approvals:`, err);
       });
+      if (initialStatus.conversationId) {
+        recoverOrphanedConversationApproval(initialStatus.agentId, initialStatus.conversationId)
+          .then(result => {
+            if (result.recovered) {
+              console.log(`[Agent:${agentConfig.name}] Startup: cleared orphaned approvals: ${result.details}`);
+            }
+          })
+          .catch(err => {
+            console.warn(`[Agent:${agentConfig.name}] Startup: failed to check orphaned approvals:`, err);
+          });
+      }
     }
 
     // Create and register channels


### PR DESCRIPTION
## Summary

- **Startup cleanup**: On boot, clear orphaned approval requests left over from the previous session
- **Pre-message guard**: After a suspicious turn (error or < 3 tool calls), proactively check for and clear orphaned approvals before the next message

## Problem

When a large multi-tool turn (100+ tool calls) gets interrupted or times out, pending `approval_request_message`s can become orphaned in the Letta server. The originating run transitions to `completed/requires_approval` but no client ever responds to the approval requests.

This blocks subsequent turns — the agent can only do partial work before bailing out, creating a "limping agent" pattern where each turn completes with suspiciously few tool calls. The existing reactive recovery (on 409 CONFLICT or terminal errors) doesn't catch this because the agent technically succeeds — it just does very little.

## Evidence

From production logs (Feb 21, 2026):
```
04:19 — Turn with 105 assistant messages (large multi-tool turn)
04:42 — Next turn: only 25 messages, partial work
04:44 — Next turn: only 39 messages, "I got interrupted"
04:46 — Next turn: only 19 messages, "I don't know why I stopped"
04:47 — Next turn: only 15 messages, still limping
04:49 — Restart → recovery found 50 orphaned approvals → cleared → normal operation resumed
```

## Safety

The existing `recoverOrphanedConversationApproval()` function already safely distinguishes orphaned vs active approvals by checking each run's status. It only clears approvals from runs that are `failed`, `cancelled`, `completed/requires_approval`, or `running/requires_approval` (stuck). Active runs with normal stop reasons are never touched.

## Test plan

- [ ] Verify `npx tsc --noEmit` passes
- [ ] Restart LettaBot and confirm startup log shows approval check
- [ ] Simulate orphaned approvals and verify pre-message cleanup triggers
- [ ] Verify normal operation (no false positives on short legitimate turns like heartbeats)

🤖 Generated with [Letta Code](https://letta.com)