### PR TITLE
chore(deps): bump @letta-ai/letta-code-sdk to 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@clack/prompts": "^0.11.0",
         "@hapi/boom": "^10.0.1",
         "@letta-ai/letta-client": "^1.7.12",
-        "@letta-ai/letta-code-sdk": "^0.1.11",
+        "@letta-ai/letta-code-sdk": "^0.1.12",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.10",
         "@types/node-schedule": "^2.1.8",
@@ -1351,9 +1351,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.18.2.tgz",
-      "integrity": "sha512-HzNqMjBUiAq5IyZ8DSSWBHq/ahkd4RRYfO/V9eXMBZRTRpLb7Dae2hwvicE+aRSLmJqMdxpH6WI7+ZHKlFsILQ==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.18.3.tgz",
+      "integrity": "sha512-Om1Ck3bx//FCfAV3AjOO0L0nZYfW3tdzR3sYcNFeM6MlB90S3UiA1d6fzzD62XSOC2+1KQVAaPTC7mlWs0+e5w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1362,6 +1362,7 @@
         "highlight.js": "^11.11.1",
         "ink-link": "^5.0.0",
         "lowlight": "^3.3.0",
+        "node-pty": "^1.1.0",
         "open": "^10.2.0",
         "sharp": "^0.34.5",
         "ws": "^8.19.0"
@@ -1377,12 +1378,12 @@
       }
     },
     "node_modules/@letta-ai/letta-code-sdk": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.11.tgz",
-      "integrity": "sha512-P1ueLWQuCnERizrvU3fZ9/rrMAJSIT+2j2/xxptqxMOKUuUrDmvAix1/eyDXqAwZkBVGImyqLGm4zqwNVNA7Dg==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.12.tgz",
+      "integrity": "sha512-pwVKBLx8TPEIjWqJb/t9ioIezc1a0qWo3HYq88MXNpZmUh0yMhI7RcMitToa/+YpvejYU1Et4HKk5uoMWUe1KQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@letta-ai/letta-code": "0.18.2"
+        "@letta-ai/letta-code": "0.18.3"
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/balanced-match": {
@@ -1424,9 +1425,9 @@
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -6456,8 +6457,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -6509,6 +6509,16 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/node-schedule": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@clack/prompts": "^0.11.0",
     "@hapi/boom": "^10.0.1",
     "@letta-ai/letta-client": "^1.7.12",
-    "@letta-ai/letta-code-sdk": "^0.1.11",
+    "@letta-ai/letta-code-sdk": "^0.1.12",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.10",
     "@types/node-schedule": "^2.1.8",


### PR DESCRIPTION
## Summary

- Bumps SDK to 0.1.12 which bundles letta-code 0.18.3
- Fixes: `Unknown control request subtype: recover_pending_approvals` in headless mode

The SDK's `recoverPendingApprovals()` now works in headless/stream-json mode.

## Test plan

- [x] Verified SDK 0.1.12 depends on letta-code 0.18.3
- [ ] Deploy and verify approval recovery works

Written by Cameron ◯ Letta Code

"First, solve the problem. Then, write the code." - John Johnson