### PR TITLE
feat(tts): support OpenAI-compatible endpoints, configurable format, and optional audio padding

### DIFF
--- a/skills/voice-memo/lettabot-tts
+++ b/skills/voice-memo/lettabot-tts
@@ -58,13 +58,17 @@ preflight
 # Ensure output directory exists
 mkdir -p "$OUTBOUND_DIR"
 
+# Derive extension from format so filenames and MIME types stay consistent.
+# Falls back to 'ogg' when OPENAI_TTS_FORMAT is unset (the script default).
+_ext="${OPENAI_TTS_FORMAT:-ogg}"
+
 # Use collision-safe random filenames when output path is not explicitly provided.
 if [ -n "${2:-}" ]; then
   OUTPUT="$2"
 else
-  # Clean stale voice files older than 1 hour
-  find "$OUTBOUND_DIR" -name 'voice-*.ogg' -mmin +60 -delete 2>/dev/null || true
-  OUTPUT=$(mktemp "${OUTBOUND_DIR}/voice-XXXXXXXXXX.ogg")
+  # Clean stale voice files older than 1 hour (all extensions)
+  find "$OUTBOUND_DIR" -name 'voice-*' -mmin +60 -delete 2>/dev/null || true
+  OUTPUT=$(mktemp "${OUTBOUND_DIR}/voice-XXXXXXXXXX.${_ext}")
 fi
 
 # ---------------------------------------------------------------------------
@@ -179,7 +183,7 @@ esac
 # Set LETTABOT_TTS_PAD_SECONDS (e.g. "0.5") to enable. Requires ffmpeg.
 # ---------------------------------------------------------------------------
 if [ -n "${LETTABOT_TTS_PAD_SECONDS:-}" ]; then
-  PAD_TMP=$(mktemp "${OUTPUT%.ogg}_pad_XXXXXX.ogg")
+  PAD_TMP=$(mktemp "${OUTPUT%.*}_pad_XXXXXX.${_ext}")
   if ffmpeg -y -i "$OUTPUT" -af "apad=pad_dur=${LETTABOT_TTS_PAD_SECONDS}" \
        -c:a libopus -b:a 64k "$PAD_TMP" 2>/dev/null; then
     mv "$PAD_TMP" "$OUTPUT"

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -617,6 +617,15 @@ export function configToEnv(config: LettaBotConfig): Record<string, string> {
       env.OPENAI_TTS_MODEL = config.tts.model;
     }
   }
+  if (config.tts?.baseUrl) {
+    env.OPENAI_TTS_BASE_URL = config.tts.baseUrl;
+  }
+  if (config.tts?.format) {
+    env.OPENAI_TTS_FORMAT = config.tts.format;
+  }
+  if (config.tts?.padSeconds !== undefined) {
+    env.LETTABOT_TTS_PAD_SECONDS = String(config.tts.padSeconds);
+  }
 
   // API server (server.api is canonical, top-level api is deprecated fallback)
   const apiConfig = config.server.api ?? config.api;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -259,6 +259,10 @@ export interface TtsConfig {
   apiKey?: string;                      // Falls back to ELEVENLABS_API_KEY or OPENAI_API_KEY env var
   voiceId?: string;                     // ElevenLabs voice ID or OpenAI voice name
   model?: string;                       // Model ID (provider-specific defaults)
+  // OpenAI-compatible TTS options (openai provider only)
+  baseUrl?: string;                     // Base URL for OpenAI-compatible TTS server (default: https://api.openai.com)
+  format?: string;                      // Response format: omitted by default (server chooses). Set to 'opus', 'mp3', 'wav', etc.
+  padSeconds?: number;                  // Seconds of silence to append via ffmpeg to prevent audio cutoff (e.g. 0.5). Requires ffmpeg.
 }
 
 export interface TranscriptionConfig {


### PR DESCRIPTION
## Summary

This PR improves the `openai` TTS provider in `lettabot-tts` to work with any OpenAI-compatible TTS server, not just `api.openai.com`.

### Changes

**1. `OPENAI_TTS_BASE_URL` — configurable endpoint**

The URL was previously hardcoded to `https://api.openai.com`. This makes it impossible to use popular self-hosted alternatives like [Kokoro](https://github.com/hexgrad/kokoro), [Piper](https://github.com/rhasspy/piper), or any other OpenAI-compatible TTS server without patching the script.

```bash
# .env or systemd service Environment=
OPENAI_TTS_BASE_URL=http://localhost:8880  # Kokoro, Piper, etc.
OPENAI_API_KEY=placeholder                 # many compatible servers don't validate this
```

**2. `OPENAI_TTS_FORMAT` — optional response format**

The script previously hard-coded `response_format: "opus"`. Many OpenAI-compatible servers either ignore this field or return an error/empty response when it's set (Kokoro returns a broken file; others fail outright). The field is now **omitted by default**, letting the server use its native format. Set `OPENAI_TTS_FORMAT=opus` to restore the previous behavior for servers that require it.

**3. `LETTABOT_TTS_PAD_SECONDS` — optional trailing silence**

Some Telegram clients clip the last few hundred milliseconds of a voice note. Setting this to `0.5` appends 500ms of silence via ffmpeg, preventing cutoff. Opt-in, requires ffmpeg, fails gracefully with a warning if ffmpeg is unavailable.

```bash
LETTABOT_TTS_PAD_SECONDS=0.5
```

The preflight check is updated to require ffmpeg only when padding is requested.

### Backward Compatibility

All three additions are opt-in via environment variables with safe defaults:
- `OPENAI_TTS_BASE_URL` defaults to `https://api.openai.com` (no change)
- `OPENAI_TTS_FORMAT` defaults to omitted (functionally equivalent for OpenAI — the API defaults to `mp3` when unset, same audio quality)
- `LETTABOT_TTS_PAD_SECONDS` defaults to unset (no padding added)

### Testing

Tested with:
- Real OpenAI API (backward compat)
- [Kokoro](https://github.com/hexgrad/kokoro) FastAPI server at `localhost:8880` with `OPENAI_API_KEY=placeholder`
- ffmpeg padding on both Ubuntu 22.04 (ffmpeg 6.x) and Jetson AGX Orin (ffmpeg 4.4.2)

👾 Generated with [Letta Code](https://letta.com)