### PR TITLE
docs: document /api/v1/chat/async endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -925,6 +925,27 @@ data: {"type":"result","success":true}
 
 ```
 
+**Asynchronous** (fire-and-forget):
+
+```bash
+curl -X POST http://localhost:8080/api/v1/chat/async \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -d '{"message": "Check my todos and let me know if anything is urgent."}'
+```
+
+Response (`202 Accepted`):
+
+```json
+{
+  "success": true,
+  "status": "queued",
+  "agentName": "LettaBot"
+}
+```
+
+Use this when you want to enqueue work and return immediately. The API does not return the agent's final text for this route.
+
 **Request fields:**
 
 | Field | Type | Required | Description |

--- a/docs/openai-compat.md
+++ b/docs/openai-compat.md
@@ -18,7 +18,7 @@ All requests require an API key, passed as either:
 - `Authorization: Bearer <key>`
 - `X-Api-Key: <key>`
 
-The API key is auto-generated on first run and saved to `lettabot-api.json`, or set via the `LETTABOT_API_KEY` environment variable. This is the same key used by the `/api/v1/chat` endpoint.
+The API key is auto-generated on first run and saved to `lettabot-api.json`, or set via the `LETTABOT_API_KEY` environment variable. This is the same key used by `/api/v1/chat` and `/api/v1/chat/async`.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- add docs for `POST /api/v1/chat/async` in the Chat API section
- include a fire-and-forget curl example and `202 Accepted` response
- clarify in OpenAI compat docs that the same API key applies to both `/api/v1/chat` and `/api/v1/chat/async`

## Testing
- docs-only change (no tests run)

Refs #329