### PR TITLE
feat: make streaming edits toggleable per-channel, disabled by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,17 +65,20 @@ channels:
     enabled: true
     token: "123456:ABC-DEF..."
     dmPolicy: pairing
+    # streaming: true             # Opt-in: progressively edit messages as tokens arrive
 
   slack:
     enabled: true
     botToken: xoxb-...
     appToken: xapp-...
     dmPolicy: pairing
+    # streaming: true
 
   discord:
     enabled: true
     token: "..."
     dmPolicy: pairing
+    # streaming: true
 
   whatsapp:
     enabled: true
@@ -368,6 +371,7 @@ All channels share these common options:
 | `instantGroups` | string[] | Group/channel IDs that bypass debounce entirely (legacy) |
 | `groups` | object | Per-group configuration map (use `*` as default) |
 | `mentionPatterns` | string[] | Extra regex patterns for mention detection (Telegram/WhatsApp/Signal) |
+| `streaming` | boolean | Stream responses via progressive message edits (default: false; Telegram/Discord/Slack only) |
 
 ### Group Message Debouncing
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -26,6 +26,7 @@ export interface DiscordConfig {
   token: string;
   dmPolicy?: DmPolicy;      // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: string[];  // Discord user IDs
+  streaming?: boolean;      // Stream responses via progressive message edits (default: false)
   attachmentsDir?: string;
   attachmentsMaxBytes?: number;
   groups?: Record<string, GroupModeConfig>;  // Per-guild/channel settings
@@ -414,7 +415,7 @@ Ask the bot owner to approve with:
   }
 
   supportsEditing(): boolean {
-    return true;
+    return this.config.streaming ?? false;
   }
 
   private async handleReactionEvent(

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -24,6 +24,7 @@ export interface SlackConfig {
   appToken: string;       // xapp-... (for Socket Mode)
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[]; // Slack user IDs (e.g., U01234567)
+  streaming?: boolean;    // Stream responses via progressive message edits (default: false)
   attachmentsDir?: string;
   attachmentsMaxBytes?: number;
   groups?: Record<string, GroupModeConfig>;  // Per-channel settings
@@ -326,6 +327,10 @@ export class SlackAdapter implements ChannelAdapter {
     return { messageId: ts };
   }
   
+  supportsEditing(): boolean {
+    return this.config.streaming ?? false;
+  }
+
   async editMessage(chatId: string, messageId: string, text: string): Promise<void> {
     if (!this.app) throw new Error('Slack not started');
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -27,6 +27,7 @@ export interface TelegramConfig {
   token: string;
   dmPolicy?: DmPolicy;           // 'pairing' (default), 'allowlist', or 'open'
   allowedUsers?: number[];       // Telegram user IDs (config allowlist)
+  streaming?: boolean;           // Stream responses via progressive message edits (default: false)
   attachmentsDir?: string;
   attachmentsMaxBytes?: number;
   mentionPatterns?: string[];    // Regex patterns for mention detection
@@ -600,6 +601,10 @@ export class TelegramAdapter implements ChannelAdapter {
     return { messageId: String(result.message_id) };
   }
   
+  supportsEditing(): boolean {
+    return this.config.streaming ?? false;
+  }
+
   async editMessage(chatId: string, messageId: string, text: string): Promise<void> {
     const { markdownToTelegramV2 } = await import('./telegram-format.js');
     try {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -273,6 +273,7 @@ export interface TelegramConfig {
   token?: string;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
+  streaming?: boolean;              // Stream responses via progressive message edits (default: false)
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Group chat IDs that bypass batching
@@ -299,6 +300,7 @@ export interface SlackConfig {
   botToken?: string;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
+  streaming?: boolean;              // Stream responses via progressive message edits (default: false)
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Channel IDs that bypass batching
@@ -345,6 +347,7 @@ export interface DiscordConfig {
   token?: string;
   dmPolicy?: 'pairing' | 'allowlist' | 'open';
   allowedUsers?: string[];
+  streaming?: boolean;              // Stream responses via progressive message edits (default: false)
   groupDebounceSec?: number;      // Debounce interval in seconds (default: 5, 0 = immediate)
   groupPollIntervalMin?: number;  // @deprecated Use groupDebounceSec instead
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -2082,7 +2082,7 @@ export class LettaBot implements AgentSession {
             
             // Live-edit streaming for channels that support it
             // Hold back streaming edits while response could still be <no-reply/> or <actions> block
-            const canEdit = adapter.supportsEditing?.() ?? true;
+            const canEdit = adapter.supportsEditing?.() ?? false;
             const trimmed = response.trim();
             const mayBeHidden = '<no-reply/>'.startsWith(trimmed)
               || '<actions>'.startsWith(trimmed)

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,6 +365,7 @@ function createChannelsForAgent(
       allowedUsers: agentConfig.channels.telegram!.allowedUsers && agentConfig.channels.telegram!.allowedUsers.length > 0
         ? agentConfig.channels.telegram!.allowedUsers.map(u => typeof u === 'string' ? parseInt(u, 10) : u)
         : undefined,
+      streaming: agentConfig.channels.telegram!.streaming,
       attachmentsDir,
       attachmentsMaxBytes,
       groups: agentConfig.channels.telegram!.groups,
@@ -396,6 +397,7 @@ function createChannelsForAgent(
       allowedUsers: agentConfig.channels.slack.allowedUsers && agentConfig.channels.slack.allowedUsers.length > 0
         ? agentConfig.channels.slack.allowedUsers
         : undefined,
+      streaming: agentConfig.channels.slack.streaming,
       attachmentsDir,
       attachmentsMaxBytes,
       groups: agentConfig.channels.slack.groups,
@@ -452,6 +454,7 @@ function createChannelsForAgent(
       allowedUsers: agentConfig.channels.discord.allowedUsers && agentConfig.channels.discord.allowedUsers.length > 0
         ? agentConfig.channels.discord.allowedUsers
         : undefined,
+      streaming: agentConfig.channels.discord.streaming,
       attachmentsDir,
       attachmentsMaxBytes,
       groups: agentConfig.channels.discord.groups,


### PR DESCRIPTION
## Summary
- Adds `streaming` boolean to Telegram, Discord, and Slack channel configs (default: `false`)
- Each adapter's `supportsEditing()` now reads from config instead of being hardcoded
- Flips the bot.ts fallback from `?? true` to `?? false` so new adapters also default to off
- Documents the option in `docs/configuration.md`

Streaming edits (progressively editing a message as tokens arrive) cause jittery UX and Telegram 429 rate limits. This makes it opt-in:

```yaml
channels:
  telegram:
    streaming: true  # opt-in
```

## Test plan
- [x] Tested Telegram without `streaming` set -- message delivered as single send, no edits
- [x] `npx tsc --noEmit` passes
- [x] All 697 tests pass

Written by Cameron ◯ Letta Code

"The stream of consciousness is not a river but a decision." — James Gleick