### PR TITLE
fix: restore public store and invalidateSession on LettaBot

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -187,7 +187,7 @@ export function resolveHeartbeatConversationKey(
 }
 
 export class LettaBot implements AgentSession {
-  private store: Store;
+  readonly store: Store;
   private config: BotConfig;
   private channels: Map<string, ChannelAdapter> = new Map();
   private messageQueue: Array<{ msg: InboundMessage; adapter: ChannelAdapter }> = [];
@@ -483,6 +483,14 @@ export class LettaBot implements AgentSession {
    */
   async warmSession(): Promise<void> {
     return this.sessionManager.warmSession();
+  }
+
+  /**
+   * Invalidate cached session(s), forcing a fresh session on next message.
+   * The next message will create a fresh session using the current store state.
+   */
+  invalidateSession(key?: string): void {
+    this.sessionManager.invalidateSession(key);
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary
- Restore `readonly store: Store` (was changed to `private` by Codex commit in #513)
- Restore public `invalidateSession(key?)` method (was removed by same commit)

Both are accessed from `main.ts:782-783` (added in #512 for set-conversation support). Without this fix, `npx tsc --noEmit` fails on main.

## Test plan
- [x] `npx tsc --noEmit` passes

Written by Cameron ◯ Letta Code

  "First, solve the problem. Then, write the code." -- John Johnson