### PR TITLE
fix: skip retry/recovery for non-retryable API errors

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -67,6 +67,11 @@ function formatApiErrorForUser(error: { message: string; stopReason: string; api
   const apiMsg = (typeof apiError.message === 'string' ? apiError.message : '').toLowerCase();
   const reasons: string[] = Array.isArray(apiError.reasons) ? apiError.reasons : [];
 
+  // Billing / credits exhausted
+  if (msg.includes('out of credits') || apiMsg.includes('out of credits')) {
+    return '(Out of credits for hosted inference. Add credits or enable auto-recharge at app.letta.com/settings/organization/usage.)';
+  }
+
   // Rate limiting / usage exceeded (429)
   if (msg.includes('rate limit') || msg.includes('429') || msg.includes('usage limit')
     || apiMsg.includes('rate limit') || apiMsg.includes('usage limit')) {
@@ -1682,8 +1687,19 @@ export class LettaBot implements AgentSession {
               }
             }
 
+            // Non-retryable errors: billing, auth, not-found -- skip recovery/retry
+            // entirely and surface the error to the user immediately.
+            const errMsg = lastErrorDetail?.message?.toLowerCase() || '';
+            const isNonRetryableError = isTerminalError && (
+              errMsg.includes('out of credits') || errMsg.includes('usage limit') ||
+              errMsg.includes('401') || errMsg.includes('403') ||
+              errMsg.includes('unauthorized') || errMsg.includes('forbidden') ||
+              errMsg.includes('not found') || errMsg.includes('404') ||
+              errMsg.includes('rate limit') || errMsg.includes('429')
+            );
+
             const shouldRetryForEmptyResult = streamMsg.success && resultText === '' && nothingDelivered;
-            const shouldRetryForErrorResult = isTerminalError && nothingDelivered && !isConflictError;
+            const shouldRetryForErrorResult = isTerminalError && nothingDelivered && !isConflictError && !isNonRetryableError;
             if (shouldRetryForEmptyResult || shouldRetryForErrorResult) {
               if (shouldRetryForEmptyResult) {
                 log.error(`Warning: Agent returned empty result with no response. stopReason=${streamMsg.stopReason || 'N/A'}, conv=${streamMsg.conversationId || 'N/A'}`);


### PR DESCRIPTION
## Summary

- Non-retryable API errors (billing/credits, auth, 404, rate-limit) now skip the orphan recovery + retry path and surface to the user immediately
- Adds a specific user-facing message for "out of credits" errors

## Problem

When the API returns `"Your account is out of credits"`, the error flow was:

1. Error arrives at 0ms (instant failure)
2. Bot attempts orphaned approval recovery (spawns new session, waits)
3. No orphans found, retries the entire message
4. Same error again, this time formats and sends to user

The user on Discord/Telegram waited through all of that for an error that was never going to resolve with a retry. Credits don't refill between attempts.

The same problem applied to auth errors (401/403), not-found (404), and rate limits (429) -- all non-retryable in the short term.

## Fix

Added `isNonRetryableError` check that matches billing, auth, not-found, and rate-limit errors. When true, `shouldRetryForErrorResult` is forced false, skipping the recovery/retry block entirely. The error falls through to `formatApiErrorForUser` which sends it to the user immediately.

Also added a dedicated format case for "out of credits" which was previously falling through to the generic `(Agent error: ...)` fallback.

## Test plan

- [ ] Send a message when credits are exhausted -- should get error in Discord within 1-2 seconds, not 10+
- [ ] Verify auth errors (bad API key) still surface quickly
- [ ] Verify transient errors (500, tool failures) still retry as before

Written by Cameron ◯ Letta Code