### PR TITLE
fix: change Grep display label to "Searching files"

### DIFF
--- a/src/core/display.ts
+++ b/src/core/display.ts
@@ -35,7 +35,7 @@ const TOOL_DISPLAY_MAP: Record<string, {
   Edit:                { header: 'Editing',          argKeys: ['file_path'] },
   Write:               { header: 'Writing',          argKeys: ['file_path'] },
   Glob:                { header: 'Finding files',    argKeys: ['pattern'] },
-  Grep:                { header: 'Searching code',   argKeys: ['pattern'] },
+  Grep:                { header: 'Searching files',   argKeys: ['pattern'] },
   Task:                { header: 'Delegating',       argKeys: ['description'] },
   conversation_search: { header: 'Searching conversation history', argKeys: ['query'] },
   archival_memory_search: { header: 'Searching archival memory', argKeys: ['query'] },


### PR DESCRIPTION
## Summary
- Changes the Grep tool's user-facing display header from "Searching code" to "Searching files"
- Grep searches file contents by pattern, not just code -- "Searching files" is more accurate

## Test plan
- [ ] Trigger a Grep tool call, verify the display message says "Searching files" instead of "Searching code"

Written by Cameron ◯ Letta Code