### PR TITLE
feat: exponential backoff retry for transient LLM errors

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -315,6 +315,15 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
   if (config.features?.maxToolCalls !== undefined) {
     env.MAX_TOOL_CALLS = String(config.features.maxToolCalls);
   }
+  if (config.features?.maxRetries !== undefined) {
+    env.MAX_RETRIES = String(config.features.maxRetries);
+  }
+  if (config.features?.retryBaseDelayMs !== undefined) {
+    env.RETRY_BASE_DELAY_MS = String(config.features.retryBaseDelayMs);
+  }
+  if (config.features?.retryMaxDelayMs !== undefined) {
+    env.RETRY_MAX_DELAY_MS = String(config.features.retryMaxDelayMs);
+  }
 
   // Polling - top-level polling config (preferred)
   if (config.polling?.gmail?.enabled) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -64,6 +64,9 @@ export interface AgentConfig {
       target?: string;       // Delivery target ("telegram:123", "slack:C123", etc.)
     };
     maxToolCalls?: number;
+    maxRetries?: number;          // Max retry attempts for transient errors (default: 3)
+    retryBaseDelayMs?: number;    // Base delay for exponential backoff in ms (default: 5000)
+    retryMaxDelayMs?: number;     // Maximum delay cap for backoff in ms (default: 30000)
   };
   /** Polling config */
   polling?: PollingYamlConfig;
@@ -136,6 +139,9 @@ export interface LettaBotConfig {
     };
     inlineImages?: boolean;   // Send images directly to the LLM (default: true). Set false to only send file paths.
     maxToolCalls?: number;  // Abort if agent calls this many tools in one turn (default: 100)
