### PR TITLE
fix: use sender phone number as userId for WhatsApp group messages

### DIFF
--- a/src/channels/whatsapp/index.ts
+++ b/src/channels/whatsapp/index.ts
@@ -691,7 +691,7 @@ export class WhatsAppAdapter implements ChannelAdapter {
       }
 
       const { body, from, chatId, pushName, senderE164, chatType, isSelfChat: isExtractedSelfChat } = extracted;
-      const userId = normalizePhoneForStorage(from);
+      const userId = normalizePhoneForStorage(senderE164 || from);
       const isGroup = chatType === "group";
 
       // CRITICAL: Skip messages older than connection time (prevents duplicate responses on reconnect)

--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -80,10 +80,30 @@ describe('formatMessageEnvelope', () => {
   });
 
   describe('sender formatting', () => {
-    it('uses userName when available', () => {
+    it('uses userName when available (non-phone channels)', () => {
       const msg = createMessage({ userName: 'John Doe' });
       const result = formatMessageEnvelope(msg);
       expect(result).toContain('**Sender**: John Doe');
+    });
+
+    it('includes phone number alongside name for WhatsApp', () => {
+      const msg = createMessage({
+        channel: 'whatsapp',
+        userName: 'John',
+        userId: '+15551234567',
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('**Sender**: John (+1 (555) 123-4567)');
+    });
+
+    it('includes phone number alongside name for Signal', () => {
+      const msg = createMessage({
+        channel: 'signal',
+        userName: 'Jane',
+        userId: '+15559876543',
+      });
+      const result = formatMessageEnvelope(msg);
+      expect(result).toContain('**Sender**: Jane (+1 (555) 987-6543)');
     });
 
     it('formats Slack users with @ prefix', () => {

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -87,34 +87,37 @@ function formatPhoneNumber(phone: string): string {
  * Format the sender identifier nicely based on channel
  */
 function formatSender(msg: InboundMessage): string {
-  // Use display name if available
-  if (msg.userName?.trim()) {
-    return msg.userName.trim();
-  }
-  
+  const name = msg.userName?.trim();
+
   // Format based on channel
   switch (msg.channel) {
     case 'slack':
       // Add @ prefix for Slack usernames/IDs
-      return msg.userHandle ? `@${msg.userHandle}` : `@${msg.userId}`;
+      return name || (msg.userHandle ? `@${msg.userHandle}` : `@${msg.userId}`);
 
     case 'discord':
       // Add @ prefix for Discord usernames/IDs
-      return msg.userHandle ? `@${msg.userHandle}` : `@${msg.userId}`;
+      return name || (msg.userHandle ? `@${msg.userHandle}` : `@${msg.userId}`);
     
     case 'whatsapp':
-    case 'signal':
-      // Format phone numbers nicely
-      if (/^\+?\d{10,}$/.test(msg.userId.replace(/\D/g, ''))) {
+    case 'signal': {
+      // For phone-based channels, always include the phone number so the agent
+      // can uniquely identify senders (pushName is user-chosen and not unique).
+      const isPhone = /^\+?\d{10,}$/.test(msg.userId.replace(/\D/g, ''));
+      if (name && isPhone) {
+        return `${name} (${formatPhoneNumber(msg.userId)})`;
+      }
+      if (isPhone) {
         return formatPhoneNumber(msg.userId);
       }
-      return msg.userId;
+      return name || msg.userId;
+    }
     
     case 'telegram':
-      return msg.userHandle ? `@${msg.userHandle}` : msg.userId;
+      return name || (msg.userHandle ? `@${msg.userHandle}` : msg.userId);
     
     default:
-      return msg.userId;
+      return name || msg.userId;
   }
 }
 


### PR DESCRIPTION
## Summary

- In WhatsApp group chats, `userId` was derived from the group JID instead of the individual sender's phone number, making it impossible for the agent to uniquely identify users in groups
- Now uses `senderE164` (the actual sender phone) for `userId` in group messages, with fallback to `from` for DMs (no behavior change)
- Updates `formatSender()` to always include the phone number alongside the display name for WhatsApp/Signal channels (e.g., `John (+1 (555) 123-4567)` instead of just `John`)
- Fixes debouncer keying (was per-group, now correctly per-sender-per-group) and `dailyUserLimit` tracking (was counting all group members as one user)

Reported by Signo on Discord.

## Test plan

- [x] Formatter tests pass (49/49, including 2 new tests for phone-alongside-name)
- [x] TypeScript compiles cleanly
- [ ] Manual test: send message in WhatsApp group, verify agent sees sender phone number in metadata
- [ ] Manual test: send DM on WhatsApp, verify no behavior change

Written by Cameron ◯ Letta Code

"The most profound technologies are those that disappear." -- Mark Weiser