### PR TITLE
feat(discord): add daily rate limiting for group messages

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -12,6 +12,7 @@ import { isUserAllowed, upsertPairingRequest } from '../pairing/store.js';
 import { buildAttachmentPath, downloadToFile } from './attachments.js';
 import { HELP_TEXT } from '../core/commands.js';
 import { isGroupAllowed, isGroupUserAllowed, resolveGroupMode, resolveReceiveBotMessages, type GroupModeConfig } from './group-mode.js';
+import { incrementAndCheck } from '../rate-limit/store.js';
 import { basename } from 'node:path';
 
 import { createLogger } from '../logger.js';
@@ -285,6 +286,22 @@ Ask the bot owner to approve with:
 
           if (!isGroupUserAllowed(this.config.groups, keys, userId)) {
             return; // User not in group allowedUsers -- silent drop
+          }
+
+          const effectiveConfig = (() => {
+            for (const key of keys) {
+              if (this.config.groups?.[key]) return this.config.groups[key];
+            }
+            return this.config.groups?.['*'];
+          })();
+          if (effectiveConfig?.dailyLimit) {
+            const allowed = await incrementAndCheck(chatId, userId, effectiveConfig.dailyLimit);
+            if (!allowed) {
+              if (effectiveConfig.onLimitReached === 'notify') {
+                await message.reply('You have reached your daily message limit for this group.');
+              }
+              return;
+            }
           }
 
           const mode = resolveGroupMode(this.config.groups, keys, 'open');

--- a/src/channels/group-mode.ts
+++ b/src/channels/group-mode.ts
@@ -10,6 +10,10 @@ export interface GroupModeConfig {
   allowedUsers?: string[];
   /** Process messages from other bots instead of dropping them. Default: false. */
   receiveBotMessages?: boolean;
+  /** Maximum messages per user per day in this group. Default: unlimited. */
+  dailyLimit?: number;
+  /** What to do when daily limit is reached. Default: 'silent'. */
+  onLimitReached?: 'silent' | 'notify';
   /**
    * @deprecated Use mode: "mention-only" (true) or "open" (false).
    */

--- a/src/rate-limit/store.ts
+++ b/src/rate-limit/store.ts
@@ -1,0 +1,30 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DATA_DIR = 'data/rate-limits';
+const getPath = (channel: string) => join(DATA_DIR, `${channel}-daily.json`);
+
+type DailyStore = { date: string; counts: Record<string, number> };
+
+export async function incrementAndCheck(
+  channel: string,
+  key: string,
+  limit: number
+): Promise<boolean> {
+  await mkdir(DATA_DIR, { recursive: true });
+  const path = getPath(channel);
+  const today = new Date().toISOString().slice(0, 10);
+
+  let store: DailyStore = { date: today, counts: {} };
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as DailyStore;
+    if (parsed.date === today) store = parsed;
+  } catch { /* first run or stale file */ }
+
+  const count = (store.counts[key] ?? 0) + 1;
+  store.counts[key] = count;
+  await writeFile(path, JSON.stringify(store), 'utf8');
+
+  return count <= limit;
+}


### PR DESCRIPTION
## Summary
- Added daily rate limiting feature for Discord group messages
- New dailyLimit and onLimitReached config options in GroupModeConfig
- Created rate-limit store module with persistent daily counters per channel/user

## Changes
- Added src/rate-limit/store.ts with incrementAndCheck function
- Updated GroupModeConfig interface with dailyLimit?: number and onLimitReached?: 'silent' | 'notify'
- Integrated rate limiting in Discord adapter's group gating logic