### PR TITLE
fix(help): centralize Telegram help output with shared command text

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -22,6 +22,7 @@ import { basename } from 'node:path';
 import { buildAttachmentPath, downloadToFile } from './attachments.js';
 import { applyTelegramGroupGating } from './telegram-group-gating.js';
 import { resolveDailyLimits, checkDailyLimit, type GroupModeConfig } from './group-mode.js';
+import { HELP_TEXT } from '../core/commands.js';
 
 import { createLogger } from '../logger.js';
 
@@ -250,17 +251,15 @@ export class TelegramAdapter implements ChannelAdapter {
     
     // Handle /start and /help
     this.bot.command(['start', 'help'], async (ctx) => {
-      await ctx.reply(
-        "*LettaBot* - AI assistant with persistent memory\n\n" +
-        "*Commands:*\n" +
-        "/status - Show current status\n" +
-        "/model - Show current model and recommendations\n" +
-        "/reset - Reset conversation\n" +
-        "/cancel - Cancel active run\n" +
-        "/help - Show this message\n\n" +
-        "Just send me a message to get started!",
-        { parse_mode: 'Markdown' }
-      );
+      const replyToMessageId =
+        'message' in ctx && ctx.message
+          ? String(ctx.message.message_id)
+          : undefined;
+      await this.sendMessage({
+        chatId: String(ctx.chat.id),
+        text: HELP_TEXT,
+        replyToMessageId,
+      });
     });
     
     // Handle /status

--- a/src/core/commands.test.ts
+++ b/src/core/commands.test.ts
@@ -106,8 +106,12 @@ describe('HELP_TEXT', () => {
   it('contains command descriptions', () => {
     expect(HELP_TEXT).toContain('/status');
     expect(HELP_TEXT).toContain('/heartbeat');
+    expect(HELP_TEXT).toContain('/reset');
+    expect(HELP_TEXT).toContain('/cancel');
     expect(HELP_TEXT).toContain('/help');
+    expect(HELP_TEXT).toContain('/start');
     expect(HELP_TEXT).toContain('/model');
+    expect(HELP_TEXT).toContain('/setconv');
   });
 
   it('contains LettaBot branding', () => {

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -23,6 +23,7 @@ Commands:
 /model <handle> - Switch to a different model
 /setconv <id> - Set conversation ID for this chat
 /help - Show this message
+/start - Show this message
 
 Just send a message to get started!`;
 


### PR DESCRIPTION
## Summary
- Replace Telegram's hardcoded `/start`/`/help` response with shared `HELP_TEXT` so help output stays consistent with other channels.
- Add `/start` to `HELP_TEXT` to reflect actual supported command aliases.
- Expand `HELP_TEXT` tests to cover the full managed command set (`/status`, `/heartbeat`, `/reset`, `/cancel`, `/help`, `/start`, `/model`, `/setconv`).

## Test plan
- [x] `npm run test:run -- src/core/commands.test.ts src/channels/telegram.test.ts`

👾 Generated with [Letta Code](https://letta.com)