### PR TITLE
feat: add ignoreBotReactions config toggle for Discord

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -34,6 +34,7 @@ export interface DiscordConfig {
   attachmentsMaxBytes?: number;
   groups?: Record<string, GroupModeConfig>;  // Per-guild/channel settings
   agentName?: string;       // For scoping daily limit counters in multi-agent mode
+  ignoreBotReactions?: boolean;   // Ignore all bot reactions (default: true). Set false for multi-bot setups.
 }
 
 export function shouldProcessDiscordBotMessage(params: {
@@ -434,7 +435,11 @@ Ask the bot owner to approve with:
     user: import('discord.js').User | import('discord.js').PartialUser,
     action: InboundReaction['action']
   ): Promise<void> {
-    if ('bot' in user && user.bot) return;
+    // By default ignore all bot reactions; when ignoreBotReactions is false,
+    // only ignore self-reactions (allows multi-bot setups)
+    const ignoreBots = this.config.ignoreBotReactions ?? true;
+    if (ignoreBots && 'bot' in user && user.bot) return;
+    if (!ignoreBots && user.id === this.client?.user?.id) return;
 
     try {
       if (reaction.partial) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -372,6 +372,7 @@ export interface DiscordConfig {
   instantGroups?: string[];       // Guild/server IDs or channel IDs that bypass batching
   listeningGroups?: string[];     // @deprecated Use groups.<id>.mode = "listen"
   groups?: Record<string, GroupConfig>;  // Per-guild/channel settings, "*" for defaults
+  ignoreBotReactions?: boolean;   // Ignore all bot reactions (default: true). Set false for multi-bot setups.
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -467,6 +467,7 @@ function createChannelsForAgent(
       attachmentsMaxBytes,
       groups: agentConfig.channels.discord.groups,
       agentName: agentConfig.name,
+      ignoreBotReactions: agentConfig.channels.discord.ignoreBotReactions,
     }));
   }
 


### PR DESCRIPTION
## Summary
- Add `ignoreBotReactions` config option to Discord channel config (default: `true`)
- When `true` (default): ignores all bot reactions (current behavior, backward compatible)
- When `false`: only ignores self-reactions, allowing multi-bot setups where bots react to each other

Fixes #498

## Config example

```yaml
channels:
  discord:
    ignoreBotReactions: false  # allow other bots' reactions through
```

## Test plan
- [ ] Verify default behavior unchanged (bot reactions still ignored)
- [ ] Verify `ignoreBotReactions: false` allows other bots' reactions but not self-reactions

Written by Cameron ◯ Letta Code

  "Simplicity is the ultimate sophistication." -- Leonardo da Vinci