### PR TITLE
fix: install git in Docker image for SDK memory sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY . .
 RUN npm run build
 
 FROM node:22-slim
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- Adds `git` to the runtime Docker image (`node:22-slim` doesn't include it)
- The letta-code-sdk CLI runs `git` for memory sync on startup; without it the process exits with `spawn git ENOENT`

## Test plan
- [x] Verified Railway deploy logs show the crash
- [ ] Redeploy on Railway after merge

Written by Cameron ◯ Letta Code

"In the beginning was the command line." — Neal Stephenson