### PR TITLE
fix: enforce runtime console lint in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint runtime console usage
+        run: npm run lint:console
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Lint runtime console usage
+        run: npm run lint:console
       
       - name: Build
         run: npm run build
@@ -40,6 +43,9 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Lint runtime console usage
+        run: npm run lint:console
       
       - name: Build
         run: npm run build

--- a/scripts/no-console.sh
+++ b/scripts/no-console.sh
@@ -3,25 +3,24 @@
 # Runtime code should use createLogger() from src/logger.ts instead.
 #
 # Excluded:
-#   - CLI commands (src/cli*, onboard, setup) -- user-facing terminal output
+#   - CLI commands (src/cli*, src/cron/cli.ts, onboard, setup) -- user-facing terminal output
 #   - Test files (*.test.ts, mock-*) -- test output
 #   - banner.ts -- ASCII art display
-#   - whatsapp/session.ts installConsoleFilters() -- intentional console interception (Baileys noise filter)
 #   - JSDoc examples (lines starting with ' *')
 
 set -euo pipefail
 
-hits=$(grep -rn 'console\.\(log\|error\|warn\|info\)(' src/ --include='*.ts' \
-  | grep -v '/cli' \
-  | grep -v '\.test\.' \
-  | grep -v 'mock-channel' \
-  | grep -v 'banner\.ts' \
-  | grep -v 'session\.ts.*\(originalLog\|originalError\|originalWarn\|console\.\(log\|error\|warn\) =\)' \
-  | grep -v 'setup\.ts' \
-  | grep -v 'onboard\.ts' \
-  | grep -v 'slack-wizard\.ts' \
-  | grep -v 'cron/cli\.ts' \
-  | grep -v ' \* ' \
+hits=$(grep -rEn 'console\.(log|error|warn|info|debug|trace)[[:space:]]*\(' src/ --include='*.ts' \
+  --exclude='*.test.ts' \
+  --exclude='mock-*.ts' \
+  --exclude='mock-channel.ts' \
+  --exclude='banner.ts' \
+  --exclude='setup.ts' \
+  --exclude='onboard.ts' \
+  --exclude='slack-wizard.ts' \
+  --exclude='cli.ts' \
+  --exclude-dir='cli' \
+  | grep -Ev ':[0-9]+:[[:space:]]*\* ' \
   || true)
 
 if [ -n "$hits" ]; then


### PR DESCRIPTION
## Summary
- harden `scripts/no-console.sh` to catch `console.debug/trace` and optional whitespace before calls
- simplify exclusions using grep `--exclude` flags
- enforce `npm run lint:console` in unit/e2e CI and release workflow

## Why
PR #397 introduced the lint script but it could miss some console call patterns and was not enforced in CI, so regressions could still slip through.

## Validation
- npm run lint:console
- npm run test:run
