### PR TITLE
fix: close API server on shutdown to prevent EADDRINUSE

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -814,9 +814,10 @@ async function main() {
     services.cronServices.forEach(c => c.stop());
     services.pollingServices.forEach(p => p.stop());
     await gateway.stop();
+    apiServer.close();
     process.exit(0);
   };
-  
+
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
 }


### PR DESCRIPTION
## Summary
- Adds `apiServer.close()` to the shutdown handler in `src/main.ts`
- Without this, the HTTP API server on port 8080 is never closed during graceful shutdown, causing `EADDRINUSE` errors on restart

## Details
The `shutdown()` function stops all services (group batchers, heartbeat, cron, polling) and calls `gateway.stop()`, but never closes the API server. When the process exits and is restarted quickly, the port is still held by the OS, causing the new process to crash.

## Test plan
- Start lettabot with `lettabot server`
- Send SIGINT (Ctrl+C) to stop
- Immediately restart — should bind to port 8080 without `EADDRINUSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)