### PR TITLE
docs: note that skills CLI commands are directory-scoped

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -140,6 +140,8 @@ lettabot skills sync
 lettabot skills status
 ```
 
+> **Important:** These commands discover skills relative to the current working directory. Run them from the lettabot project root to ensure all project-level skills (`.skills/`) and bundled skills (`skills/`) are found. Running from a different directory will only show globally installed skills.
+
 External skill sources:
 
 - [Clawdhub](https://clawdhub.com/) -- `npx clawdhub@latest install <skill>`


### PR DESCRIPTION
## Summary

- Adds a callout to `docs/skills.md` noting that `lettabot skills sync` and related CLI commands discover skills relative to the current working directory
- Running from outside the lettabot project root silently misses project-level (`.skills/`) and bundled (`skills/`) skills, which was confusing users (reported by Ed T in Discord)

## Test plan

- [ ] Documentation-only change, no code impact

Written by Cameron ◯ Letta Code

"The beginning of wisdom is the definition of terms." -- Socrates