### PR TITLE
fix: add diagnostic logging when agent skips lettabot-message CLI in silent mode

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1573,10 +1573,15 @@ export class LettaBot implements AgentSession {
         try {
           let response = '';
           let sawStaleDuplicateResult = false;
+          let usedMessageCli = false;
           let lastErrorDetail: { message: string; stopReason: string; apiError?: Record<string, unknown> } | undefined;
           for await (const msg of stream()) {
             if (msg.type === 'tool_call') {
               this.sessionManager.syncTodoToolCall(msg);
+              if (isSilent && msg.toolName === 'Bash') {
+                const cmd = String((msg as any).toolInput?.command ?? msg.rawArguments ?? '');
+                if (cmd.includes('lettabot-message send')) usedMessageCli = true;
+              }
             }
             if (msg.type === 'error') {
               lastErrorDetail = {
@@ -1626,7 +1631,11 @@ export class LettaBot implements AgentSession {
           }
 
           if (isSilent && response.trim()) {
-            log.info(`Silent mode: collected ${response.length} chars (not delivered)`);
+            if (usedMessageCli) {
+              log.info(`Silent mode: agent used lettabot-message CLI, collected ${response.length} chars (not delivered)`);
+            } else {
+              log.warn(`Silent mode: agent produced ${response.length} chars but did NOT use lettabot-message CLI — response discarded. If this keeps happening, the agent's model may not be following silent mode instructions.`);
+            }
           }
           return response;
         } catch (error) {


### PR DESCRIPTION
## Summary

Track whether the agent called `lettabot-message send` during a silent mode run (heartbeat, polling, cron). When the agent produces text but never used the CLI, log a warning explaining the response was discarded.

Before:
```
[Bot] Silent mode: collected 82 chars (not delivered)
```

After (when agent used CLI):
```
[Bot] Silent mode: agent used lettabot-message CLI, collected 82 chars (not delivered)
```

After (when agent did NOT use CLI):
```
[Bot] Silent mode: agent produced 82 chars but did NOT use lettabot-message CLI — response discarded. If this keeps happening, the agent's model may not be following silent mode instructions.
```

No behavioral change -- silent mode semantics are preserved. This is diagnostic-only to help operators debug issues like #446.

## Test plan

- [x] All 20 sdk-session-contract tests pass
- [x] TypeScript builds cleanly

Related: #446, #475

Written by Cameron ◯ Letta Code

"All problems in computer science can be solved by another level of indirection."
  — David Wheeler