### PR TITLE
feat: tag new agents with origin:lettabot

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -950,6 +950,7 @@ export class LettaBot implements AgentSession {
       const newAgentId = await createAgent({
         systemPrompt: SYSTEM_PROMPT,
         memory: loadMemoryBlocks(this.config.agentName),
+        tags: ['origin:lettabot'],
         ...(this.config.memfs !== undefined ? { memfs: this.config.memfs } : {}),
       });
       const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -1538,6 +1538,7 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
       const agentId = await createAgent({
         systemPrompt: SYSTEM_PROMPT,
         memory: loadMemoryBlocks(config.agentName || 'LettaBot'),
+        tags: ['origin:lettabot'],
         ...(config.model ? { model: config.model } : {}),
       });
       


### PR DESCRIPTION
## Summary
- Adds `tags: ['origin:lettabot']` to both `createAgent` call sites (`bot.ts` and `onboard.ts`) so agents created by LettaBot are identifiable in the core database
- Adds a test in `sdk-session-contract.test.ts` verifying `createAgent` is called with the tag when a new agent is created

## Test plan
- [x] Existing tests pass (12/12 in `sdk-session-contract.test.ts`)
- [x] New test verifies `createAgent` receives `tags: ['origin:lettabot']`
- [ ] Manual: deploy and confirm new agents appear with the tag in the DB

🐾 Generated with [Letta Code](https://letta.com)