### PR TITLE
fix: scope cron jobs to individual agents in multi-agent mode

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -956,6 +956,11 @@ export class LettaBot implements AgentSession {
       ? this.store.conversationId
       : this.store.getConversationId(key);
 
+    // Propagate per-agent cron store path to CLI subprocesses (lettabot-schedule)
+    if (this.config.cronStorePath) {
+      process.env.CRON_STORE_PATH = this.config.cronStorePath;
+    }
+
     if (convId) {
       process.env.LETTA_AGENT_ID = this.store.agentId || undefined;
       if (this.store.agentId) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -155,6 +155,9 @@ export interface BotConfig {
   sendFileMaxSize?: number; // Max file size in bytes for <send-file> (default: 50MB)
   sendFileCleanup?: boolean; // Allow <send-file cleanup="true"> to delete files after send (default: false)
 
+  // Cron
+  cronStorePath?: string; // Resolved cron store path (per-agent in multi-agent mode)
+
   // Conversation routing
   conversationMode?: 'shared' | 'per-channel' | 'per-chat'; // Default: shared
   heartbeatConversation?: string; // "dedicated" | "last-active" | "<channel>" (default: last-active)

--- a/src/cron/cli.ts
+++ b/src/cron/cli.ts
@@ -55,8 +55,8 @@ interface CronStore {
   jobs: CronJob[];
 }
 
-// Store path
-const STORE_PATH = getCronStorePath();
+// Store path (CRON_STORE_PATH env var set by bot.ts for per-agent scoping in multi-agent mode)
+const STORE_PATH = process.env.CRON_STORE_PATH || getCronStorePath();
 const LOG_PATH = getCronLogPath();
 
 function migrateLegacyStoreIfNeeded(): void {


### PR DESCRIPTION
## Summary

- In multi-agent mode, each agent now gets its own cron store file (`cron-jobs-{name}.json`) instead of all agents sharing a single `cron-jobs.json`
- Single-agent mode is unchanged (backward compatible)
- On upgrade from single-agent to multi-agent, existing jobs are migrated to the first agent's store; other agents start with empty cron stores

## Details

**Root cause:** `CronService` instances all resolved to the same global `cron-jobs.json` via `getCronStorePath()`. Every agent loaded, scheduled, and executed the same jobs -- causing duplicate execution, duplicate messages, and overwritten `lastResponse` state.

**Fix across 5 files:**
- `src/core/types.ts` -- Added `cronStorePath` to `BotConfig`
- `src/main.ts` -- Computes per-agent store path when `agents.length > 1`, passes to both `BotConfig` and `CronService`
- `src/core/bot.ts` -- Propagates `CRON_STORE_PATH` env var to SDK subprocesses so `lettabot-schedule` CLI resolves to the correct file
- `src/cron/cli.ts` -- Reads `CRON_STORE_PATH` env var with fallback to global path
- `src/cron/service.ts` -- Added `migrateFromGlobalStoreIfNeeded()` for upgrade path

Fixes #428

## Test plan

- [ ] Single-agent config still uses global `cron-jobs.json`
- [ ] Multi-agent config creates separate `cron-jobs-{name}.json` per agent
- [ ] `lettabot-schedule` CLI resolves to correct agent-specific file via env var
- [ ] Migration copies existing jobs to first agent only on upgrade
- [ ] Two agents with cron enabled don't execute each other's jobs
- [ ] All 673 existing tests pass

Written by Cameron ◯ Letta Code

"The only way to do great work is to love what you do." — Steve Jobs