### PR TITLE
refactor: deduplicate sleep helpers into src/utils

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
 import { isLettaApiUrl } from './utils/server.js';
 import { getDataDir, getWorkingDir, hasRailwayVolume } from './utils/paths.js';
 import { parseCsvList, parseNonNegativeNumber } from './utils/parse.js';
+import { sleep } from './utils/time.js';
 import { createLogger, setLogLevel } from './logger.js';
 
 const log = createLogger('Config');
@@ -210,10 +211,6 @@ const ATTACHMENTS_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const DISCOVERY_LOCK_TIMEOUT_MS = 15_000;
 const DISCOVERY_LOCK_STALE_MS = 60_000;
 const DISCOVERY_LOCK_RETRY_MS = 100;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 function getDiscoveryLockPath(agentName: string): string {
   const safe = agentName

--- a/src/utils/time.test.ts
+++ b/src/utils/time.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { sleep, sleepSync } from './time.js';
+
+describe('sleep', () => {
+  it('waits asynchronously', async () => {
+    const start = Date.now();
+    await sleep(10);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe('sleepSync', () => {
+  it('does not throw for zero delay', () => {
+    expect(() => sleepSync(0)).not.toThrow();
+  });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared timing helpers used across startup and persistence paths.
+ */
+
+const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
+let warnedAboutBusyWait = false;
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function sleepSync(ms: number, onBusyWait?: () => void): void {
+  if (typeof Atomics.wait === 'function') {
+    Atomics.wait(SLEEP_BUFFER, 0, 0, ms);
+    return;
+  }
+  if (!warnedAboutBusyWait) {
+    onBusyWait?.();
+    warnedAboutBusyWait = true;
+  }
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // Busy-wait fallback -- should not be reached in standard Node.js (v8+)
+  }
+}


### PR DESCRIPTION
## Summary
- add shared timing helpers in `src/utils/time.ts` (`sleep`, `sleepSync`)
- migrate `main.ts` to import shared async `sleep`
- migrate `core/store.ts` to import shared `sleepSync` while preserving one-time busy-wait warning behavior
- add unit tests for the new timing helpers

## Validation
- `npm run test:run -- src/utils/time.test.ts src/core/store.test.ts`
- `npm run build -- --noEmit` *(fails due pre-existing unrelated type errors in `src/core/bot.ts`)*

## Notes
- This is Part 2 of #377 (`sleep`/`sleepSync` deduplication).
- Part 1 (parse helper dedupe): #398
