### PR TITLE
feat: per-agent allowedTools and disallowedTools config

### DIFF
--- a/lettabot.example.yaml
+++ b/lettabot.example.yaml
@@ -20,6 +20,10 @@ agents:
     # Note: model is configured on the Letta agent server-side.
     # Select a model during `lettabot onboard` or change it with `lettabot model set <handle>`.
 
+    # Per-agent tool access (overrides global features.allowedTools / features.disallowedTools)
+    # features:
+    #   allowedTools: [Read, Glob, Grep, web_search, conversation_search]  # Read-only agent (no Bash/Edit/Write)
+
     # Conversation routing (optional)
     conversations:
       mode: shared        # "shared" (default) or "per-channel"
@@ -78,6 +82,8 @@ features:
   # sendFileMaxSize: 52428800       # Max file size in bytes for <send-file> (default: 50MB)
   # sendFileCleanup: false          # Allow <send-file cleanup="true"> to delete files after send (default: false)
   # memfs: true   # Enable memory filesystem (git-backed context repository). Syncs memory blocks to local files.
+  # allowedTools: [Bash, Read, Edit, Write, Glob, Grep, Task, web_search, conversation_search]  # Global default
+  # disallowedTools: [EnterPlanMode, ExitPlanMode]  # Global default
   # display:
   #   showToolCalls: false       # Show tool invocations in chat (e.g. "Using tool: Read (file_path: ...)")
   #   showReasoning: false       # Show agent reasoning/thinking in chat

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -86,6 +86,8 @@ export interface AgentConfig {
     sendFileMaxSize?: number; // Max file size in bytes for <send-file> (default: 50MB)
     sendFileCleanup?: boolean; // Allow <send-file cleanup="true"> to delete after send (default: false)
     display?: DisplayConfig;
+    allowedTools?: string[];       // Per-agent tool whitelist (overrides global/env ALLOWED_TOOLS)
+    disallowedTools?: string[];    // Per-agent tool blocklist (overrides global/env DISALLOWED_TOOLS)
   };
   /** Polling config */
   polling?: PollingYamlConfig;
@@ -167,6 +169,8 @@ export interface LettaBotConfig {
     sendFileMaxSize?: number; // Max file size in bytes for <send-file> (default: 50MB)
     sendFileCleanup?: boolean; // Allow <send-file cleanup="true"> to delete after send (default: false)
     display?: DisplayConfig;  // Show tool calls / reasoning in channel output
+    allowedTools?: string[];       // Global tool whitelist (overridden by per-agent, falls back to ALLOWED_TOOLS env)
+    disallowedTools?: string[];    // Global tool blocklist (overridden by per-agent, falls back to DISALLOWED_TOOLS env)
   };
 
   // Polling - system-level background checks (Gmail, etc.)

--- a/src/main.ts
+++ b/src/main.ts
@@ -494,12 +494,13 @@ function ensureRequiredTools(tools: string[]): string[] {
 // Global config (shared across all agents)
 const globalConfig = {
   workingDir: getWorkingDir(),
-  allowedTools: ensureRequiredTools(parseCsvList(
-    process.env.ALLOWED_TOOLS || 'Bash,Read,Edit,Write,Glob,Grep,Task,web_search,conversation_search',
-  )),
-  disallowedTools: parseCsvList(
-    process.env.DISALLOWED_TOOLS || 'EnterPlanMode,ExitPlanMode',
+  allowedTools: ensureRequiredTools(
+    yamlConfig.features?.allowedTools ??
+    parseCsvList(process.env.ALLOWED_TOOLS || 'Bash,Read,Edit,Write,Glob,Grep,Task,web_search,conversation_search'),
   ),
+  disallowedTools:
+    yamlConfig.features?.disallowedTools ??
+    parseCsvList(process.env.DISALLOWED_TOOLS || 'EnterPlanMode,ExitPlanMode'),
   attachmentsMaxBytes: resolveAttachmentsMaxBytes(),
   attachmentsMaxAgeDays: resolveAttachmentsMaxAgeDays(),
   cronEnabled: process.env.CRON_ENABLED === 'true',  // Legacy env var fallback
@@ -578,8 +579,8 @@ async function main() {
     const bot = new LettaBot({
       workingDir: globalConfig.workingDir,
       agentName: agentConfig.name,
-      allowedTools: globalConfig.allowedTools,
-      disallowedTools: globalConfig.disallowedTools,
+      allowedTools: ensureRequiredTools(agentConfig.features?.allowedTools ?? globalConfig.allowedTools),
+      disallowedTools: agentConfig.features?.disallowedTools ?? globalConfig.disallowedTools,
       displayName: agentConfig.displayName,
       maxToolCalls: agentConfig.features?.maxToolCalls,
       sendFileDir: agentConfig.features?.sendFileDir,


### PR DESCRIPTION
## Summary

- Adds `allowedTools` and `disallowedTools` to per-agent `features:` config in `lettabot.yaml`
- Also adds the same fields to the root-level `features:` block as a YAML alternative to env vars
- Follows existing per-agent override pattern (same as `memfs`, `maxToolCalls`, `cron`, etc.)

**Precedence chain:** per-agent YAML > global YAML `features` > `ALLOWED_TOOLS` env var > hardcoded default

**Use case:** Personal agent gets Bash/Edit/Write access, public-facing agent is restricted to read-only tools.

```yaml
agents:
  - name: personal-bot
    # Inherits global allowedTools (includes Bash)

  - name: public-bot
    features:
      allowedTools: [Read, Glob, Grep, web_search, conversation_search]
```

Fully backwards compatible -- no behavior change for existing configs.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 623 unit tests pass
- [ ] Manual test: set per-agent `allowedTools` in YAML, verify agent gets restricted tool set
- [ ] Manual test: verify global `features.allowedTools` in YAML overrides env var default
- [ ] Manual test: verify env var still works as fallback when YAML fields are omitted

Written by Cameron ◯ Letta Code

"The best way to find out if you can trust somebody is to trust them." -- Ernest Hemingway