### PR TITLE
feat: channel-aware per-message directives via adapter hints

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -312,6 +312,7 @@ Ask the bot owner to approve with:
           wasMentioned,
           isListeningMode,
           attachments,
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -414,6 +415,14 @@ Ask the bot owner to approve with:
     return this.config.dmPolicy || 'pairing';
   }
 
+  getFormatterHints() {
+    return {
+      supportsReactions: true,
+      supportsFiles: true,
+      formatHint: 'Discord markdown: **bold** *italic* `code` [links](url) ```code blocks``` — supports headers',
+    };
+  }
+
   supportsEditing(): boolean {
     return this.config.streaming ?? false;
   }
@@ -477,6 +486,7 @@ Ask the bot owner to approve with:
         messageId: message.id,
         action,
       },
+      formatterHints: this.getFormatterHints(),
     }).catch((err) => {
       log.error('Error handling reaction:', err);
     });

--- a/src/channels/signal.ts
+++ b/src/channels/signal.ts
@@ -339,6 +339,14 @@ This code expires in 1 hour.`;
     return this.config.dmPolicy || 'pairing';
   }
 
+  getFormatterHints() {
+    return {
+      supportsReactions: true,
+      supportsFiles: false,
+      formatHint: 'ONLY: *bold* _italic_ `code` — NO: headers, code fences, links, quotes, tables',
+    };
+  }
+
   supportsEditing(): boolean {
     return false;
   }
@@ -868,6 +876,7 @@ This code expires in 1 hour.`;
         wasMentioned,
         isListeningMode,
         attachments: collectedAttachments.length > 0 ? collectedAttachments : undefined,
+        formatterHints: this.getFormatterHints(),
       };
       
       this.onMessage?.(msg).catch((err) => {

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -169,6 +169,7 @@ export class SlackAdapter implements ChannelAdapter {
           wasMentioned: false, // Regular messages; app_mention handles mentions
           isListeningMode: mode === 'listen',
           attachments,
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -264,6 +265,7 @@ export class SlackAdapter implements ChannelAdapter {
           groupName: isGroup ? channelId : undefined,
           wasMentioned: true, // app_mention is always a mention
           attachments,
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -359,6 +361,14 @@ export class SlackAdapter implements ChannelAdapter {
     return this.config.dmPolicy || 'pairing';
   }
 
+  getFormatterHints() {
+    return {
+      supportsReactions: true,
+      supportsFiles: true,
+      formatHint: 'Slack mrkdwn: *bold* _italic_ `code` <URL|text> — NO standard markdown headers',
+    };
+  }
+
   /** Check if a channel is allowed by the groups config allowlist */
   private isChannelAllowed(channelId: string): boolean {
     return isGroupAllowed(this.config.groups, [channelId]);
@@ -413,6 +423,7 @@ export class SlackAdapter implements ChannelAdapter {
         messageId,
         action,
       },
+      formatterHints: this.getFormatterHints(),
     });
   }
 

--- a/src/channels/telegram-mtproto.ts
+++ b/src/channels/telegram-mtproto.ts
@@ -496,6 +496,7 @@ Reply **approve** or **deny** to this message.`;
       text,
       messageId,
       timestamp: new Date(message.date * 1000),
+      formatterHints: this.getFormatterHints(),
     };
 
     // Call handler
@@ -747,6 +748,14 @@ Reply **approve** or **deny** to this message.`;
     // updateMessageSendSucceeded provides the real ID.
     // TODO: Implement message ID tracking to enable streaming edits
     return false;
+  }
+
+  getFormatterHints() {
+    return {
+      supportsReactions: false,
+      supportsFiles: false,
+      formatHint: 'MarkdownV2: *bold* _italic_ `code` [link](url) — NO: headers, tables',
+    };
   }
 
   async sendMessage(msg: OutboundMessage): Promise<{ messageId: string }> {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -304,6 +304,7 @@ export class TelegramAdapter implements ChannelAdapter {
           groupName,
           wasMentioned,
           isListeningMode,
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -349,6 +350,7 @@ export class TelegramAdapter implements ChannelAdapter {
             messageId: String(messageId),
             action,
           },
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -409,6 +411,7 @@ export class TelegramAdapter implements ChannelAdapter {
             groupName,
             wasMentioned,
             isListeningMode,
+            formatterHints: this.getFormatterHints(),
           });
         }
       } catch (error) {
@@ -427,6 +430,7 @@ export class TelegramAdapter implements ChannelAdapter {
             groupName,
             wasMentioned,
             isListeningMode,
+            formatterHints: this.getFormatterHints(),
           });
         }
       }
@@ -461,6 +465,7 @@ export class TelegramAdapter implements ChannelAdapter {
           wasMentioned,
           isListeningMode,
           attachments,
+          formatterHints: this.getFormatterHints(),
         });
       }
     });
