### PR TITLE
fix: default memfs to false instead of undefined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -573,8 +573,10 @@ async function main() {
   for (const agentConfig of agents) {
     console.log(`\n[Setup] Configuring agent: ${agentConfig.name}`);
     
-    // Resolve memfs: YAML config takes precedence, then env var, then undefined (leave unchanged)
-    const resolvedMemfs = agentConfig.features?.memfs ?? (process.env.LETTABOT_MEMFS === 'true' ? true : process.env.LETTABOT_MEMFS === 'false' ? false : undefined);
+    // Resolve memfs: YAML config takes precedence, then env var, then default false.
+    // Default false prevents the SDK from auto-enabling memfs, which crashes on
+    // self-hosted Letta servers that don't have the git endpoint.
+    const resolvedMemfs = agentConfig.features?.memfs ?? (process.env.LETTABOT_MEMFS === 'true' ? true : false);
 
     // Create LettaBot for this agent
     const bot = new LettaBot({


### PR DESCRIPTION
## Summary

- When no `memfs` config is set in YAML or env var, lettabot was passing `undefined` to the SDK
- The SDK then passes neither `--memfs` nor `--no-memfs` to the letta-code CLI
- The CLI auto-enables memfs on Letta Cloud, but the git sync initialization runs on ALL servers and crashes self-hosted deployments that don't have the git endpoint (`fatal: repository not found`)
- This was reported by Michett on Discord -- session subprocess dies immediately on self-hosted Docker

**Fix:** Default to `false` instead of `undefined`. This ensures `--no-memfs` is always passed unless the user explicitly opts in via `features.memfs: true` in YAML or `LETTABOT_MEMFS=true` env var.

One-line change in `src/main.ts`.

## Test plan

- [x] `npx tsc --noEmit` -- clean
- [ ] Self-hosted deployment: verify session starts without git clone attempt
- [ ] Letta Cloud with `memfs: true`: verify memfs still works when explicitly enabled

Written by Cameron and Letta Code

"The safest default is the one that doesn't burn down your house." -- every ops engineer