### PR TITLE
fix: prevent agent recreation when Letta server is temporarily unreachable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -543,13 +543,42 @@ async function main() {
       initialStatus = bot.getStatus();
     }
     
-    // Verify agent exists (clear stale ID if deleted)
+    // Verify agent exists (clear stale ID only on confirmed 404, never on transient errors)
     if (initialStatus.agentId) {
-      const exists = await agentExists(initialStatus.agentId);
-      if (!exists) {
-        console.log(`[Agent:${agentConfig.name}] Stored agent ${initialStatus.agentId} not found on server`);
-        bot.reset();
-        initialStatus = bot.getStatus();
+      let agentVerified = false;
+      for (let attempt = 1; attempt <= 5; attempt++) {
+        try {
+          agentVerified = await agentExists(initialStatus.agentId);
+          break; // Server responded — trust the result
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[Agent:${agentConfig.name}] Server unreachable checking agent (attempt ${attempt}/5): ${msg}`);
+          if (attempt < 5) {
+            // Exponential backoff: 2s, 4s, 8s, 16s
+            const delay = Math.min(2000 * Math.pow(2, attempt - 1), 16000);
+            console.log(`[Agent:${agentConfig.name}] Retrying in ${delay / 1000}s...`);
+            await new Promise(r => setTimeout(r, delay));
+          }
+        }
+      }
+      if (!agentVerified && initialStatus.agentId) {
+        // All retries exhausted without a definitive answer. Do one final
+        // confirmation: if the server is reachable AND the agent is still
+        // not found, only then reset. This guards against the race where
+        // the server comes up between the last retry and this check.
+        try {
+          const finalCheck = await agentExists(initialStatus.agentId);
+          if (finalCheck) {
+            console.log(`[Agent:${agentConfig.name}] Agent found on final check (server may have just come up)`);
+          } else {
+            console.log(`[Agent:${agentConfig.name}] Stored agent ${initialStatus.agentId} confirmed not found on server`);
+            bot.reset();
+            initialStatus = bot.getStatus();
+          }
+        } catch {
+          // Server still unreachable — keep the stored agent ID, don't reset
+          console.warn(`[Agent:${agentConfig.name}] Server unreachable after retries — keeping stored agent ID ${initialStatus.agentId}`);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- **`agentExists()`**: Only return `false` on confirmed 404 (`NotFoundError`). Re-throw connection errors and other transient failures instead of silently treating them as "agent not found"
- **Startup verification**: Replace single `agentExists()` call with retry loop (5 attempts, exponential backoff 2-16s). Only reset the stored agent ID after a confirmed 404 from a reachable server

## Problem

`agentExists()` catches ALL errors and returns `false`. When the Letta server is temporarily unreachable (e.g. during a restart), this is interpreted as "agent deleted" — triggering `bot.reset()` and creation of a brand new agent, losing all memory and conversation history.

From production logs (Feb 18-19, 2026), a series of Letta server restarts caused 5+ new agents to be created in rapid succession:

```
23:30:48 — Letta server stopped (restart)
23:31:00 — LettaBot starts, agentExists() → server booting → error → false → "not found"
23:31:39 — Creates new agent (memory/history lost)
00:51:20 — Another server restart → same cascade
01:23:14 — Again...
```

## Safety

- The retry loop uses exponential backoff (2s, 4s, 8s, 16s) to avoid hammering the server
- After all retries fail, one final `agentExists()` call is made — if the server is now up and returns 404, the agent is genuinely gone and reset is safe
- If the server remains unreachable, the stored agent ID is preserved (never reset on uncertainty)

## Test plan

- [ ] Verify `npx tsc --noEmit` passes
- [ ] Restart LettaBot while Letta server is running — agent found on first try, no retries
- [ ] Stop Letta server, restart LettaBot — retries logged, agent ID preserved, no new agent created
- [ ] Delete agent via API, restart LettaBot — 404 detected, reset triggered correctly

🤖 Generated with [Letta Code](https://letta.com)