### PR TITLE
docs: add skills architecture and authoring guide

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -146,7 +146,7 @@ See the [Letta Code skills documentation](https://docs.letta.com/letta-code/skil
 
 To add a skill to lettabot:
 
-1. Create a directory under `skills/<name>/` with a `SKILL.md` file. The frontmatter declares metadata (see above). The body is a prompt loaded into the agent's context -- write it as instructions the agent will follow, not as human documentation.
+1. Create a directory under `skills/<name>/` (in the lettabot repo root) with a `SKILL.md` file. The frontmatter declares metadata (see above). The body is a prompt loaded into the agent's context -- write it as instructions the agent will follow, not as human documentation.
 2. Place any executables or scripts alongside `SKILL.md` in the same directory. These become available on the agent's PATH at runtime.
 3. If the skill should be feature-gated (only installed when a config flag is set), add an entry to `FEATURE_SKILLS` in `src/skills/loader.ts` and wire up the corresponding config flag in `main.ts`.
 4. Verify with `lettabot skills status` that the skill is discovered and eligible.


### PR DESCRIPTION
## Summary
- New `docs/skills.md` covering the skills system end-to-end: directory hierarchy, feature-gated installation, SKILL.md format (frontmatter + agent-facing body), runtime PATH injection, bundled skills, CLI commands, and authoring guide
- Links to upstream [Letta Code skills docs](https://docs.letta.com/letta-code/skills) for the general Agent Skills standard
- Added link in `docs/README.md` guides list

## Context
The skills system had no dedicated documentation -- everything was scattered across inline code comments, type definitions, and a few lines in the README. This consolidates it.

## Test plan
- [ ] Verify all internal links resolve (cron-setup.md, skills.sh, clawdhub.com, docs.letta.com)
- [ ] Read through for accuracy against `src/skills/loader.ts`, `types.ts`, `status.ts`, `install.ts`

Written by Cameron ◯ Letta Code

"The beginning of wisdom is the definition of terms." -- Socrates