### PR TITLE
fix: cast vi.fn() mock to satisfy bun-types fetch type

### DIFF
--- a/src/channels/bluesky.test.ts
+++ b/src/channels/bluesky.test.ts
@@ -24,7 +24,7 @@ describe('BlueskyAdapter', () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
-    globalThis.fetch = vi.fn();
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Fix TS2322 in `bluesky.test.ts` -- `bun-types` requires `preconnect` on the `fetch` type which `vi.fn()` doesn't provide
- Standard `as unknown as typeof fetch` cast for mocking globals with stricter type defs

## Test plan

- [x] `tsc --noEmit` passes cleanly

Written by Cameron ◯ Letta Code

"Types are not a substitute for tests, but they are a useful complement."
  — Rich Hickey (paraphrased)