### PR TITLE
feat: /cancel slash command to abort active agent runs

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -254,7 +254,7 @@ Ask the bot owner to approve with:
           return;
         }
         if (this.onCommand) {
-          if (command === 'status' || command === 'reset' || command === 'heartbeat' || command === 'model') {
+          if (command === 'status' || command === 'reset' || command === 'heartbeat' || command === 'cancel' || command === 'model') {
             const result = await this.onCommand(command, message.channel.id, cmdArgs);
             if (result) {
               await message.channel.send(result);

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -259,6 +259,13 @@ export class TelegramAdapter implements ChannelAdapter {
       }
     });
 
+    this.bot.command('cancel', async (ctx) => {
+      if (this.onCommand) {
+        const result = await this.onCommand('cancel', String(ctx.chat.id));
+        if (result) await ctx.reply(result);
+      }
+    });
+
     // Handle /model [handle]
     this.bot.command('model', async (ctx) => {
       if (this.onCommand) {

--- a/src/core/commands.test.ts
+++ b/src/core/commands.test.ts
@@ -26,6 +26,10 @@ describe('parseCommand', () => {
     it('returns { command, args } for /model', () => {
       expect(parseCommand('/model')).toEqual({ command: 'model', args: '' });
     });
+
+    it('returns { command, args } for /cancel', () => {
+      expect(parseCommand('/cancel')).toEqual({ command: 'cancel', args: '' });
+    });
   });
 
   describe('invalid input', () => {
@@ -93,7 +97,7 @@ describe('COMMANDS', () => {
   });
 
   it('has exactly 6 commands', () => {
-    expect(COMMANDS).toHaveLength(6);
+    expect(COMMANDS).toHaveLength(7);
   });
 });
 

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -4,7 +4,7 @@
  * Shared command parsing and help text for all channels.
  */
 
-export const COMMANDS = ['status', 'heartbeat', 'reset', 'help', 'start', 'model'] as const;
+export const COMMANDS = ['status', 'heartbeat', 'reset', 'cancel', 'help', 'start', 'model'] as const;
 export type Command = typeof COMMANDS[number];
 
 export interface ParsedCommand {
@@ -18,6 +18,7 @@ Commands:
 /status - Show current status
 /heartbeat - Trigger heartbeat
 /reset - Reset conversation (keeps agent memory)
+/cancel - Abort the current agent run
 /model - Show current model and list available models
 /model <handle> - Switch to a different model
 /help - Show this message


### PR DESCRIPTION
## Summary

- Adds `/cancel` command to abort a stuck or unwanted agent run from any channel
- Uses `processingKeys` to detect active runs (reuses existing state)
- `cancelledKeys` set signals the stream loop to break on next chunk
- Edits partial streaming message to "(Run cancelled.)"
- Conversation-scoped `cancelConversation()` API (no agent-level fallback)
- Handles `stopReason=cancelled` result flushing on next message
- Registered in Discord command list and Telegram `bot.command()`

Rebased onto latest main (resolves conflicts with /model command from #420).

Fixes #311
Supersedes #366

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 665 tests pass
- [x] Manual: `/cancel` while streaming -- aborts and shows "(Run cancelled.)"
- [x] Manual: `/cancel` when idle -- shows "(Nothing to cancel -- no active run.)"
- [x] Manual: message after cancel -- works normally

Written by Cameron ◯ Letta Code