### PR TITLE
feat: auto-continue agent turn on max_tokens truncation (up to 3 retries)

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -907,7 +907,7 @@ export class LettaBot implements AgentSession {
   // processMessage - User-facing message handling
   // =========================================================================
   
-  private async processMessage(msg: InboundMessage, adapter: ChannelAdapter, retried = false): Promise<void> {
+  private async processMessage(msg: InboundMessage, adapter: ChannelAdapter, retried = false, continuationAttempt = 0): Promise<void> {
     // Track timing and last target
     const debugTiming = !!process.env.LETTABOT_DEBUG_TIMING;
     const t0 = debugTiming ? performance.now() : 0;
@@ -1016,6 +1016,7 @@ export class LettaBot implements AgentSession {
       let lastMsgType: string | null = null;
       let lastAssistantUuid: string | null = null;
       let sentAnyMessage = false;
+      let needsContinuation = false;
       let receivedAnyData = false;
       let sawNonAssistantSinceLastUuid = false;
       const msgTypeCounts: Record<string, number> = {};
@@ -1214,6 +1215,19 @@ export class LettaBot implements AgentSession {
               }
             }
 
+            // Auto-continue when the agent was truncated by max_tokens.
+            // Unlike the empty-result retry above, this fires even when text
+            // was already delivered — the agent was mid-work and got cut off.
+            // Allows up to MAX_CONTINUATIONS attempts before giving up.
+            const MAX_CONTINUATIONS = 3;
+            const isTruncated = String(streamMsg.stopReason || '') === 'max_tokens_exceeded';
+            if (isTruncated && continuationAttempt < MAX_CONTINUATIONS) {
+              console.log(`[Bot] Agent hit max_tokens (attempt ${continuationAttempt + 1}/${MAX_CONTINUATIONS}) — will send continuation prompt after delivering buffered text.`);
+              needsContinuation = true;
+            } else if (isTruncated) {
+              console.warn(`[Bot] Agent hit max_tokens but exhausted all ${MAX_CONTINUATIONS} continuation attempts. Giving up.`);
+            }
+
             if (isTerminalError && !hasResponse && !sentAnyMessage) {
               const err = streamMsg.error || 'unknown error';
               const reason = streamMsg.stopReason ? ` [${streamMsg.stopReason}]` : '';
@@ -1303,6 +1317,18 @@ export class LettaBot implements AgentSession {
         }
       }
       
+      // Auto-continue: after delivering any buffered text, send a
+      // continuation prompt so the agent can finish its truncated work.
+      if (needsContinuation) {
+        const nextAttempt = continuationAttempt + 1;
+        console.log(`[Bot] Sending continuation prompt after max_tokens truncation (attempt ${nextAttempt})...`);
+        const continuationMsg: InboundMessage = {
+          ...msg,
+          text: '[SYSTEM] Your previous turn was truncated at the output token limit. Continue where you left off.',
+        };
+        return this.processMessage(continuationMsg, adapter, retried, nextAttempt);
+      }
+
     } catch (error) {
       console.error('[Bot] Error processing message:', error);
       try {


### PR DESCRIPTION
## Summary
- When the Letta server returns `stop_reason=max_tokens_exceeded`, the agent was mid-work and got silently cut off — LettaBot previously treated this as a successful completion
- Now detects truncation via `stopReason` on the result event and automatically sends a continuation prompt to the same conversation
- Allows up to **3 continuation attempts**, giving ~16K effective output budget even with the default 4192 max_tokens cap

## How it works
1. During stream processing, checks if `streamMsg.stopReason === 'max_tokens_exceeded'` on the result event
2. Sets a `needsContinuation` flag (doesn't interrupt the current delivery flow)
3. After any buffered text is delivered to the user, sends a continuation message via `processMessage()` with an incremented `continuationAttempt` counter
4. Stops after 3 attempts (configurable via `MAX_CONTINUATIONS` constant)

## Design decisions
- **Separate counter**: Uses `continuationAttempt` instead of reusing the existing `retried` boolean, so it doesn't interfere with the orphaned approval recovery logic
- **Post-delivery**: Continuation happens after the truncated response is delivered, so the user sees partial progress
- **Preserves `retried` state**: The original `retried` flag is passed through to continuation calls, keeping approval recovery working correctly
- **Non-breaking**: Only activates on `max_tokens_exceeded` — all other stop reasons behave exactly as before

## Context
The Letta server's `StopReasonType.max_tokens_exceeded` maps to `RunStatus.failed`, so the SDK surfaces it as `success=false` with `stopReason='max_tokens_exceeded'`. The existing empty-result retry logic (~line 1154) doesn't catch this case because it requires `nothingDelivered` — but truncated turns typically *have* delivered partial text to the user.

With the default Letta Code SDK max_tokens of 4192, 3 retries gives an effective ~16K output budget per user message — enough for most complex implementation tasks.

## Test plan
- [ ] Trigger max_tokens by setting a low `max_tokens` value (e.g., 1024) and sending a complex multi-step task
- [ ] Verify the agent receives continuation prompts and completes its work
- [ ] Verify it stops after 3 attempts (check logs for "exhausted all 3 continuation attempts")
- [ ] Verify normal (non-truncated) turns are unaffected
- [ ] Verify orphaned approval recovery still works (retried flag preserved)

🐾 Generated with [Letta Code](https://letta.com)