### PR TITLE
fix: add message chunking to Discord adapter and log delivery failures

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -350,8 +350,14 @@ Ask the bot owner to approve with:
       throw new Error(`Discord channel not found or not text-based: ${msg.chatId}`);
     }
 
-    const result = await (channel as { send: (content: string) => Promise<{ id: string }> }).send(msg.text);
-    return { messageId: result.id };
+    const sendable = channel as { send: (content: string) => Promise<{ id: string }> };
+    const chunks = splitMessageText(msg.text);
+    let lastMessageId = '';
+    for (const chunk of chunks) {
+      const result = await sendable.send(chunk);
+      lastMessageId = result.id;
+    }
+    return { messageId: lastMessageId };
   }
 
   async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
@@ -384,7 +390,12 @@ Ask the bot owner to approve with:
       log.warn('Cannot edit message not sent by bot');
       return;
     }
-    await message.edit(text);
+
+    // Discord edit limit is 2000 chars -- truncate if needed (edits can't split)
+    const truncated = text.length > DISCORD_MAX_LENGTH
+      ? text.slice(0, DISCORD_MAX_LENGTH - 1) + '\u2026'
+      : text;
+    await message.edit(truncated);
   }
 
   async addReaction(chatId: string, messageId: string, emoji: string): Promise<void> {
@@ -557,6 +568,58 @@ function resolveDiscordEmoji(input: string): string {
     return DISCORD_EMOJI_ALIAS_TO_UNICODE[input];
   }
   return input;
+}
+
+// Discord message length limit
+const DISCORD_MAX_LENGTH = 2000;
+// Leave some headroom when choosing split points
+const DISCORD_SPLIT_THRESHOLD = 1900;
+
+/**
+ * Split text into chunks that fit within Discord's 2000-char limit.
+ * Splits at paragraph boundaries (double newlines), falling back to
+ * single newlines, then hard-splitting at the threshold.
+ */
+function splitMessageText(text: string): string[] {
+  if (text.length <= DISCORD_SPLIT_THRESHOLD) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > DISCORD_SPLIT_THRESHOLD) {
+    let splitIdx = -1;
+
+    const searchRegion = remaining.slice(0, DISCORD_SPLIT_THRESHOLD);
+    // Try paragraph boundary (double newline)
+    const lastParagraph = searchRegion.lastIndexOf('\n\n');
+    if (lastParagraph > DISCORD_SPLIT_THRESHOLD * 0.3) {
+      splitIdx = lastParagraph;
+    }
+
+    // Fall back to single newline
+    if (splitIdx === -1) {
+      const lastNewline = searchRegion.lastIndexOf('\n');
+      if (lastNewline > DISCORD_SPLIT_THRESHOLD * 0.3) {
+        splitIdx = lastNewline;
+      }
+    }
+
+    // Hard split as last resort
+    if (splitIdx === -1) {
+      splitIdx = DISCORD_SPLIT_THRESHOLD;
+    }
+
+    chunks.push(remaining.slice(0, splitIdx).trimEnd());
+    remaining = remaining.slice(splitIdx).trimStart();
+  }
+
+  if (remaining.trim()) {
+    chunks.push(remaining.trim());
+  }
+
+  return chunks;
 }
 
 type DiscordAttachment = {

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1642,8 +1642,13 @@ export class LettaBot implements AgentSession {
               await adapter.sendMessage({ chatId: msg.chatId, text: prefixed, threadId: msg.threadId });
             }
             sentAnyMessage = true;
-          } catch {
-            if (messageId) sentAnyMessage = true;
+          } catch (finalizeErr) {
+            if (messageId) {
+              // Edit failed but original message was already visible
+              sentAnyMessage = true;
+            } else {
+              log.warn('finalizeMessage send failed:', finalizeErr instanceof Error ? finalizeErr.message : finalizeErr);
+            }
           }
         }
         response = '';
@@ -2060,8 +2065,9 @@ export class LettaBot implements AgentSession {
           }
           sentAnyMessage = true;
           this.store.resetRecoveryAttempts();
-        } catch {
+        } catch (sendErr) {
           // Edit failed -- send as new message so user isn't left with truncated text
+          log.warn('Final message delivery failed:', sendErr instanceof Error ? sendErr.message : sendErr);
           try {
             await adapter.sendMessage({ chatId: msg.chatId, text: prefixedFinal, threadId: msg.threadId });
             sentAnyMessage = true;


### PR DESCRIPTION
## Summary

- Discord's `sendMessage()` had no message splitting -- responses over 2000 chars were silently rejected by the Discord API. With streaming edits disabled by default (#436), the full response is now sent in a single call instead of being streamed incrementally, making this a visible regression for any agent producing longer replies (user sees "The agent processed your message but didn't produce a visible response" instead of the actual content).
- Adds `splitMessageText()` to the Discord adapter (splits at paragraph/line boundaries, 1900-char threshold) matching the pattern already used in the Telegram adapter.
- Truncates `editMessage()` content at 2000 chars with ellipsis when streaming edits are enabled (edits can't be split into multiple messages).
- Logs delivery failures in two bot.ts catch blocks (`finalizeMessage` and final send) that were previously bare catches silently swallowing errors -- this was hiding the root cause from logs entirely.

Reported by anna and Vedant in Discord community.

## Test plan

- [ ] Send a message to a Discord bot that triggers a response longer than 2000 chars -- should arrive as multiple sequential messages instead of the "no visible response" error
- [ ] With `streaming: true` enabled on Discord, verify long streaming responses truncate gracefully on edit rather than throwing
- [ ] Verify short messages (under 1900 chars) still send as a single message with no behavior change
- [ ] Check server logs for new warning messages on delivery failures

Written by Cameron ◯ Letta Code

"The significant problems we face cannot be solved at the same level of thinking we were at when we created them." -- Albert Einstein