### PR TITLE
feat: log and optionally display compaction events

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -38,6 +38,8 @@ export interface DisplayConfig {
   showReasoning?: boolean;
   /** Truncate reasoning to N characters (default: 0 = no limit) */
   reasoningMaxChars?: number;
+  /** Show compaction events in channel output (default: false) */
+  showCompaction?: boolean;
 }
 
 export type SleeptimeTrigger = 'off' | 'step-count' | 'compaction-event';

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1535,6 +1535,35 @@ export class LettaBot implements AgentSession {
             retryInfo = { attempt: rm.attempt, maxAttempts: rm.maxAttempts, reason: rm.reason };
             log.info(`Retrying (${rm.attempt}/${rm.maxAttempts}): ${rm.reason}`);
             sawNonAssistantSinceLastUuid = true;
+          } else if (streamMsg.type === 'compaction_start') {
+            log.info('Compaction started (trigger event received)');
+            sawNonAssistantSinceLastUuid = true;
+          } else if (streamMsg.type === 'compaction_summary') {
+            const sm = streamMsg as any;
+            const stats = sm.stats as { trigger?: string; contextTokensBefore?: number; contextTokensAfter?: number; contextWindow?: number; messagesCountBefore?: number; messagesCountAfter?: number } | undefined;
+            if (stats) {
+              const fmtTokens = (n?: number) => n != null ? `${Math.round(n / 1000)}K` : '?';
+              log.info(
+                `Compaction complete: ${fmtTokens(stats.contextTokensBefore)} -> ${fmtTokens(stats.contextTokensAfter)} tokens ` +
+                `(${stats.messagesCountBefore ?? '?'} -> ${stats.messagesCountAfter ?? '?'} messages, trigger=${stats.trigger ?? 'unknown'})`
+              );
+            } else {
+              log.info('Compaction complete (no stats available)');
+            }
+            sawNonAssistantSinceLastUuid = true;
+
+            // Optional channel display
+            if (this.config.display?.showCompaction && !suppressDelivery) {
+              const fmtTokens = (n?: number) => n != null ? `${Math.round(n / 1000)}K` : '?';
+              const displayText = stats
+                ? `(Context compacted: ${fmtTokens(stats.contextTokensBefore)} -> ${fmtTokens(stats.contextTokensAfter)} tokens)`
+                : '(Context compacted)';
+              try {
+                await adapter.sendMessage({ chatId: msg.chatId, text: displayText, threadId: msg.threadId });
+              } catch (err) {
+                log.warn('Failed to send compaction display:', err instanceof Error ? err.message : err);
+              }
+            }
           } else if (streamMsg.type !== 'assistant') {
             sawNonAssistantSinceLastUuid = true;
           }
@@ -2004,6 +2033,14 @@ export class LettaBot implements AgentSession {
                 stopReason: (msg as any).stopReason || 'error',
                 apiError: (msg as any).apiError,
               };
+            }
+            if (msg.type === 'compaction_summary') {
+              const stats = (msg as any).stats as { contextTokensBefore?: number; contextTokensAfter?: number; messagesCountBefore?: number; messagesCountAfter?: number; trigger?: string } | undefined;
+              const fmtTokens = (n?: number) => n != null ? `${Math.round(n / 1000)}K` : '?';
+              log.info(
+                `sendToAgent compaction: ${fmtTokens(stats?.contextTokensBefore)} -> ${fmtTokens(stats?.contextTokensAfter)} tokens` +
+                (stats?.trigger ? ` (trigger=${stats.trigger})` : '')
+              );
             }
             if (msg.type === 'assistant') {
               response += msg.content || '';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -173,6 +173,7 @@ export interface BotConfig {
     showToolCalls?: boolean;      // Show tool invocations in channel output
     showReasoning?: boolean;      // Show agent reasoning/thinking in channel output
     reasoningMaxChars?: number;   // Truncate reasoning to N chars (default: 0 = no limit)
+    showCompaction?: boolean;     // Show compaction events in channel output
   };
 
   // Skills


### PR DESCRIPTION
## Summary

- Handle `compaction_start` and `compaction_summary` SDK message types in both `processMessage()` and `sendToAgent()` stream loops
- Log before/after token counts, message counts, and trigger type on every compaction
- Add `display.showCompaction` config option to optionally show a brief note in the active channel (e.g. "(Context compacted: 197K -> 64K tokens)")
- Add `showCompaction` to both `DisplayConfig` and `BotConfig.display`

## Context

Ed T noticed that compaction events never appear in lettabot logs, making it impossible to know if/when automatic compactions fire on the server. Manual trigger worked (197K -> 64K), but there was no way to verify automatic compaction behavior.

The Letta API already sends `event_message` and `summary_message` during compaction, but the SDK was silently dropping them. letta-code-sdk#76 fixes the SDK side; this PR consumes the newly-surfaced messages.

## Config example

```yaml
features:
  display:
    showCompaction: true  # optional, default false
```

## Dependencies

- Requires letta-code-sdk#76 to be merged and published

## Test plan

- [x] Type-checks clean (`tsc --noEmit`)
- [x] Verified foreground run filter passes compaction messages through (no `runId` -> `eventRunIds` is empty -> not filtered)
- [ ] Manual test with a compaction event after SDK bump

Written by Cameron ◯ Letta Code

"Not everything that counts can be counted, and not everything that can be counted counts." -- William Bruce Cameron