### PR TITLE
fix: resolve WhatsApp LID to phone number for inbound DMs

### DIFF
--- a/src/channels/whatsapp/inbound/extract.test.ts
+++ b/src/channels/whatsapp/inbound/extract.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GroupMetaCache } from '../utils.js';
+import { extractInboundMessage } from './extract.js';
+
+const REMOTE_LID = '210501234567890@lid';
+
+function createMessage(
+  overrides: {
+    key?: Record<string, unknown>;
+    message?: Record<string, unknown>;
+    messageTimestamp?: number;
+    pushName?: string;
+  } = {}
+): Record<string, unknown> {
+  const { key: keyOverrides, message: messageOverrides, ...rest } = overrides;
+  return {
+    key: {
+      remoteJid: REMOTE_LID,
+      id: 'msg-1',
+      ...keyOverrides,
+    },
+    message: {
+      conversation: 'hello from web',
+      ...messageOverrides,
+    },
+    messageTimestamp: 1700000000,
+    pushName: 'Alice',
+    ...rest,
+  };
+}
+
+function createSocket(options: { lidMapping?: Map<string, string> } = {}): Record<string, unknown> {
+  return {
+    user: { id: '19998887777@s.whatsapp.net' },
+    signalRepository: options.lidMapping ? { lidMapping: options.lidMapping } : {},
+    groupMetadata: vi.fn(),
+  };
+}
+
+function createGroupMetaCache(): GroupMetaCache {
+  return {
+    get: vi.fn(async () => ({ expires: Date.now() + 60_000 })),
+    clear: vi.fn(),
+  };
+}
+
+describe('extractInboundMessage (LID DM resolution)', () => {
+  it('resolves LID DMs via senderPn and normalizes chatId to a PN JID', async () => {
+    const msg = createMessage({
+      key: {
+        senderPn: '15551234567@s.whatsapp.net',
+      },
+    });
+    const sock = createSocket();
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.chatId).toBe('15551234567@s.whatsapp.net');
+    expect(extracted?.from).toBe('15551234567');
+    expect(extracted?.senderE164).toBe('15551234567');
+  });
+
+  it('falls back to signalRepository.lidMapping when senderPn is missing', async () => {
+    const msg = createMessage();
+    const sock = createSocket({
+      lidMapping: new Map([[REMOTE_LID, '16667778888@s.whatsapp.net']]),
+    });
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.chatId).toBe('16667778888@s.whatsapp.net');
+    expect(extracted?.from).toBe('16667778888');
+    expect(extracted?.senderE164).toBe('16667778888');
+  });
+
+  it('falls back to the LID-derived number when no mapping is available', async () => {
+    const msg = createMessage();
+    const sock = createSocket();
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.chatId).toBe(REMOTE_LID);
+    expect(extracted?.from).toBe('210501234567890');
+    expect(extracted?.senderE164).toBe('210501234567890');
+  });
+
+  it('accepts plain phone-number senderPn values by converting them to PN JIDs', async () => {
+    const msg = createMessage({
+      key: {
+        senderPn: '+1 (555) 222-3333',
+      },
+    });
+    const sock = createSocket();
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.chatId).toBe('15552223333@s.whatsapp.net');
+    expect(extracted?.from).toBe('15552223333');
+    expect(extracted?.senderE164).toBe('15552223333');
+  });
+});

--- a/src/channels/whatsapp/inbound/extract.ts
+++ b/src/channels/whatsapp/inbound/extract.ts
@@ -141,15 +141,35 @@ function resolveLidToPhoneJid(
   msg: import("@whiskeysockets/baileys").WAMessage,
   sock: import("@whiskeysockets/baileys").WASocket
 ): string | null {
+  const normalizePhoneJid = (value: string | undefined): string | null => {
+    if (!value) return null;
+
+    const trimmed = value.trim();
+    if (!trimmed || isLid(trimmed)) {
+      return null;
+    }
+
+    if (trimmed.includes('@')) {
+      return trimmed;
+    }
+
+    // Defensive fallback: handle plain phone numbers by converting to a PN JID.
+    const digits = trimmed.replace(/[^\d]/g, '');
+    if (!digits) {
+      return null;
+    }
+    return `${digits}@s.whatsapp.net`;
+  };
+
   // Try senderPn from message key (most reliable)
-  const senderPn = (msg.key as any).senderPn;
-  if (senderPn && typeof senderPn === 'string') {
+  const senderPn = normalizePhoneJid(msg.key?.senderPn);
+  if (senderPn) {
     return senderPn;
   }
 
   // Try signalRepository.lidMapping (Baileys built-in)
   const signalRepo = sock.signalRepository as unknown as { lidMapping?: Map<string, string> } | undefined;
-  const signalMapping = signalRepo?.lidMapping?.get(lidJid);
+  const signalMapping = normalizePhoneJid(signalRepo?.lidMapping?.get(lidJid));
   if (signalMapping) {
     return signalMapping;
   }


### PR DESCRIPTION
## Summary
- When a user messages from WhatsApp Web, their JID uses `@lid` format instead of `@s.whatsapp.net`
- Without resolution, the same user gets different `userId`s depending on their device, breaking debouncing, daily limits, and conversation routing
- Added `resolveLidToPhoneJid()` that resolves LIDs via `msg.key.senderPn` (Baileys field) or `sock.signalRepository.lidMapping` (same source the outbound code uses)
- Falls back to LID-stripped number if resolution fails (backward compatible)
- Also normalizes `chatId` to the resolved phone JID so the same DM conversation doesn't split across two chat IDs

Fixes #504

## Test plan
- [ ] Send message from WhatsApp Web (LID JID) -- verify agent sees phone number, not opaque LID
- [ ] Send message from phone app -- verify no behavior change
- [ ] Verify debouncer correctly groups messages from same user across devices
- [ ] Verify daily limits count same user once, not twice

Written by Cameron ◯ Letta Code

  "The best code is no code at all." -- Jeff Atwood