### PR TITLE
fix: reduce log spam from pre-foreground event buffering

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1276,11 +1276,11 @@ export class LettaBot implements AgentSession {
               if (runId && (streamMsg.type === 'reasoning' || streamMsg.type === 'tool_call')) {
                 bufferRunScopedDisplayEvent(runId, streamMsg);
                 filteredRunEventCount++;
-                log.info(`Buffering run-scoped pre-foreground display event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runId=${runId})`);
+                log.debug(`Buffering run-scoped pre-foreground display event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runId=${runId})`);
                 continue;
               }
               filteredRunEventCount++;
-              log.info(`Deferring run-scoped pre-foreground event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runIds=${eventRunIds.join(',')})`);
+              log.debug(`Deferring run-scoped pre-foreground event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runIds=${eventRunIds.join(',')})`);
               continue;
             }
           } else if (expectedForegroundRunId && eventRunIds.length > 0 && !eventRunIds.includes(expectedForegroundRunId)) {
@@ -1291,7 +1291,7 @@ export class LettaBot implements AgentSession {
               ignoredNonForegroundResultCount++;
               log.warn(`Ignoring non-foreground result event (seq=${seq}, key=${convKey}, runIds=${eventRunIds.join(',')}, expected=${expectedForegroundRunId}, source=${expectedForegroundRunSource || 'unknown'})`);
             } else {
-              log.info(`Skipping non-foreground stream event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runIds=${eventRunIds.join(',')}, expected=${expectedForegroundRunId})`);
+              log.debug(`Skipping non-foreground stream event (seq=${seq}, key=${convKey}, type=${streamMsg.type}, runIds=${eventRunIds.join(',')}, expected=${expectedForegroundRunId})`);
             }
             continue;
           }


### PR DESCRIPTION
## Summary

- Demote three per-event `log.info()` to `log.debug()` in the stream event filtering path added by PR #513
- These fire for every reasoning chunk and tool_call before the foreground run is identified, producing dozens to hundreds of log lines per message with sleeptime/background runs
- The aggregate summary at line 1500 remains at `log.info`, preserving visibility without noise

Fixes #528

Reported by odonata_ in Discord #lettabot.

## Test plan

- [ ] Run LettaBot with sleeptime enabled and verify info-level logs no longer contain per-event buffering messages
- [ ] Set log level to debug and verify the messages still appear for debugging
- [ ] Confirm the aggregate summary line at 1500 still logs at info level

🐾 Generated with [Letta Code](https://letta.com)