### PR TITLE
fix: strip <no-reply/> marker in sendToAgent before returning to callers

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1955,6 +1955,12 @@ export class LettaBot implements AgentSession {
             }
           }
 
+          // Strip <no-reply/> marker so callers (cron, webhooks) see empty string
+          if (response.trim() === '<no-reply/>') {
+            log.info('sendToAgent: agent responded with <no-reply/> marker, suppressing');
+            response = '';
+          }
+
           if (isSilent && response.trim()) {
             if (usedMessageCli || executedDirectives) {
               log.info(`Silent mode: agent delivered via ${[usedMessageCli && 'CLI', executedDirectives && 'directives'].filter(Boolean).join(' + ')}, remaining text (${response.length} chars) not delivered`);


### PR DESCRIPTION
## Summary

`sendToAgent()` returned the raw `<no-reply/>` string to callers (cron, webhooks), which then delivered it as literal text to channels. On Telegram, the `-` in `<no-reply/>` also triggered a MarkdownV2 parse error.

The `processMessage` path already strips this marker (lines 1252, 1699), but `sendToAgent` did not.

Now strips the marker and returns empty string before the silent mode check, so the existing `if (response)` guards in cron/webhook callers skip delivery.

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 33 sdk-session-contract tests pass

Fixes #573

Written by Cameron ◯ Letta Code

"The simplest thing that could possibly work."
  — Ward Cunningham