### PR TITLE
fix: convert markdown bold/italic to HTML in Telegram thinking blocks

### DIFF
--- a/src/core/display.test.ts
+++ b/src/core/display.test.ts
@@ -88,6 +88,14 @@ describe('formatReasoningDisplay', () => {
     expect(result.text).toBe('<blockquote expandable><b>Thinking</b>\na &lt; b &amp; c &gt; d</blockquote>');
   });
 
+  it('converts markdown bold and italic to HTML tags in telegram output', () => {
+    const result = formatReasoningDisplay('**Responding with warmth**\nSome text with *emphasis* here', 'telegram');
+    expect(result.parseMode).toBe('HTML');
+    expect(result.text).toBe(
+      '<blockquote expandable><b>Thinking</b>\n<b>Responding with warmth</b>\nSome text with <i>emphasis</i> here</blockquote>',
+    );
+  });
+
   it('formats non-signal/telegram channels as markdown blockquote', () => {
     const result = formatReasoningDisplay('line 1\n line 2', 'discord');
     expect(result).toEqual({ text: '> **Thinking**\n> line 1\n> line 2' });

--- a/src/core/display.ts
+++ b/src/core/display.ts
@@ -231,13 +231,18 @@ export function formatReasoningDisplay(
     return { text: `**Thinking**\n_${truncated}_` };
   }
   if (channelId === 'telegram' || channelId === 'telegram-mtproto') {
-    // Telegram: use HTML blockquote to bypass telegramify-markdown spacing
+    // Telegram: use HTML blockquote to bypass telegramify-markdown spacing.
+    // Convert basic markdown inline formatting to HTML tags so bold/italic
+    // render correctly instead of showing raw ** and * characters.
     const escaped = truncated
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
+    const html = escaped
+      .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+      .replace(/\*(.+?)\*/g, '<i>$1</i>');
     return {
-      text: `<blockquote expandable><b>Thinking</b>\n${escaped}</blockquote>`,
+      text: `<blockquote expandable><b>Thinking</b>\n${html}</blockquote>`,
       parseMode: 'HTML',
     };
   }


### PR DESCRIPTION
## Summary

- Telegram thinking blocks are sent as HTML (`parseMode: 'HTML'`), but reasoning content from LLMs contains markdown formatting (`**bold**`, `*italic*`). The existing code only HTML-escaped `&`, `<`, `>` without converting markdown to HTML tags, so `**` and `*` appeared as literal text.
- Adds `.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')` and `.replace(/\*(.+?)\*/g, '<i>$1</i>')` after HTML escaping in `formatReasoningDisplay()`.

## Test plan

- [x] Existing display tests pass
- [x] New test case verifies bold and italic conversion for Telegram channel
- [ ] Manual verification in Telegram with a model that uses `**headers**` in reasoning (e.g., OpenAI)

Written by Cameron ◯ Letta Code

"The medium is the message." -- Marshall McLuhan