+    maxRetries?: number;          // Max retry attempts for transient errors (default: 3)
+    retryBaseDelayMs?: number;    // Base delay for exponential backoff in ms (default: 5000)
+    retryMaxDelayMs?: number;     // Maximum delay cap for backoff in ms (default: 30000)
   };
 
   // Polling - system-level background checks (Gmail, etc.)

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -907,7 +907,7 @@ export class LettaBot implements AgentSession {
   // processMessage - User-facing message handling
   // =========================================================================
   
-  private async processMessage(msg: InboundMessage, adapter: ChannelAdapter, retried = false): Promise<void> {
+  private async processMessage(msg: InboundMessage, adapter: ChannelAdapter, retryAttempt = 0): Promise<void> {
     // Track timing and last target
     const debugTiming = !!process.env.LETTABOT_DEBUG_TIMING;
     const t0 = debugTiming ? performance.now() : 0;
@@ -1005,7 +1005,7 @@ export class LettaBot implements AgentSession {
     let session: Session | null = null;
     try {
       const convKey = this.resolveConversationKey(msg.channel);
-      const run = await this.runSession(messageToSend, { retried, canUseTool, convKey });
+      const run = await this.runSession(messageToSend, { retried: retryAttempt > 0, canUseTool, convKey });
       lap('session send');
       session = run.session;
 
@@ -1189,35 +1189,61 @@ export class LettaBot implements AgentSession {
               const retryConvId = retryConvKey === 'shared'
                 ? this.store.conversationId
                 : this.store.getConversationId(retryConvKey);
-              if (!retried && this.store.agentId && retryConvId) {
+              const maxRetries = this.config.maxRetries ?? 3;
+              if (retryAttempt < maxRetries && this.store.agentId && retryConvId) {
                 const reason = shouldRetryForErrorResult ? 'error result' : 'empty result';
-                console.log(`[Bot] ${reason} - attempting orphaned approval recovery...`);
+
+                // On first attempt, try orphaned approval recovery
+                if (retryAttempt === 0) {
+                  console.log(`[Bot] ${reason} - attempting orphaned approval recovery...`);
+                  this.invalidateSession(retryConvKey);
+                  session = null;
+                  clearInterval(typingInterval);
+                  const convResult = await recoverOrphanedConversationApproval(
+                    this.store.agentId,
+                    retryConvId
+                  );
+                  if (convResult.recovered) {
+                    console.log(`[Bot] Recovery succeeded (${convResult.details}), retrying message...`);
+                    return this.processMessage(msg, adapter, retryAttempt + 1);
+                  }
+                  console.warn(`[Bot] No orphaned approvals found: ${convResult.details}`);
+                }
+
+                // Exponential backoff: base * 2^attempt, capped at max
+                const baseDelay = this.config.retryBaseDelayMs ?? 5000;
+                const maxDelay = this.config.retryMaxDelayMs ?? 30000;
+                const delay = Math.min(baseDelay * Math.pow(2, retryAttempt), maxDelay);
+                console.log(`[Bot] Retry ${retryAttempt + 1}/${maxRetries} after ${reason} — waiting ${delay}ms (exponential backoff)...`);
+
+                // Notify user that we're retrying (only on first retry to avoid spam)
+                if (retryAttempt === 0 && !suppressDelivery) {
+                  try {
+                    await adapter.sendMessage({
+                      chatId: msg.chatId,
+                      text: '⏳ Server temporarily unavailable — retrying...',
+                      threadId: msg.threadId,
+                    });
+                  } catch { /* best-effort notification */ }
+                }
+
                 this.invalidateSession(retryConvKey);
                 session = null;
                 clearInterval(typingInterval);
-                const convResult = await recoverOrphanedConversationApproval(
-                  this.store.agentId,
-                  retryConvId
-                );
-                if (convResult.recovered) {
-                  console.log(`[Bot] Recovery succeeded (${convResult.details}), retrying message...`);
-                  return this.processMessage(msg, adapter, true);
-                }
-                console.warn(`[Bot] No orphaned approvals found: ${convResult.details}`);
-
-                // Some client-side approval failures do not surface as pending approvals.
-                // Retry once anyway in case the previous run terminated mid-tool cycle.
-                if (shouldRetryForErrorResult) {
-                  console.log('[Bot] Retrying once after terminal error (no orphaned approvals detected)...');
-                  return this.processMessage(msg, adapter, true);
-                }
+                await new Promise(resolve => setTimeout(resolve, delay));
+                return this.processMessage(msg, adapter, retryAttempt + 1);
               }
             }
 
             if (isTerminalError && !hasResponse && !sentAnyMessage) {
-              const err = streamMsg.error || 'unknown error';
-              const reason = streamMsg.stopReason ? ` [${streamMsg.stopReason}]` : '';
-              response = `(Agent run failed: ${err}${reason}. Try sending your message again.)`;
+              const maxRetries = this.config.maxRetries ?? 3;
+              if (retryAttempt >= maxRetries) {
+                response = `Sorry, the AI server is currently unavailable. I tried ${retryAttempt} times with no luck. Please try again in a minute or two.`;
+              } else {
+                const err = streamMsg.error || 'unknown error';
+                const reason = streamMsg.stopReason ? ` [${streamMsg.stopReason}]` : '';
+                response = `(Agent run failed: ${err}${reason}. Try sending your message again.)`;
+              }
             }
             
             break;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -135,6 +135,11 @@ export interface BotConfig {
   // Safety
   maxToolCalls?: number; // Abort if agent calls this many tools in one turn (default: 100)
 
+  // Retry
+  maxRetries?: number;          // Max retry attempts for transient errors (default: 3)
+  retryBaseDelayMs?: number;    // Base delay for exponential backoff in ms (default: 5000)
+  retryMaxDelayMs?: number;     // Maximum delay cap for backoff in ms (default: 30000)
+
   // Security
   allowedUsers?: string[];  // Empty = allow all
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -527,6 +527,9 @@ async function main() {
       disallowedTools: globalConfig.disallowedTools,
       displayName: agentConfig.displayName,
       maxToolCalls: agentConfig.features?.maxToolCalls,
+      maxRetries: agentConfig.features?.maxRetries,
+      retryBaseDelayMs: agentConfig.features?.retryBaseDelayMs,
+      retryMaxDelayMs: agentConfig.features?.retryMaxDelayMs,
       conversationMode: agentConfig.conversations?.mode || 'shared',
       heartbeatConversation: agentConfig.conversations?.heartbeat || 'last-active',
       skills: {


### PR DESCRIPTION
## Summary
- Replace single-retry with configurable exponential backoff for transient LLM errors (e.g., Anthropic `overloaded_error`)
- User gets friendly "⏳ Server temporarily unavailable — retrying..." notification instead of raw error dump
- Configurable via `features.maxRetries`, `features.retryBaseDelayMs`, `features.retryMaxDelayMs`

## Problem
When the LLM provider is temporarily overloaded, the bot retries once immediately — which usually fails again because the provider hasn't recovered. The user sees a cryptic `(Agent run failed: error [error]. Try sending your message again.)` message.

## Solution
Exponential backoff: `min(baseDelay × 2^attempt, maxDelay)`

Defaults: 3 retries, 5s base, 30s max → delays of **5s, 10s, 20s**

| Attempt | Delay | Action |
|---------|-------|--------|
| 0 (first fail) | 5s | Orphaned approval recovery + notify user "⏳ retrying..." |
| 1 | 10s | Direct retry with backoff |
| 2 | 20s | Direct retry with backoff |
| 3 (exhausted) | — | "Sorry, the AI server is currently unavailable..." |

## Config
```yaml
features:
  maxRetries: 3           # default
  retryBaseDelayMs: 5000  # default
  retryMaxDelayMs: 30000  # default
```

## Test plan
- [ ] Simulate overloaded error (or wait for one naturally)
- [ ] Verify user sees "⏳ Server temporarily unavailable — retrying..." on first retry
- [ ] Verify exponential delays in logs (5s, 10s, 20s)
- [ ] Verify friendly final message after all retries exhausted
- [ ] Verify normal operation unaffected (no retry on success)
- [ ] Verify config overrides work

🐾 Generated with [Letta Code](https://letta.com)