@@ -631,6 +636,14 @@ export class TelegramAdapter implements ChannelAdapter {
   
   getDmPolicy(): string {
     return this.config.dmPolicy || 'pairing';
+  }
+
+  getFormatterHints() {
+    return {
+      supportsReactions: true,
+      supportsFiles: true,
+      formatHint: 'MarkdownV2: *bold* _italic_ `code` [link](url) — NO: headers, tables',
+    };
   }
 
   async sendTypingIndicator(chatId: string): Promise<void> {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -4,7 +4,7 @@
  * Each channel (Telegram, Slack, Discord, WhatsApp, Signal) implements this interface.
  */
 
-import type { ChannelId, InboundMessage, OutboundMessage, OutboundFile } from '../core/types.js';
+import type { ChannelId, InboundMessage, OutboundMessage, OutboundFile, FormatterHints } from '../core/types.js';
 
 /**
  * Channel adapter - implement this for each messaging platform
@@ -29,6 +29,7 @@ export interface ChannelAdapter {
   sendFile?(file: OutboundFile): Promise<{ messageId: string }>;
   addReaction?(chatId: string, messageId: string, emoji: string): Promise<void>;
   getDmPolicy?(): string;
+  getFormatterHints(): FormatterHints;
   
   // Event handlers (set by bot core)
   onMessage?: (msg: InboundMessage) => Promise<void>;

--- a/src/channels/whatsapp/index.ts
+++ b/src/channels/whatsapp/index.ts
@@ -836,6 +836,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
           isListeningMode,
           replyToUser: extracted.replyContext?.senderE164,
           attachments: extracted.attachments,
+          formatterHints: this.getFormatterHints(),
         });
       }
     }
@@ -1000,6 +1001,14 @@ export class WhatsAppAdapter implements ChannelAdapter {
 
   getDmPolicy(): string {
     return this.config.dmPolicy || 'pairing';
+  }
+
+  getFormatterHints() {
+    return {
+      supportsReactions: false,
+      supportsFiles: true,
+      formatHint: 'WhatsApp: *bold* _italic_ `code` — NO: headers, code fences, links, tables',
+    };
   }
 
   supportsEditing(): boolean {

--- a/src/core/group-batcher.ts
+++ b/src/core/group-batcher.ts
@@ -95,6 +95,7 @@ export class GroupBatcher {
       isListeningMode: messages.every((m) => m.isListeningMode === true) ? true : undefined,
       isBatch: true,
       batchedMessages: messages,
+      formatterHints: last.formatterHints,
     };
 
     this.onFlush(batchMsg, adapter);

--- a/src/core/redaction-channel.test.ts
+++ b/src/core/redaction-channel.test.ts
@@ -35,6 +35,7 @@ describe('channel redaction wrapping', () => {
       sendMessage: sendSpy,
       editMessage: vi.fn(async () => {}),
       sendTypingIndicator: vi.fn(async () => {}),
+      getFormatterHints: () => ({ supportsReactions: false, supportsFiles: false }),
     };
 
     bot.registerChannel(adapter);

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -6,7 +6,18 @@ export const SYSTEM_PROMPT = `You are a self-improving AI agent with advanced me
 
 You are connected to a multi-channel messaging system (LettaBot) that allows you to communicate with users across Telegram, Slack, Discord, WhatsApp, and Signal. You run on a remote server and can execute tools, manage files, and interact with various services.
 
-Not every message requires a response. Before replying, consider whether your response adds value. In group chats especially, avoid replying to messages not directed at you, simple acknowledgments, or conversations between other users. Quality over quantity — only reply when you have something meaningful to contribute.
+Not every message requires a response. Before replying, consider whether your response adds value. When in doubt, prefer \`<no-reply/>\` over a low-value response.
+
+## Choosing Not to Reply
+
+Use \`<no-reply/>\` when the message:
+- Is a simple acknowledgment ("ok", "thanks", "got it") that doesn't need a follow-up
+- Is a conversation between other users that you're not part of
+- Is a notification or status update with no question or request
+- Has already been addressed in a previous turn
+- Is in a group chat and not directed at you
+
+Channel-specific response options (reactions, file sending) are listed in the **Response Directives** section of each incoming message.
 
 # Communication System
 
@@ -73,54 +84,6 @@ During heartbeats and background tasks:
 - If nothing requires attention → just end your turn silently
 
 You don't need to notify the user about everything. Use judgment about what's worth interrupting them for.
-
-## Choosing Not to Reply
-
-Not all messages warrant a response. If a message doesn't need a reply, respond with exactly:
-
-\`<no-reply/>\`
-
-This suppresses the message so nothing is sent to the user. Use this for:
-- Messages in a group not directed at you
-- Simple acknowledgments (e.g., "ok", "thanks", thumbs up)
-- Conversations between other users you don't need to join
-- Notifications or updates that don't require a response
-- Messages you've already addressed
-
-When in doubt, prefer \`<no-reply/>\` over a low-value response. Users appreciate an agent that knows when to stay quiet.
-
-## Response Directives
-
-You can include an \`<actions>\` block at the **start** of your response to perform actions alongside your reply. The entire block is stripped before your message is sent.
-
-\`\`\`
-<actions>
-  <react emoji="👍" />
-</actions>
-Great idea!
-\`\`\`
-
-This sends "Great idea!" and reacts with thumbsup.
-
-### Available directives
-
-- \`<react emoji="👀" />\` -- react to the message you are responding to. Use the actual emoji character (👀, 👍, ❤️, 🔥, 🎉, 👏).
-- \`<react emoji="🔥" message="123" />\` -- react to a specific message by ID.
-- \`<send-file path="/path/to/file.png" kind="image" caption="..." />\` -- send a file or image to the same channel/chat. File paths are restricted to the configured send-file directory (default: \`data/outbound/\` in the working directory). Paths outside this directory are blocked.
-- \`<send-file path="/path/to/voice.ogg" kind="audio" cleanup="true" />\` -- send a voice note. Audio files (.ogg, .mp3, etc.) are sent as native voice memos on Telegram and WhatsApp. Use \`cleanup="true"\` to delete the file after sending.
-- \`<voice>Your message here</voice>\` -- generate and send a voice memo. The text is converted to speech via TTS and sent as a native voice note. No tool calls needed. Use for short conversational replies, responding to voice messages, or when the user asks for audio.
-
-### Actions-only response
-
-An \`<actions>\` block with no text after it executes silently (nothing sent to the user), like \`<no-reply/>\`:
-
-\`\`\`
-<actions>
-  <react emoji="👀" />
-</actions>
-\`\`\`
-
-Prefer directives over tool calls for simple actions like reactions. They are faster and cheaper.
 
 ## Available Channels
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -84,6 +84,16 @@ export interface InboundMessage {
   isBatch?: boolean;                  // Is this a batched group message?
   batchedMessages?: InboundMessage[]; // Original individual messages (for batch formatting)
   isListeningMode?: boolean;          // Listening mode: agent processes for memory but response is suppressed
+  formatterHints?: FormatterHints;    // Channel capabilities for directive rendering
+}
+
+/**
+ * Channel capability hints for per-message directive rendering
+ */
+export interface FormatterHints {
+  supportsReactions?: boolean;
+  supportsFiles?: boolean;
+  formatHint?: string;
 }
 
 /**

--- a/src/test/mock-channel.ts
+++ b/src/test/mock-channel.ts
@@ -55,6 +55,10 @@ export class MockChannelAdapter implements ChannelAdapter {
   supportsEditing(): boolean {
     return false; // Disable streaming edits for simpler testing
   }
+
+  getFormatterHints() {
+    return { supportsReactions: false, supportsFiles: false };
+  }
   
   /**
    * Simulate an inbound message and wait for response


### PR DESCRIPTION
## Summary

- Adds `getFormatterHints()` to `ChannelAdapter` interface, returning `{ supportsReactions, supportsFiles, formatHint }`
- Each adapter declares its actual capabilities; `buildResponseDirectives()` renders only relevant directives per-message
- System prompt shrinks by ~45 lines -- directive docs now live per-message where agents without the standard system prompt can still see them
- Replaces hardcoded `CHANNEL_FORMATS` map with adapter-provided `formatHint` strings
- Listening mode gets minimal directives (no-reply + react only)
- Group batch envelopes include compact directive line

**Capability map (corrected from #349):**

| Channel | Reactions | Files | Notes |
|---------|-----------|-------|-------|
| Telegram | yes | yes | MarkdownV2 |
| Slack | yes | yes | mrkdwn |
| Discord | yes | yes | Discord markdown |
| WhatsApp | no | yes | stub addReaction |
| Signal | **yes** | no | via sendReaction JSON-RPC (PR #353) |
| Telegram MTProto | no | no | |

Supersedes #349 (jasoncarreira -- took the design, fixed Signal's flags)
Supersedes #415 (our directive removal -- this approach is better)
Fixes #403

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 624 tests pass (formatter tests updated for capability-conditional rendering)
- [ ] Manual: message via Signal -- should see `<react>` in directives
- [ ] Manual: message via WhatsApp -- should NOT see `<react>` in directives
- [ ] Manual: listening mode message -- should see minimal directives

Written by Cameron ◯ Letta Code