### PR TITLE
fix: enable link preview generation for WhatsApp outbound messages

### DIFF
--- a/src/channels/whatsapp/outbound.ts
+++ b/src/channels/whatsapp/outbound.ts
@@ -6,13 +6,29 @@
  */
 
 import type { OutboundMessage, OutboundFile } from "../../core/types.js";
-import type { WAMessage } from '@whiskeysockets/baileys';
+import type { WAMessage, WAUrlInfo } from '@whiskeysockets/baileys';
 import { isLid } from "./utils.js";
 import { basename } from "node:path";
 
 import { createLogger } from '../../logger.js';
 
 const log = createLogger('WhatsApp');
+
+/**
+ * URL detection regex - matches https:// URLs.
+ * This is the same pattern Baileys uses internally for link preview detection.
+ * @see https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
+ */
+const URL_REGEX = /https:\/\/(?![^:@\/\s]+:[^:@\/\s]+@)[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(:\d+)?(\/[^\s]*)?/g;
+
+/**
+ * Extract the first URL from text.
+ * Used to enable link previews in WhatsApp messages.
+ */
+function extractUrl(text: string): string | null {
+  const matches = text.match(URL_REGEX);
+  return matches?.[0] ?? null;
+}
 /**
  * LID (Linked Identifier) mapping for message sending.
  * Maps LID addresses to real JIDs.
@@ -121,8 +137,26 @@ export async function sendWhatsAppMessage(
       // Ignore presence errors
     }
 
+    // Build message content with link preview support
+    // Baileys will auto-generate link previews, but we need to ensure
+    // matchedText is set even if preview fetch fails (network timeout, etc.)
+    // This ensures URLs are always clickable/tappable in WhatsApp.
+    const url = extractUrl(msg.text);
+    const messageContent: { text: string; linkPreview?: WAUrlInfo } = { text: msg.text };
+
+    if (url) {
+      // Provide minimal linkPreview with matched-text to ensure URL is clickable.
+      // Baileys will try to fetch full preview data (title, description, thumbnail),
+      // but if that fails, the URL will still be tappable because matched-text is set.
+      messageContent.linkPreview = {
+        'canonical-url': url,
+        'matched-text': url,
+        title: '',  // Will be filled by Baileys if preview fetch succeeds
+      };
+    }
+
     // Send message
-    const result = await sock.sendMessage(targetJid, { text: msg.text });
+    const result = await sock.sendMessage(targetJid, messageContent);
     const messageId = result?.key?.id || "";
     const message = result?.message;
 


### PR DESCRIPTION
## Summary
- URLs in agent responses were arriving as plain text in WhatsApp without link previews
- Added URL detection and minimal `linkPreview` object with `matched-text` field so WhatsApp renders URLs as clickable
- Baileys auto-fetches full preview data (title, description, thumbnail) when possible, but the URL remains tappable even if the preview fetch fails
- Only matches `https://` URLs (WhatsApp requires HTTPS for link previews)

Fixes #505

## Test plan
- [ ] Send message containing a URL -- verify it renders as clickable in WhatsApp
- [ ] Send message without URLs -- verify no behavior change
- [ ] Send message with multiple URLs -- verify first URL gets preview treatment

Written by Cameron ◯ Letta Code

  "Make it work, make it right, make it fast." -- Kent Beck