### PR TITLE
test: add Docker image build check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,13 @@ jobs:
         env:
           LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
           LETTA_E2E_AGENT_ID: ${{ secrets.LETTA_E2E_AGENT_ID }}
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        # Ensures Dockerfile build path stays healthy on main and PRs.
+        run: docker build --tag lettabot:test .


### PR DESCRIPTION
## Summary
- add a dedicated `Docker Build` job to `.github/workflows/test.yml`
- run `docker build --tag lettabot:test .` on pushes/PRs to `main`
- catch Docker-path TypeScript/build regressions before release

## Test plan
- [x] `docker build --tag lettabot:test .` (local)
- [ ] GitHub Actions `Docker Build` job passes on this PR

👾 Generated with [Letta Code](https://letta.com)