### PR TITLE
fix: kill session subprocess on /cancel to break stuck streams

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -763,12 +763,18 @@ export class LettaBot implements AgentSession {
         // Signal the stream loop to break
         this.cancelledKeys.add(convKey);
 
-        // Abort client-side stream
+        // Abort client-side stream and kill the session subprocess.
+        // abort() sends an interrupt control_request, but the CLI may not
+        // handle it if blocked on a long-running tool (e.g., Task subagent).
+        // invalidateSession() calls session.close() which kills the subprocess,
+        // closes the transport pump, and resolves all stream waiters with null
+        // -- guaranteeing the for-await loop in processMessage breaks.
         const session = this.sessionManager.getSession(convKey);
         if (session) {
           session.abort().catch(() => {});
           log.info(`/cancel - aborted session stream (key=${convKey})`);
         }
+        this.sessionManager.invalidateSession(convKey);
 
         // Cancel server-side run (conversation-scoped)
         const convId = convKey === 'shared'
@@ -1668,8 +1674,12 @@ export class LettaBot implements AgentSession {
       }
       lap('stream complete');
 
-      // If cancelled, clean up partial state and return early
+      // If cancelled, clean up partial state and return early.
+      // Invalidate defensively in case the cancel handler's invalidation
+      // didn't fire (e.g., race with command dispatch).
       if (this.cancelledKeys.has(convKey)) {
+        this.sessionManager.invalidateSession(convKey);
+        session = null;
         if (messageId) {
           try {
             await adapter.editMessage(msg.chatId, messageId, '(Run cancelled.)');


### PR DESCRIPTION
## Summary

- `/cancel` was ineffective when the agent was stuck in a long-running tool call (e.g., Task subagent fetching a URL). `session.abort()` sends an interrupt to the CLI subprocess, but the CLI can't process it when blocked on a subagent. The `for await` stream loop in `processMessage` blocked indefinitely, requiring Ctrl+C to recover.
- After `abort()`, also call `invalidateSession()` which kills the subprocess, closes the transport pump, and resolves all stream waiters with null -- guaranteeing the stream breaks immediately.
- Defensive invalidation added to post-cancel cleanup for race conditions between the cancel handler and the stream loop.

## Test plan

- [ ] Start a long-running Task (e.g., agent fetches a URL via subagent), send `/cancel`, verify the stream breaks immediately and the user gets "(Run cancelled.)"
- [ ] Send a normal message after `/cancel` -- should work with a fresh session (~5s init)
- [ ] Verify `npm run build` passes

Written by Cameron ◯ Letta Code

"There are two ways of constructing a software design: One way is to make it so simple that there are obviously no deficiencies, and the other way is to make it so complicated that there are no obvious deficiencies." -- C.A.R. Hoare