### PR TITLE
fix: throttle streaming edits and handle Telegram 429 rate limits

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1838,6 +1838,7 @@ export class LettaBot implements AgentSession {
       // Stream response with delivery
       let response = '';
       let lastUpdate = 0; // Start at 0 so the first streaming edit fires immediately
+      let rateLimitedUntil = 0; // Timestamp until which we should avoid API calls (429 backoff)
       let messageId: string | null = null;
       let lastMsgType: string | null = null;
       let lastAssistantUuid: string | null = null;
@@ -1880,6 +1881,13 @@ export class LettaBot implements AgentSession {
         }
 
         if (!suppressDelivery && response.trim()) {
+          // Wait out any active rate limit before sending
+          const rlRemaining = rateLimitedUntil - Date.now();
+          if (rlRemaining > 0) {
+            const waitMs = Math.min(rlRemaining, 30_000);
+            log.info(`Waiting ${(waitMs / 1000).toFixed(1)}s for rate limit before finalize`);
+            await new Promise(resolve => setTimeout(resolve, waitMs));
+          }
           try {
             const prefixed = this.prefixResponse(response);
             if (messageId) {
@@ -2038,7 +2046,7 @@ export class LettaBot implements AgentSession {
               || (trimmed.startsWith('<actions') && !trimmed.includes('</actions>'));
             // Strip any completed <actions> block from the streaming text
             const streamText = stripActionsBlock(response).trim();
-            if (canEdit && !mayBeHidden && !suppressDelivery && !this.cancelledKeys.has(convKey) && streamText.length > 0 && Date.now() - lastUpdate > 500) {
+            if (canEdit && !mayBeHidden && !suppressDelivery && !this.cancelledKeys.has(convKey) && streamText.length > 0 && Date.now() - lastUpdate > 1500 && Date.now() > rateLimitedUntil) {
               try {
                 const prefixedStream = this.prefixResponse(streamText);
                 if (messageId) {
@@ -2048,8 +2056,16 @@ export class LettaBot implements AgentSession {
                   messageId = result.messageId;
                   sentAnyMessage = true;
                 }
-              } catch (editErr) {
+              } catch (editErr: any) {
                 log.warn('Streaming edit failed:', editErr instanceof Error ? editErr.message : editErr);
+                // Detect 429 rate limit and suppress further streaming edits
+                const errStr = String(editErr?.message ?? editErr);
+                const retryMatch = errStr.match(/retry after (\d+)/i);
+                if (errStr.includes('429') || retryMatch) {
+                  const retryAfter = retryMatch ? Number(retryMatch[1]) : 30;
+                  rateLimitedUntil = Date.now() + retryAfter * 1000;
+                  log.warn(`Rate limited -- suppressing streaming edits for ${retryAfter}s`);
+                }
               }
               lastUpdate = Date.now();
             }
@@ -2243,6 +2259,13 @@ export class LettaBot implements AgentSession {
       lap('directives done');
       // Send final response
       if (response.trim()) {
+        // Wait out any active rate limit before sending the final message
+        const rateLimitRemaining = rateLimitedUntil - Date.now();
+        if (rateLimitRemaining > 0) {
+          const waitMs = Math.min(rateLimitRemaining, 30_000); // Cap at 30s
+          log.info(`Waiting ${(waitMs / 1000).toFixed(1)}s for rate limit before final send`);
+          await new Promise(resolve => setTimeout(resolve, waitMs));
+        }
         const prefixedFinal = this.prefixResponse(response);
         try {
           if (messageId) {


### PR DESCRIPTION
## Summary

- Increased streaming edit interval from 500ms to 1500ms to stay under Telegram's per-chat rate limit (~1 msg/sec)
- Added 429 detection in the streaming edit catch block -- when rate-limited, suppresses further edits for the `retry_after` duration
- Before the final message send, waits out any active rate limit penalty (capped at 30s) so the user always receives the complete response

Reported in https://discord.com/channels/1161736243340640419/1471247856311603292

## Context

The streaming edit loop was calling `editMessageText` every 500ms (~2 calls/sec per chat). For responses that stream for more than a few seconds, this accumulates rate limit debt with the Telegram Bot API. By the time the final `sendMessage`/`editMessage` fires, Telegram returns `429 Too Many Requests: retry after 126`. The retry also fails (still in penalty window), and the user never receives the response.

## Test plan

- [ ] Send a message that triggers a long streaming response on Telegram
- [ ] Verify streaming updates appear ~every 1.5s instead of every 0.5s
- [ ] Verify the final message is always delivered
- [ ] Confirm no regression on other channels (Discord, WhatsApp, Signal)

Written by Cameron ◯ Letta Code

"The cure for anything is salt water: sweat, tears, or the sea." -- Isak Dinesen