### PR TITLE
fix: default group chat settings and voice transcription to 'no' in o…

### DIFF
--- a/src/channels/setup.ts
+++ b/src/channels/setup.ts
@@ -97,7 +97,7 @@ async function promptGroupSettings(
 
   const configure = await p.confirm({
     message: 'Configure group chat settings?',
-    initialValue: hasExisting,
+    initialValue: false,
   });
   if (p.isCancel(configure)) {
     p.cancel('Cancelled');

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -997,7 +997,7 @@ async function stepProviders(config: OnboardConfig, env: Record<string, string>)
         if (provider.id === 'openai') {
           const enableTranscription = await p.confirm({
             message: 'Enable voice message transcription with this OpenAI key? (uses Whisper)',
-            initialValue: true,
+            initialValue: false,
           });
           if (!p.isCancel(enableTranscription) && enableTranscription) {
             config.transcription.enabled = true;
@@ -1191,7 +1191,7 @@ async function stepTranscription(config: OnboardConfig, forcePrompt?: boolean): 
 
   const setupTranscription = await p.confirm({
     message: 'Enable voice message transcription?',
-    initialValue: config.transcription.enabled,
+    initialValue: false,
   });
   if (p.isCancel(setupTranscription)) { p.cancel('Setup cancelled'); process.exit(0); }
   config.transcription.enabled = setupTranscription;


### PR DESCRIPTION
…nboarding

Previously:
- 'Configure group chat settings?' defaulted to 'yes' if any existing config
- 'Enable voice message transcription?' defaulted to 'yes' if OPENAI_API_KEY set
- Voice transcription prompt when connecting OpenAI provider defaulted to 'yes'

Now all three default to 'no' to reduce noise for new users.