### PR TITLE
fix: non-blocking lock for heartbeat/background triggers

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1331,16 +1331,22 @@ export class LettaBot implements AgentSession {
    * In per-channel mode with a dedicated key, no lock needed (parallel OK).
    * In per-channel mode with a channel key, wait for that key's queue.
    * In shared mode, use the global processing flag.
+   *
+   * @param tryOnly - If true, return false immediately when the lock is held
+   *   instead of spinning. Used by background triggers (heartbeats, cron) to
+   *   avoid blocking when a user conversation is in progress.
    */
-  private async acquireLock(convKey: string): Promise<boolean> {
+  private async acquireLock(convKey: string, tryOnly = false): Promise<boolean> {
     if (convKey === 'heartbeat') return false; // No lock needed
 
     if (this.config.conversationMode === 'per-channel') {
+      if (tryOnly && this.processingKeys.has(convKey)) return false;
       while (this.processingKeys.has(convKey)) {
         await new Promise(resolve => setTimeout(resolve, 1000));
       }
       this.processingKeys.add(convKey);
     } else {
+      if (tryOnly && this.processing) return false;
       while (this.processing) {
         await new Promise(resolve => setTimeout(resolve, 1000));
       }
@@ -1364,7 +1370,13 @@ export class LettaBot implements AgentSession {
     _context?: TriggerContext
   ): Promise<string> {
     const convKey = this.resolveHeartbeatConversationKey();
-    const acquired = await this.acquireLock(convKey);
+    // Use non-blocking lock for background triggers to avoid deadlocking
+    // user conversations. If the channel is busy, skip this invocation.
+    const acquired = await this.acquireLock(convKey, /* tryOnly */ true);
+    if (!acquired && convKey !== 'heartbeat') {
+      console.log(`[Bot] sendToAgent skipped: channel "${convKey}" is busy processing a user message`);
+      return '';
+    }
     
     try {
       const { stream } = await this.runSession(text, { convKey });
@@ -1407,7 +1419,11 @@ export class LettaBot implements AgentSession {
     _context?: TriggerContext
   ): AsyncGenerator<StreamMsg> {
     const convKey = this.resolveHeartbeatConversationKey();
-    const acquired = await this.acquireLock(convKey);
+    const acquired = await this.acquireLock(convKey, /* tryOnly */ true);
+    if (!acquired && convKey !== 'heartbeat') {
+      console.log(`[Bot] streamToAgent skipped: channel "${convKey}" is busy processing a user message`);
+      return;
+    }
 
     try {
       const { stream } = await this.runSession(text, { convKey });

--- a/src/cron/heartbeat.ts
+++ b/src/cron/heartbeat.ts
@@ -208,6 +208,13 @@ export class HeartbeatService {
       // Send to agent - response text is NOT delivered (silent mode)
       // Agent must use `lettabot-message` CLI via Bash to send messages
       const response = await this.bot.sendToAgent(message, triggerContext);
+
+      // Empty response means the channel was busy (user conversation in progress)
+      if (response === '') {
+        console.log(`[Heartbeat] Skipped — channel busy with user conversation`);
+        logEvent('heartbeat_skipped_channel_busy', {});
+        return;
+      }
       
       // Log results
       console.log(`[Heartbeat] Agent finished.`);


### PR DESCRIPTION
## Problem

When `heartbeatConversation` is `'last-active'` (the default), the heartbeat resolves to the same channel key as user messages (e.g., `'telegram'`). If a user message is being processed when the heartbeat fires, `acquireLock()` enters an infinite spin loop waiting for the key to be released:

1. User message holds the lock (long tool calls, multi-step reasoning)
2. Heartbeat fires, tries to acquire the same lock, spins forever (`while` loop with 1s sleep)
3. New user messages queue behind the blocked heartbeat
4. Agent appears stuck/unresponsive — requires manual restart

This is a **deadlock by design** — the heartbeat will never acquire the lock until the user message finishes, but the user message can take minutes (tool calls, code execution, etc.).

## Fix

Add a `tryOnly` parameter to `acquireLock()`. When `true`, it returns `false` immediately if the lock is held instead of spinning. Both `sendToAgent()` and `streamToAgent()` now use `tryOnly` mode, gracefully skipping when the channel is busy.

The heartbeat service detects the empty response and logs `heartbeat_skipped_channel_busy`.

## Changes

- `src/core/bot.ts`: `acquireLock(convKey, tryOnly?)` — non-blocking mode
- `src/core/bot.ts`: `sendToAgent()` / `streamToAgent()` — use `tryOnly` + log skip
- `src/cron/heartbeat.ts`: Handle empty response as "channel busy" skip

## Why not just use `heartbeatConversation: 'dedicated'`?

That works as a workaround, but:
- The default (`'last-active'`) causes deadlocks out of the box
- Users shouldn't need to know about this config to avoid hangs
- Background triggers should never block user conversations

## Test plan

- [ ] Verify heartbeat skips gracefully when user message is processing
- [ ] Verify heartbeat runs normally when channel is idle
- [ ] Verify `dedicated` mode still works (no regression)
- [ ] Existing tests pass (465/465)