### PR TITLE
fix: custom tool call display with pretty verb headers

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -502,6 +502,21 @@ export class TelegramAdapter implements ChannelAdapter {
       // Only first chunk replies to the original message
       const replyId = !lastMessageId && msg.replyToMessageId ? Number(msg.replyToMessageId) : undefined;
       
+      // If caller specified a parse mode, send directly (skip markdown conversion)
+      if (msg.parseMode) {
+        try {
+          const result = await this.bot.api.sendMessage(msg.chatId, chunk, {
+            parse_mode: msg.parseMode as 'MarkdownV2' | 'HTML',
+            reply_to_message_id: replyId,
+          });
+          lastMessageId = String(result.message_id);
+          continue;
+        } catch (e) {
+          console.warn(`[Telegram] ${msg.parseMode} send failed, falling back to default:`, e);
+          // Fall through to default conversion path
+        }
+      }
+
       // Try MarkdownV2 first
       try {
         const formatted = await markdownToTelegramV2(chunk);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -94,6 +94,10 @@ export interface OutboundMessage {
   text: string;
   replyToMessageId?: string;
   threadId?: string;  // Slack thread_ts
+  /** When set, tells the adapter which parse mode to use (e.g., 'MarkdownV2',
+   *  'HTML') and to skip its default markdown conversion. Adapters that don't
+   *  support the specified mode ignore this and fall back to default. */
+  parseMode?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Replaces the generic tool display with custom, verb-based headers for known tools. Unknown tools fall back to the generic format.

### Examples
| Tool call | Display |
|-----------|---------|
| `web_search(query: "Prime Intellect")` | **Searching**<br>Prime Intellect |
| `fetch_webpage(url: "https://...")` | **Reading**<br>https://... |
| `Bash(description: "Show git status")` | **Running**<br>`Show git status` |
| `Read(file_path: "/src/bot.ts")` | **Reading**<br>/src/bot.ts |
| `Edit(file_path: "/src/bot.ts")` | **Editing**<br>/src/bot.ts |
| `Grep(pattern: "toolInput")` | **Searching code**<br>toolInput |
| `Task(description: "Find auth code")` | **Delegating**<br>Find auth code |
| `conversation_search(query: "meetings")` | **Remembering**<br>meetings |
| `manage_todo(...)` | **Updating todos** |
| `some_unknown_tool(x: 1)` | **Tool**<br>some_unknown_tool (x: 1) |

Bash commands shown in inline code format. Pattern matches the existing `**Thinking**` display for reasoning.

### SDK workaround
The SDK delivers `toolInput: {}` because the CLI only forwards the first streaming chunk before args are accumulated. Falls back to extracting args from the `tool_result` content (many tools echo their input, e.g. web_search includes `query` in its result JSON).

## Test plan
- [x] TypeScript compiles clean
- [x] All unit tests pass (2 pre-existing failures in normalize.test.ts)
- [ ] Manual: send message triggering web_search on Signal -- verify **Searching** header + query
- [ ] Manual: trigger Bash tool -- verify **Running** + code-formatted description
- [ ] Manual: unknown tool -- verify generic **Tool** fallback

Written by Cameron and Letta Code

"We are stuck with technology when what we really want is just stuff that works." -- Douglas Adams