### PR TITLE
fix: deduplicate approval requests across runs (#601)

### DIFF
--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -90,8 +90,13 @@ export async function recoverPendingApprovalsForAgent(
       };
     }
 
+    // Deduplicate by tool_call_id defensively (getPendingApprovals should
+    // already dedup, but this guards against any upstream regression).
+    const rejectedIds = new Set<string>();
     let rejectedCount = 0;
     for (const approval of pending) {
+      if (rejectedIds.has(approval.toolCallId)) continue;
+      rejectedIds.add(approval.toolCallId);
       const ok = await rejectApproval(agentId, {
         toolCallId: approval.toolCallId,
         reason,
@@ -433,70 +438,73 @@ export async function getPendingApprovals(
       stop_reason: 'requires_approval',
       limit: 10,
     });
-    
-    const pendingApprovals: PendingApproval[] = [];
-    
+
+    // Collect qualifying run IDs (avoid re-fetching messages per run)
+    const qualifyingRunIds: string[] = [];
     for await (const run of runsPage) {
       if (run.status === 'running' || run.stop_reason === 'requires_approval') {
-        // Get recent messages to find approval_request_message
-        const messagesPage = await client.agents.messages.list(agentId, {
-          conversation_id: conversationId,
-          limit: 100,
-        });
-        
-        const messages: Array<{ message_type?: string }> = [];
-        for await (const msg of messagesPage) {
-          messages.push(msg as { message_type?: string });
-        }
-        
-        const resolvedToolCalls = new Set<string>();
-        for (const msg of messages) {
-          if ('message_type' in msg && msg.message_type === 'approval_response_message') {
-            const approvalMsg = msg as {
-              approvals?: Array<{ tool_call_id?: string | null }>;
-            };
-            const approvals = approvalMsg.approvals || [];
-            for (const approval of approvals) {
-              if (approval.tool_call_id) {
-                resolvedToolCalls.add(approval.tool_call_id);
-              }
-            }
-          }
-        }
-        
-        const seenToolCalls = new Set<string>();
-        for (const msg of messages) {
-          // Check for approval_request_message type
-          if ('message_type' in msg && msg.message_type === 'approval_request_message') {
-            const approvalMsg = msg as {
-              id: string;
-              tool_calls?: Array<{ tool_call_id: string; name: string }>;
-              tool_call?: { tool_call_id: string; name: string };
-              run_id?: string;
-            };
-            
-            // Extract tool call info
-            const toolCalls = approvalMsg.tool_calls || (approvalMsg.tool_call ? [approvalMsg.tool_call] : []);
-            for (const tc of toolCalls) {
-              if (resolvedToolCalls.has(tc.tool_call_id)) {
-                continue;
-              }
-              if (seenToolCalls.has(tc.tool_call_id)) {
-                continue;
-              }
-              seenToolCalls.add(tc.tool_call_id);
-              pendingApprovals.push({
-                runId: approvalMsg.run_id || run.id,
-                toolCallId: tc.tool_call_id,
-                toolName: tc.name,
-                messageId: approvalMsg.id,
-              });
-            }
+        qualifyingRunIds.push(run.id);
+      }
+    }
+
+    if (qualifyingRunIds.length === 0) {
+      return [];
+    }
+
+    // Fetch messages ONCE and scan for resolved + pending approvals
+    const messagesPage = await client.agents.messages.list(agentId, {
+      conversation_id: conversationId,
+      limit: 100,
+    });
+
+    const messages: Array<{ message_type?: string }> = [];
+    for await (const msg of messagesPage) {
+      messages.push(msg as { message_type?: string });
+    }
+
+    // Build set of already-resolved tool_call_ids
+    const resolvedToolCalls = new Set<string>();
+    for (const msg of messages) {
+      if ('message_type' in msg && msg.message_type === 'approval_response_message') {
+        const approvalMsg = msg as {
+          approvals?: Array<{ tool_call_id?: string | null }>;
+        };
+        const approvals = approvalMsg.approvals || [];
+        for (const approval of approvals) {
+          if (approval.tool_call_id) {
+            resolvedToolCalls.add(approval.tool_call_id);
           }
         }
       }
     }
-    
+
+    // Collect unresolved approval requests, deduplicating across all runs
+    const pendingApprovals: PendingApproval[] = [];
+    const seenToolCalls = new Set<string>();
+    for (const msg of messages) {
+      if ('message_type' in msg && msg.message_type === 'approval_request_message') {
+        const approvalMsg = msg as {
+          id: string;
+          tool_calls?: Array<{ tool_call_id: string; name: string }>;
+          tool_call?: { tool_call_id: string; name: string };
+          run_id?: string;
+        };
+
+        const toolCalls = approvalMsg.tool_calls || (approvalMsg.tool_call ? [approvalMsg.tool_call] : []);
+        for (const tc of toolCalls) {
+          if (resolvedToolCalls.has(tc.tool_call_id)) continue;
+          if (seenToolCalls.has(tc.tool_call_id)) continue;
+          seenToolCalls.add(tc.tool_call_id);
+          pendingApprovals.push({
+            runId: approvalMsg.run_id || qualifyingRunIds[0],
+            toolCallId: tc.tool_call_id,
+            toolName: tc.name,
+            messageId: approvalMsg.id,
+          });
+        }
+      }
+    }
+
     return pendingApprovals;
   } catch (e) {
     log.error('Failed to get pending approvals:', e);


### PR DESCRIPTION
## Summary

- **Root cause**: `getPendingApprovals()` declared the `seenToolCalls` dedup Set inside the per-run loop, so it was recreated fresh for each qualifying run. The message fetch was also inside the loop, fetching the same conversation messages N times. This allowed the same `approval_request_message` to be added to `pendingApprovals` once per run.
- **Effect**: `recoverPendingApprovalsForAgent()` rejected the same `tool_call_id` 20+ times, each rejection spawning a new server-side run that also got stuck on approval -- creating the rejection loop reported in #601.
- **Fix**: Hoist message fetch, `resolvedToolCalls`, and `seenToolCalls` outside the run loop. Messages are fetched once and tool_call_ids are properly deduplicated across all runs. Also adds a defensive dedup in `recoverPendingApprovalsForAgent()`.

Fixes #601

## Test plan

- [ ] Deploy to staging and trigger an approval scenario with multiple qualifying runs
- [ ] Verify `getPendingApprovals()` returns each tool_call_id exactly once regardless of run count
- [ ] Verify `recoverPendingApprovalsForAgent()` calls `rejectApproval()` once per unique tool_call_id
- [ ] Confirm no approval rejection loop occurs during session recovery

Written by Cameron ◯ Letta Code

"The beginning of wisdom is the definition of terms." -- Socrates