### PR TITLE
fix(telegram): fall back to result text when streamed response is empty

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1641,6 +1641,10 @@ export class LettaBot implements AgentSession {
                   `(resultLen=${resultText.length}, streamLen=${streamedAssistantText.length}). ` +
                   `Preferring streamed content to avoid n-1 desync.`
                 );
+                // Fall back to result text if nothing was delivered yet
+                if (!sentAnyMessage && response.trim().length === 0) {
+                  response = resultText;
+                }
               } else if (streamedTextTrimmed.length === 0 && streamMsg.success !== false && !streamMsg.error) {
                 // Fallback for models/providers that only populate result text.
                 // Skip on error results -- the result field may contain reasoning


### PR DESCRIPTION
## Summary

- When streamed assistant text is empty and no message has been sent yet, fall back to `resultText` so the user receives a response
- Fixes a case where Telegram users got silence instead of a reply when a model/provider populated only the result field (not the stream)

## Context

Discussed with Ezra in Discord: https://discord.com/channels/1161736243340640419/1428499304485490688/threads/1481375937072336976

## Test plan

- [ ] Trigger a tool call with a model that populates result text but not streamed text
- [ ] Confirm the Telegram user receives the response rather than silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)