### PR TITLE
fix: remove redundant per-message directive hints from envelope

### DIFF
--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -181,20 +181,11 @@ describe('formatMessageEnvelope', () => {
       expect(result).toContain('**Mentioned**: yes');
     });
 
-    it('includes directives hint for group chats', () => {
-      const msg = createMessage({ isGroup: true });
-      const result = formatMessageEnvelope(msg);
-      expect(result).toContain('Response Directives');
-      expect(result).toContain('<no-reply/>');
-      expect(result).toContain('<actions>');
-    });
-
-    it('includes directives hint for DMs', () => {
-      const msg = createMessage({ isGroup: false });
-      const result = formatMessageEnvelope(msg);
-      expect(result).toContain('Response Directives');
-      expect(result).toContain('<no-reply/>');
-      expect(result).toContain('<actions>');
+    it('does not include per-message directive hints (covered by system prompt)', () => {
+      const groupMsg = createMessage({ isGroup: true });
+      const dmMsg = createMessage({ isGroup: false });
+      expect(formatMessageEnvelope(groupMsg)).not.toContain('Response Directives');
+      expect(formatMessageEnvelope(dmMsg)).not.toContain('Response Directives');
     });
   });
 

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -256,7 +256,7 @@ function buildChatContextLines(msg: InboundMessage, options: EnvelopeOptions): s
     if (msg.wasMentioned) {
       lines.push(`- **Mentioned**: yes`);
     }
-    lines.push(`- **Hint**: See Response Directives below for \`<no-reply/>\` and \`<actions>\``);
+    lines.push(`- **Hint**: Use \`<no-reply/>\` to skip replying, \`<actions>\` for reactions/voice`);
   } else {
     lines.push(`- **Type**: Direct message`);
   }
@@ -350,15 +350,6 @@ export function formatMessageEnvelope(
   if (contextLines.length > 0) {
     sections.push(`## Chat Context\n${contextLines.join('\n')}`);
   }
-
-  // Response directives hint
-  const directiveLines = [
-    `- To skip replying: \`<no-reply/>\``,
-    `- To perform actions: wrap in \`<actions>\` at the start of your response`,
-    `  Example: \`<actions><react emoji="thumbsup" /></actions>Your text here\``,
-    `- To send a voice memo: \`<actions><voice>Your message here</voice></actions>\``,
-  ];
-  sections.push(`## Response Directives\n${directiveLines.join('\n')}`);
 
   // Build the full system-reminder block
   const reminderContent = sections.join('\n\n');


### PR DESCRIPTION
## Summary

- The `## Response Directives` section was injected into every user message via `formatMessageEnvelope`, adding ~4 lines of directive documentation per message
- This is redundant -- the system prompt (`system-prompt.ts` lines 92-123) already has comprehensive directive docs that the agent sees once and retains in context
- Removes the per-message injection, saving tokens on every single message
- Updates the group chat context hint to be self-contained rather than referencing a "below" section that no longer exists

Fixes #403

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 622 tests pass (two directive-presence tests consolidated into one absence test)
- [ ] Verify agent still uses directives correctly without per-message reminders (the system prompt covers this)

Written by Cameron ◯ Letta Code