### PR TITLE
fix: avoid false italic conversion in Telegram reasoning

### DIFF
--- a/src/core/display.test.ts
+++ b/src/core/display.test.ts
@@ -96,6 +96,14 @@ describe('formatReasoningDisplay', () => {
     );
   });
 
+  it('does not convert math-like asterisks to telegram italic formatting', () => {
+    const spaced = formatReasoningDisplay('2 * 3 * 4', 'telegram');
+    const compact = formatReasoningDisplay('2*3*4', 'telegram');
+    expect(spaced.parseMode).toBe('HTML');
+    expect(spaced.text).toBe('<blockquote expandable><b>Thinking</b>\n2 * 3 * 4</blockquote>');
+    expect(compact.text).toBe('<blockquote expandable><b>Thinking</b>\n2*3*4</blockquote>');
+  });
+
   it('formats non-signal/telegram channels as markdown blockquote', () => {
     const result = formatReasoningDisplay('line 1\n line 2', 'discord');
     expect(result).toEqual({ text: '> **Thinking**\n> line 1\n> line 2' });

--- a/src/core/display.ts
+++ b/src/core/display.ts
@@ -239,8 +239,11 @@ export function formatReasoningDisplay(
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
     const html = escaped
-      .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
-      .replace(/\*(.+?)\*/g, '<i>$1</i>');
+      // Only convert likely markdown delimiters:
+      // - ignore escaped asterisks (\*)
+      // - ignore in-word/math operators (e.g., 2*3*4, 2 * 3 * 4)
+      .replace(/(?<![\\\w])\*\*(?=\S)([\s\S]*?\S)\*\*(?!\w)/g, '<b>$1</b>')
+      .replace(/(?<![\\\w])\*(?=\S)([^*\n]*?\S)\*(?!\w)/g, '<i>$1</i>');
     return {
       text: `<blockquote expandable><b>Thinking</b>\n${html}</blockquote>`,
       parseMode: 'HTML',


### PR DESCRIPTION
## Summary
- tighten Telegram reasoning markdown-to-HTML conversion for `*italic*` and `**bold**`
- avoid converting math/operator asterisks like `2 * 3 * 4` or `2*3*4`
- add regression tests for spaced and compact math expressions

## Why
PR #523 added markdown conversion for Telegram thinking blocks, but the broad italic regex also matched non-markdown uses of asterisks.

## Testing
- npm test -- src/core/display.test.ts
- npm run test:run
