### PR TITLE
test: add runId type field and foreground-run stream filtering tests

### DIFF
--- a/src/core/result-guard.test.ts
+++ b/src/core/result-guard.test.ts
@@ -158,4 +158,139 @@ describe('result divergence guard', () => {
     expect(lastSent).not.toContain('Evaluating response protocol');
     expect(lastSent).toMatch(/\(.*\)/); // Parenthesized system message
   });
+
+  it('filters non-foreground run events during processMessage stream delivery', async () => {
+    const bot = new LettaBot({
+      workingDir: workDir,
+      allowedTools: [],
+      display: { showReasoning: true, showToolCalls: true },
+    });
+
+    const adapter = {
+      id: 'mock',
+      name: 'Mock',
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      isRunning: vi.fn(() => true),
+      sendMessage: vi.fn(async (_msg: OutboundMessage) => ({ messageId: 'msg-1' })),
+      editMessage: vi.fn(async () => {}),
+      sendTypingIndicator: vi.fn(async () => {}),
+      stopTypingIndicator: vi.fn(async () => {}),
+      supportsEditing: vi.fn(() => false),
+      sendFile: vi.fn(async () => ({ messageId: 'file-1' })),
+    };
+
+    (bot as any).sessionManager.runSession = vi.fn(async () => ({
+      session: { abort: vi.fn(async () => {}) },
+      stream: async function* () {
+        yield { type: 'assistant', content: 'primary ', runId: 'run-main' };
+        yield { type: 'reasoning', content: 'background-thinking', runId: 'run-bg' };
+        yield { type: 'tool_call', toolCallId: 'tc-bg', toolName: 'Bash', toolInput: { command: 'echo leak' }, runId: 'run-bg' };
+        yield { type: 'assistant', content: 'background text', runId: 'run-bg' };
+        yield { type: 'assistant', content: 'reply', runId: 'run-main' };
+        yield { type: 'result', success: true, result: 'primary reply', runIds: ['run-main'] };
+      },
+    }));
+
+    const msg: InboundMessage = {
+      channel: 'discord',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      text: 'hello',
+      timestamp: new Date(),
+    };
+
+    await (bot as any).processMessage(msg, adapter);
+
+    const sentTexts = adapter.sendMessage.mock.calls.map(([payload]) => payload.text);
+    expect(sentTexts).toEqual(['primary reply']);
+  });
+
+  it('defers pre-foreground run-scoped events until assistant run is known', async () => {
+    const bot = new LettaBot({
+      workingDir: workDir,
+      allowedTools: [],
+      display: { showReasoning: true, showToolCalls: true },
+    });
+
+    const adapter = {
+      id: 'mock',
+      name: 'Mock',
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      isRunning: vi.fn(() => true),
+      sendMessage: vi.fn(async (_msg: OutboundMessage) => ({ messageId: 'msg-1' })),
+      editMessage: vi.fn(async () => {}),
+      sendTypingIndicator: vi.fn(async () => {}),
+      stopTypingIndicator: vi.fn(async () => {}),
+      supportsEditing: vi.fn(() => false),
+      sendFile: vi.fn(async () => ({ messageId: 'file-1' })),
+    };
+
+    (bot as any).sessionManager.runSession = vi.fn(async () => ({
+      session: { abort: vi.fn(async () => {}) },
+      stream: async function* () {
+        yield { type: 'reasoning', content: 'background-thinking', runId: 'run-bg' };
+        yield { type: 'tool_call', toolCallId: 'tc-bg', toolName: 'Bash', toolInput: { command: 'echo leak' }, runId: 'run-bg' };
+        yield { type: 'assistant', content: 'main reply', runId: 'run-main' };
+        yield { type: 'result', success: true, result: 'main reply', runIds: ['run-main'] };
+      },
+    }));
+
+    const msg: InboundMessage = {
+      channel: 'discord',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      text: 'hello',
+      timestamp: new Date(),
+    };
+
+    await (bot as any).processMessage(msg, adapter);
+
+    const sentTexts = adapter.sendMessage.mock.calls.map(([payload]) => payload.text);
+    expect(sentTexts).toEqual(['main reply']);
+  });
+
+  it('switches foreground run at result boundary when initial assistant chunks are stale', async () => {
+    const bot = new LettaBot({
+      workingDir: workDir,
+      allowedTools: [],
+    });
+
+    const adapter = {
+      id: 'mock',
+      name: 'Mock',
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      isRunning: vi.fn(() => true),
+      sendMessage: vi.fn(async (_msg: OutboundMessage) => ({ messageId: 'msg-1' })),
+      editMessage: vi.fn(async () => {}),
+      sendTypingIndicator: vi.fn(async () => {}),
+      stopTypingIndicator: vi.fn(async () => {}),
+      supportsEditing: vi.fn(() => false),
+      sendFile: vi.fn(async () => ({ messageId: 'file-1' })),
+    };
+
+    (bot as any).sessionManager.runSession = vi.fn(async () => ({
+      session: { abort: vi.fn(async () => {}) },
+      stream: async function* () {
+        yield { type: 'assistant', content: 'background ', runId: 'run-bg' };
+        yield { type: 'assistant', content: 'main reply', runId: 'run-main' };
+        yield { type: 'result', success: true, result: 'main reply', runIds: ['run-main'] };
+      },
+    }));
+
+    const msg: InboundMessage = {
+      channel: 'discord',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      text: 'hello',
+      timestamp: new Date(),
+    };
+
+    await (bot as any).processMessage(msg, adapter);
+
+    const sentTexts = adapter.sendMessage.mock.calls.map(([payload]) => payload.text);
+    expect(sentTexts).toEqual(['main reply']);
+  });
 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -196,6 +196,7 @@ export interface StreamMsg {
   toolCallId?: string;
   toolName?: string;
   uuid?: string;
+  runId?: string;
   isError?: boolean;
   result?: string;
   runIds?: string[];


### PR DESCRIPTION
## Summary
- Adds `runId?: string` to `StreamMsg` interface -- the per-event run identifier that the already-landed foreground-run filtering logic in `bot.ts` depends on
- Adds 3 tests covering the filtering behavior: non-foreground event suppression, pre-foreground deferral, and foreground-run switching at result boundaries

These were left as uncommitted local changes when the implementation shipped.

## Test plan
- [x] `vitest run src/core/result-guard.test.ts` -- all 6 tests pass (3 existing + 3 new)

Written by Cameron ◯ Letta Code