### PR TITLE
fix(telegram): escape horizontal rules in MarkdownV2 output

### DIFF
--- a/src/channels/telegram-format.ts
+++ b/src/channels/telegram-format.ts
@@ -17,7 +17,11 @@ export async function markdownToTelegramV2(markdown: string): Promise<string> {
     // Dynamic import to handle ESM module
     const telegramifyMarkdown = (await import('telegramify-markdown')).default;
     // Use 'keep' strategy for broad markdown support, including blockquotes.
-    return telegramifyMarkdown(markdown, 'keep');
+    let result = telegramifyMarkdown(markdown, 'keep');
+    // telegramify-markdown passes horizontal rules (---) through unescaped.
+    // '-' is reserved in MarkdownV2 and must be escaped.
+    result = result.replace(/^-{3,}$/gm, '\\-\\-\\-');
+    return result;
   } catch (e) {
     log.error('Markdown conversion failed, using escape fallback:', e);
     // Fallback: escape special characters manually (loses formatting)


### PR DESCRIPTION
## Summary

- `telegramify-markdown` passes `---` (horizontal rules) through literally
- `-` is reserved in MarkdownV2, causing `400: can't parse entities` from Telegram
- Messages still delivered via raw text fallback, but lose all formatting
- Post-processes converter output to escape bare `---` lines to `\-\-\-`

One-line fix in `telegram-format.ts`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Verified regex: `"text\n\n---\n\nmore\n"` becomes `"text\n\n\-\-\-\n\nmore\n"`
- [x] No horizontal rule in non-rule contexts affected (regex anchored to line start/end)

Fixes #561

Written by Cameron ◯ Letta Code

"The devil is in the details -- especially reserved characters."