### PR TITLE
fix(discord): route thread messages with per-thread conversations

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -318,7 +318,7 @@ Ask the bot owner to approve with:
           let commandForcePerChat = false;
           if (isGroup && this.config.groups) {
             const threadMode = resolveDiscordThreadMode(this.config.groups, keys);
-            commandForcePerChat = threadMode === 'thread-only';
+            commandForcePerChat = threadMode === 'thread-only' || isThreadMessage;
             if (commandForcePerChat && !isThreadMessage) {
               const shouldCreateThread =
                 wasMentioned && resolveDiscordAutoCreateThreadOnMention(this.config.groups, keys);
@@ -464,7 +464,8 @@ Ask the bot owner to approve with:
           serverId: message.guildId || undefined,
           wasMentioned,
           isListeningMode,
-          forcePerChat: isThreadOnly || undefined,
+          threadId: isThreadMessage ? effectiveChatId : undefined,
+          forcePerChat: (isThreadOnly || isThreadMessage) || undefined,
           attachments,
           formatterHints: this.getFormatterHints(),
         });
@@ -499,9 +500,10 @@ Ask the bot owner to approve with:
 
   async sendMessage(msg: OutboundMessage): Promise<{ messageId: string }> {
     if (!this.client) throw new Error('Discord not started');
-    const channel = await this.client.channels.fetch(msg.chatId);
+    const targetChannelId = msg.threadId || msg.chatId;
+    const channel = await this.client.channels.fetch(targetChannelId);
     if (!channel || !channel.isTextBased() || !('send' in channel)) {
-      throw new Error(`Discord channel not found or not text-based: ${msg.chatId}`);
+      throw new Error(`Discord channel not found or not text-based: ${targetChannelId}`);
     }
 
     const sendable = channel as { send: (content: string) => Promise<{ id: string }> };
@@ -516,9 +518,10 @@ Ask the bot owner to approve with:
 
   async sendFile(file: OutboundFile): Promise<{ messageId: string }> {
     if (!this.client) throw new Error('Discord not started');
-    const channel = await this.client.channels.fetch(file.chatId);
+    const targetChannelId = file.threadId || file.chatId;
+    const channel = await this.client.channels.fetch(targetChannelId);
     if (!channel || !channel.isTextBased() || !('send' in channel)) {
-      throw new Error(`Discord channel not found or not text-based: ${file.chatId}`);
+      throw new Error(`Discord channel not found or not text-based: ${targetChannelId}`);
     }
 
     const payload = {
@@ -697,7 +700,7 @@ Ask the bot owner to approve with:
       groupName,
       serverId: message.guildId || undefined,
       isListeningMode,
-      forcePerChat: reactionForcePerChat || undefined,
+      forcePerChat: (reactionForcePerChat || isThreadMessage) || undefined,
       reaction: {
         emoji,
         messageId: message.id,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -125,7 +125,7 @@ export interface OutboundMessage {
   chatId: string;
   text: string;
   replyToMessageId?: string;
-  threadId?: string;  // Slack thread_ts
+  threadId?: string;  // Thread ID (Slack thread_ts / Discord thread channel)
   /** When set, tells the adapter which parse mode to use (e.g., 'MarkdownV2',
    *  'HTML') and to skip its default markdown conversion. Adapters that don't
    *  support the specified mode ignore this and fall back to default. */


### PR DESCRIPTION
## Summary

- Set `threadId` and `forcePerChat` on inbound messages from Discord threads (not just thread-only mode)
- Propagate `forcePerChat` through reaction handler and command handler paths
- Prefer `threadId` over `chatId` in `sendMessage`/`sendFile` for explicit thread channel routing

## Details

Discord thread messages in non-thread-only mode were missing `threadId` and `forcePerChat`, causing them to share a conversation with the parent channel. Without `forcePerChat`, multiple threads and the parent channel compete on the same conversation key, leading to contention and lost responses.

All three message routing paths are updated (message handler, reaction handler, command handler), per the lesson from #542 that `forcePerChat` must propagate through every path.

In Discord, threads are channels with their own IDs, so `chatId` and `threadId` resolve to the same value for thread messages today. The outbound routing change (`threadId || chatId`) makes the adapter's contract explicit and consistent with Slack's model.

Fixes #546

## Test plan

- [x] `tsc --noEmit` clean
- [x] Unit tests pass (1 pre-existing timeout in result-guard unrelated to this change)
- [ ] Manual smoke test: send messages in a Discord thread in non-thread-only mode, verify all responses are visible

Written by Cameron ◯ Letta Code

> "Explicit is better than implicit." -- Tim Peters