### PR TITLE
feat: /cancel slash command to abort active agent runs

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -252,7 +252,7 @@ Ask the bot owner to approve with:
           return;
         }
         if (this.onCommand) {
-          if (command === 'status' || command === 'reset' || command === 'heartbeat') {
+          if (command === 'status' || command === 'reset' || command === 'heartbeat' || command === 'cancel') {
             const result = await this.onCommand(command, message.channel.id);
             if (result) {
               await message.channel.send(result);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -258,6 +258,13 @@ export class TelegramAdapter implements ChannelAdapter {
         await ctx.reply(result || 'Reset complete');
       }
     });
+
+    this.bot.command('cancel', async (ctx) => {
+      if (this.onCommand) {
+        const result = await this.onCommand('cancel', String(ctx.chat.id));
+        if (result) await ctx.reply(result);
+      }
+    });
     
     // Handle text messages
     this.bot.on('message:text', async (ctx) => {

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -13,7 +13,7 @@ import type { ChannelAdapter } from '../channels/types.js';
 import type { BotConfig, InboundMessage, TriggerContext } from './types.js';
 import type { AgentSession } from './interfaces.js';
 import { Store } from './store.js';
-import { updateAgentName, getPendingApprovals, rejectApproval, cancelRuns, recoverOrphanedConversationApproval, getLatestRunError } from '../tools/letta-api.js';
+import { updateAgentName, getPendingApprovals, rejectApproval, cancelRuns, cancelConversation, recoverOrphanedConversationApproval, getLatestRunError } from '../tools/letta-api.js';
 import { installSkillsToAgent, withAgentSkillsOnPath, getAgentSkillExecutableDirs, isVoiceMemoConfigured } from '../skills/loader.js';
 import { formatMessageEnvelope, formatGroupBatchEnvelope, type SessionContextOptions } from './formatter.js';
 import type { GroupBatcher } from './group-batcher.js';
@@ -291,6 +291,7 @@ export class LettaBot implements AgentSession {
   private listeningGroupIds: Set<string> = new Set();
   private processing = false; // Global lock for shared mode
   private processingKeys: Set<string> = new Set(); // Per-key locks for per-channel mode
+  private cancelledKeys: Set<string> = new Set(); // Tracks keys where /cancel was issued
 
   // AskUserQuestion support: resolves when the next user message arrives.
   // In per-chat mode, keyed by convKey so each chat resolves independently.
@@ -1431,6 +1432,38 @@ export class LettaBot implements AgentSession {
           return `Conversation reset for ${scope}. Other conversations are unaffected. (Agent memory is preserved.)`;
         }
       }
+      case 'cancel': {
+        const convKey = channelId ? this.resolveConversationKey(channelId, chatId) : 'shared';
+
+        // Check if there's actually an active run for this conversation key
+        if (!this.processingKeys.has(convKey) && !this.processing) {
+          return '(Nothing to cancel -- no active run.)';
+        }
+
+        // Signal the stream loop to break
+        this.cancelledKeys.add(convKey);
+
+        // Abort client-side stream
+        const session = this.sessions.get(convKey);
+        if (session) {
+          session.abort().catch(() => {});
+          log.info(`/cancel - aborted session stream (key=${convKey})`);
+        }
+
+        // Cancel server-side run (conversation-scoped)
+        const convId = convKey === 'shared'
+          ? this.store.conversationId
+          : this.store.getConversationId(convKey);
+        if (convId) {
+          const ok = await cancelConversation(convId);
+          if (!ok) {
+            return '(Run cancelled locally, but server-side cancellation failed.)';
+          }
+        }
+
+        log.info(`/cancel - run cancelled (key=${convKey})`);
+        return '(Run cancelled.)';
+      }
       default:
         return null;
     }
@@ -1806,6 +1839,11 @@ export class LettaBot implements AgentSession {
       try {
         let firstChunkLogged = false;
         for await (const streamMsg of run.stream()) {
+          // Check for /cancel before processing each chunk
+          if (this.cancelledKeys.has(convKey)) {
+            log.info(`Stream cancelled by /cancel (key=${convKey})`);
+            break;
+          }
           if (!firstChunkLogged) { lap('first stream chunk'); firstChunkLogged = true; }
           receivedAnyData = true;
           msgTypeCounts[streamMsg.type] = (msgTypeCounts[streamMsg.type] || 0) + 1;
@@ -1935,7 +1973,7 @@ export class LettaBot implements AgentSession {
               || (trimmed.startsWith('<actions') && !trimmed.includes('</actions>'));
             // Strip any completed <actions> block from the streaming text
             const streamText = stripActionsBlock(response).trim();
-            if (canEdit && !mayBeHidden && !suppressDelivery && streamText.length > 0 && Date.now() - lastUpdate > 500) {
+            if (canEdit && !mayBeHidden && !suppressDelivery && !this.cancelledKeys.has(convKey) && streamText.length > 0 && Date.now() - lastUpdate > 500) {
               try {
                 const prefixedStream = this.prefixResponse(streamText);
                 if (messageId) {
@@ -1953,6 +1991,19 @@ export class LettaBot implements AgentSession {
           }
           
           if (streamMsg.type === 'result') {
+            // Discard cancelled run results -- the server flushes accumulated
+            // content from a previously cancelled run as the result for the
+            // next message. Discard it and retry so the message gets processed.
+            if (streamMsg.stopReason === 'cancelled') {
+              log.info(`Discarding cancelled run result (len=${typeof streamMsg.result === 'string' ? streamMsg.result.length : 0})`);
+              this.invalidateSession(convKey);
+              session = null;
+              if (!retried) {
+                return this.processMessage(msg, adapter, true);
+              }
+              break;
+            }
+
             const resultText = typeof streamMsg.result === 'string' ? streamMsg.result : '';
             if (resultText.trim().length > 0) {
               response = resultText;
@@ -2093,6 +2144,17 @@ export class LettaBot implements AgentSession {
       }
       lap('stream complete');
 
+      // If cancelled, clean up partial state and return early
+      if (this.cancelledKeys.has(convKey)) {
+        if (messageId) {
+          try {
+            await adapter.editMessage(msg.chatId, messageId, '(Run cancelled.)');
+          } catch { /* best effort */ }
+        }
+        log.info(`Skipping post-stream delivery -- cancelled (key=${convKey})`);
+        return;
+      }
+
       // Parse and execute XML directives (e.g. <actions><react emoji="eyes" /></actions>)
       await parseAndHandleDirectives();
 
@@ -2174,6 +2236,7 @@ export class LettaBot implements AgentSession {
       }
     } finally {
       // Session stays alive for reuse -- only invalidated on errors
+      this.cancelledKeys.delete(this.resolveConversationKey(msg.channel, msg.chatId));
     }
   }
 

--- a/src/core/commands.test.ts
+++ b/src/core/commands.test.ts
@@ -22,6 +22,10 @@ describe('parseCommand', () => {
     it('returns "reset" for /reset', () => {
       expect(parseCommand('/reset')).toBe('reset');
     });
+
+    it('returns "cancel" for /cancel', () => {
+      expect(parseCommand('/cancel')).toBe('cancel');
+    });
   });
 
   describe('invalid input', () => {
@@ -74,8 +78,8 @@ describe('COMMANDS', () => {
     expect(COMMANDS).toContain('reset');
   });
 
-  it('has exactly 5 commands', () => {
-    expect(COMMANDS).toHaveLength(5);
+  it('has exactly 6 commands', () => {
+    expect(COMMANDS).toHaveLength(6);
   });
 });
 

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -4,7 +4,7 @@
  * Shared command parsing and help text for all channels.
  */
 
-export const COMMANDS = ['status', 'heartbeat', 'reset', 'help', 'start'] as const;
+export const COMMANDS = ['status', 'heartbeat', 'reset', 'cancel', 'help', 'start'] as const;
 export type Command = typeof COMMANDS[number];
 
 export const HELP_TEXT = `LettaBot - AI assistant with persistent memory
@@ -13,6 +13,7 @@ Commands:
 /status - Show current status
 /heartbeat - Trigger heartbeat
 /reset - Reset conversation (keeps agent memory)
+/cancel - Abort the current agent run
 /help - Show this message
 
 Just send a message to get started!`;


### PR DESCRIPTION
## Summary

Adds `/cancel` command that users can type in any channel to abort a stuck or unwanted agent run. Supersedes #366.

**What it does:**
- Checks `processingKeys` to detect active runs (reuses existing state, no redundant tracking)
- Adds conversation key to `cancelledKeys` set, which the stream loop checks on each chunk
- Aborts client-side SDK session via `session.abort()`
- Cancels server-side runs via conversation-scoped `cancelConversation()` API
- Edits any partial streaming message to "(Run cancelled.)"
- Handles `stopReason=cancelled` result flushing on the next message (discards + retries)
- Guards streaming edits against cancelled state

**Improvements over #366:**
- Uses `processingKeys` instead of redundant `activeRunKeys` set
- No dangerous agent-level `cancelRuns()` fallback -- conversation-scoped only
- Uses pino logger instead of `console.log`
- Includes tests
- Registered in Discord command list and Telegram `bot.command()`

Fixes #311
Supersedes #366

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 624 tests pass (1 new test for /cancel parsing)
- [ ] Manual: type `/cancel` while agent is streaming -- should abort and show "(Run cancelled.)"
- [ ] Manual: type `/cancel` when agent is idle -- should show "(Nothing to cancel -- no active run.)"
- [ ] Manual: send a message after `/cancel` -- should work normally (cancelled result flush is discarded)

Written by Cameron ◯ Letta Code