### PR TITLE
fix: align API key guidance links to project keys page

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -817,6 +817,9 @@ const portalHtml = `<!DOCTYPE html>
   .auth label { display: block; font-size: 13px; color: #888; margin-bottom: 8px; }
   .auth input { width: 100%; padding: 10px 12px; background: #0a0a0a; border: 1px solid #333; border-radius: 6px; color: #fff; font-size: 14px; font-family: monospace; }
   .auth input:focus { outline: none; border-color: #555; }
+  .auth-help { margin-top: 10px; font-size: 12px; color: #888; }
+  .auth-help a { color: #fff; text-decoration: underline; }
+  .auth-help a:hover { color: #ddd; }
   .auth button { margin-top: 12px; padding: 8px 20px; background: #fff; color: #000; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; }
   .auth button:hover { background: #ddd; }
 
@@ -889,6 +892,7 @@ const portalHtml = `<!DOCTYPE html>
   <div class="auth" id="auth">
     <label for="key">API Key</label>
     <input type="password" id="key" placeholder="Paste your LETTABOT_API_KEY" autocomplete="off" onkeydown="if(event.key==='Enter')login()">
+    <div class="auth-help">Find your API key at <a href="https://app.letta.com/projects/default-project/api-keys" target="_blank" rel="noopener noreferrer">app.letta.com/projects/default-project/api-keys</a>.</div>
     <button onclick="login()">Connect</button>
   </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -526,7 +526,7 @@ const globalConfig = {
 // Validate LETTA_API_KEY is set for API mode (docker mode doesn't require it)
 if (!isDockerServerMode(yamlConfig.server.mode) && !process.env.LETTA_API_KEY) {
   log.error('LETTA_API_KEY is required for Letta API.');
-  log.error('  Get your API key from https://app.letta.com and set it as an environment variable.');
+  log.error('  Get your API key from https://app.letta.com/projects/default-project/api-keys and set it as an environment variable.');
   log.error('Or use docker mode: run "lettabot onboard" and select "Enter Docker server URL".');
   process.exit(1);
 }

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -1403,7 +1403,7 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
     // Validate required fields
     if (!config.apiKey && isLettaApiUrl(config.baseUrl)) {
       console.error('❌ Error: LETTA_API_KEY is required');
-      console.error('   Get your API key from: https://app.letta.com/settings');
+      console.error('   Get your API key from: https://app.letta.com/projects/default-project/api-keys');
       console.error('   Then run: export LETTA_API_KEY="letta_..."');
       console.error('');
       console.error('   Or use a Docker server:');


### PR DESCRIPTION
## Summary
- add portal login helper copy that links directly to the default project API keys page
- update startup missing-key guidance to use the same API key URL
- update onboarding missing-key guidance to use the same API key URL

## Test plan
- [ ] Open `/portal` and verify the API key helper link appears below the input
- [ ] Start without `LETTA_API_KEY` and confirm the startup error points to the new URL
- [ ] Run onboarding without `LETTA_API_KEY` and confirm the onboarding error points to the new URL

👾 Generated with [Letta Code](https://letta.com)