### PR TITLE
revert: restore API-level approval recovery (#603)

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -16,7 +16,7 @@ import { formatApiErrorForUser } from './errors.js';
 import { formatToolCallDisplay, formatReasoningDisplay, formatQuestionsForChannel } from './display.js';
 import type { AgentSession } from './interfaces.js';
 import { Store } from './store.js';
-import { cancelConversation, getLatestRunError, getAgentModel, updateAgentModel } from '../tools/letta-api.js';
+import { getPendingApprovals, rejectApproval, cancelRuns, cancelConversation, recoverOrphanedConversationApproval, getLatestRunError, getAgentModel, updateAgentModel, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
 import { getAgentSkillExecutableDirs, isVoiceMemoConfigured } from '../skills/loader.js';
 import { formatMessageEnvelope, formatGroupBatchEnvelope, type SessionContextOptions } from './formatter.js';
 import type { GroupBatcher } from './group-batcher.js';
@@ -911,6 +911,72 @@ export class LettaBot implements AgentSession {
   }
 
   // =========================================================================
+  // Approval recovery
+  // =========================================================================
+  
+  private async attemptRecovery(maxAttempts = 2): Promise<{ recovered: boolean; shouldReset: boolean }> {
+    if (!this.store.agentId) {
+      return { recovered: false, shouldReset: false };
+    }
+    
+    log.info('Checking for pending approvals...');
+    
+    try {
+      const pendingApprovals = await getPendingApprovals(
+        this.store.agentId,
+        this.store.conversationId || undefined
+      );
+      
+      if (pendingApprovals.length === 0) {
+        if (isRecoverableConversationId(this.store.conversationId)) {
+          const convResult = await recoverOrphanedConversationApproval(
+            this.store.agentId!,
+            this.store.conversationId
+          );
+          if (convResult.recovered) {
+            log.info(`Conversation-level recovery succeeded: ${convResult.details}`);
+            return { recovered: true, shouldReset: false };
+          }
+        }
+        this.store.resetRecoveryAttempts();
+        return { recovered: false, shouldReset: false };
+      }
+      
+      const attempts = this.store.recoveryAttempts;
+      if (attempts >= maxAttempts) {
+        log.error(`Recovery failed after ${attempts} attempts. Still have ${pendingApprovals.length} pending approval(s).`);
+        return { recovered: false, shouldReset: true };
+      }
+      
+      log.info(`Found ${pendingApprovals.length} pending approval(s), attempting recovery (attempt ${attempts + 1}/${maxAttempts})...`);
+      this.store.incrementRecoveryAttempts();
+      
+      for (const approval of pendingApprovals) {
+        log.info(`Rejecting approval for ${approval.toolName} (${approval.toolCallId})`);
+        await rejectApproval(
+          this.store.agentId,
+          { toolCallId: approval.toolCallId, reason: 'Session was interrupted - retrying request' },
+          this.store.conversationId || undefined
+        );
+      }
+      
+      const runIds = [...new Set(pendingApprovals.map(a => a.runId))];
+      if (runIds.length > 0) {
+        log.info(`Cancelling ${runIds.length} active run(s)...`);
+        await cancelRuns(this.store.agentId, runIds);
+      }
+      
+      log.info('Recovery completed');
+      return { recovered: true, shouldReset: false };
+      
+    } catch (error) {
+      log.error('Recovery failed:', error);
+      this.store.incrementRecoveryAttempts();
+      return { recovered: false, shouldReset: this.store.recoveryAttempts >= maxAttempts };
+    }
+  }
+
+  // =========================================================================
   // Message queue
   // =========================================================================
 
@@ -1088,6 +1154,25 @@ export class LettaBot implements AgentSession {
       adapter.sendTypingIndicator(msg.chatId).catch(() => {});
     }
     lap('typing indicator');
+
+    // Pre-send approval recovery (secondary defense).
+    // Primary detection is now in ensureSessionForKey() via bootstrapState().
+    // This fallback only fires when previous failures incremented recoveryAttempts,
+    // covering edge cases where a cached session encounters a new stuck approval.
+    const recovery = this.store.recoveryAttempts > 0
+      ? await this.attemptRecovery()
+      : { recovered: false, shouldReset: false };
+    lap('recovery check');
+    if (recovery.shouldReset) {
+      if (!suppressDelivery) {
+        await adapter.sendMessage({
+          chatId: msg.chatId,
+          text: `(I had trouble processing that -- the session hit a stuck state and automatic recovery failed after ${this.store.recoveryAttempts} attempt(s). Please try sending your message again. If this keeps happening, /reset will clear the conversation for this channel.)`,
+          threadId: msg.threadId,
+        });
+      }
+      return null;
+    }
 
     const prevTarget = this.store.lastMessageTarget;
     const isNewChatSession = !prevTarget || prevTarget.chatId !== msg.chatId || prevTarget.channel !== msg.channel;
@@ -1533,7 +1618,9 @@ export class LettaBot implements AgentSession {
               const retryConvIdRaw = (event.conversationId && event.conversationId.length > 0)
                 ? event.conversationId
                 : retryConvIdFromStore;
-              const retryConvId = retryConvIdRaw || undefined;
+              const retryConvId = isRecoverableConversationId(retryConvIdRaw)
+                ? retryConvIdRaw
+                : undefined;
 
               const initialRetryDecision = this.buildResultRetryDecision(
                 event.raw, resultText, hasResponse, sentAnyMessage, lastErrorDetail,
@@ -1562,7 +1649,7 @@ export class LettaBot implements AgentSession {
                 log.info('Approval conflict detected -- attempting SDK recovery...');
                 clearInterval(typingInterval);
 
-                // Try SDK-level recovery (through CLI control protocol)
+                // Try SDK-level recovery first (through CLI control protocol)
                 if (session) {
                   const sdkResult = await recoverPendingApprovalsWithSdk(session, 10_000);
                   if (sdkResult.recovered) {
@@ -1571,11 +1658,20 @@ export class LettaBot implements AgentSession {
                     session = null;
                     return this.processMessage(msg, adapter, true);
                   }
-                  log.warn(`SDK approval recovery did not resolve (${sdkResult.detail ?? 'unknown'})`);
+                  log.warn(`SDK recovery did not resolve (${sdkResult.detail ?? 'unknown'}), trying API-level recovery...`);
                 }
 
+                // Fall back to API-level recovery
                 this.sessionManager.invalidateSession(retryConvKey);
                 session = null;
+                const result = (retryConvId && isRecoverableConversationId(retryConvId))
+                  ? await recoverOrphanedConversationApproval(this.store.agentId, retryConvId, true)
+                  : await recoverPendingApprovalsForAgent(this.store.agentId);
+                if (result.recovered) {
+                  log.info(`API-level recovery succeeded (${result.details}), retrying message...`);
+                } else {
+                  log.warn(`API-level recovery failed: ${result.details}`);
+                }
                 return this.processMessage(msg, adapter, true);
               }
 
@@ -1583,11 +1679,19 @@ export class LettaBot implements AgentSession {
               if (retryDecision.shouldRetryForEmptyResult || retryDecision.shouldRetryForErrorResult) {
                 if (!retried && this.store.agentId && retryConvId) {
                   const reason = retryDecision.shouldRetryForErrorResult ? 'error result' : 'empty result';
-                  log.info(`${reason} - retrying once...`);
+                  log.info(`${reason} - attempting orphaned approval recovery...`);
                   this.sessionManager.invalidateSession(retryConvKey);
                   session = null;
                   clearInterval(typingInterval);
-                  return this.processMessage(msg, adapter, true);
+                  const convResult = await recoverOrphanedConversationApproval(this.store.agentId, retryConvId);
+                  if (convResult.recovered) {
+                    log.info(`Recovery succeeded (${convResult.details}), retrying message...`);
+                    return this.processMessage(msg, adapter, true);
+                  }
+                  if (retryDecision.shouldRetryForErrorResult) {
+                    log.info('Retrying once after terminal error...');
+                    return this.processMessage(msg, adapter, true);
+                  }
                 }
               }
 
@@ -1900,7 +2004,15 @@ export class LettaBot implements AgentSession {
                   if (sdkResult.recovered) {
                     log.info('sendToAgent: SDK approval recovery succeeded');
                   } else {
-                    log.warn(`sendToAgent: SDK approval recovery did not resolve (${sdkResult.detail ?? 'unknown'})`);
+                    log.warn(`sendToAgent: SDK recovery did not resolve (${sdkResult.detail ?? 'unknown'}), trying API-level recovery...`);
+                    if (this.store.agentId) {
+                      const recovery = await recoverPendingApprovalsForAgent(this.store.agentId);
+                      if (recovery.recovered) {
+                        log.info(`sendToAgent: API-level recovery succeeded (${recovery.details})`);
+                      } else {
+                        log.warn(`sendToAgent: API-level recovery failed (${recovery.details})`);
+                      }
+                    }
                   }
                   this.sessionManager.invalidateSession(convKey);
                   retried = true;

--- a/src/core/result-guard.test.ts
+++ b/src/core/result-guard.test.ts
@@ -6,7 +6,13 @@ import { LettaBot } from './bot.js';
 import type { InboundMessage, OutboundMessage } from './types.js';
 
 vi.mock('../tools/letta-api.js', () => ({
+  getPendingApprovals: vi.fn(),
+  rejectApproval: vi.fn(),
+  cancelRuns: vi.fn(),
   cancelConversation: vi.fn(),
+  recoverOrphanedConversationApproval: vi.fn().mockResolvedValue({ recovered: false }),
+  recoverPendingApprovalsForAgent: vi.fn(),
+  isRecoverableConversationId: vi.fn(() => false),
   getLatestRunError: vi.fn().mockResolvedValue(null),
   getAgentModel: vi.fn(),
   updateAgentModel: vi.fn(),

--- a/src/core/sdk-session-contract.test.ts
+++ b/src/core/sdk-session-contract.test.ts
@@ -12,6 +12,16 @@ vi.mock('@letta-ai/letta-code-sdk', () => ({
 
 vi.mock('../tools/letta-api.js', () => ({
   updateAgentName: vi.fn().mockResolvedValue(undefined),
+  getPendingApprovals: vi.fn(),
+  rejectApproval: vi.fn(),
+  cancelRuns: vi.fn(),
+  recoverOrphanedConversationApproval: vi.fn(),
+  recoverPendingApprovalsForAgent: vi.fn(),
+  isRecoverableConversationId: vi.fn((conversationId?: string | null) => (
+    typeof conversationId === 'string' && conversationId.length > 0
+      && conversationId !== 'default'
+      && conversationId !== 'shared'
+  )),
   getLatestRunError: vi.fn().mockResolvedValue(null),
 }));
 
@@ -31,7 +41,7 @@ vi.mock('./system-prompt.js', () => ({
 }));
 
 import { createAgent, createSession, resumeSession } from '@letta-ai/letta-code-sdk';
-import { getLatestRunError } from '../tools/letta-api.js';
+import { getLatestRunError, recoverOrphanedConversationApproval, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
 import { LettaBot } from './bot.js';
 import { SessionManager } from './session-manager.js';
 import { Store } from './store.js';
@@ -66,6 +76,10 @@ describe('SDK session contract', () => {
     delete process.env.LETTA_SESSION_TIMEOUT_MS;
 
     vi.clearAllMocks();
+    vi.mocked(recoverPendingApprovalsForAgent).mockResolvedValue({
+      recovered: false,
+      details: 'No pending approvals found on agent',
+    });
   });
 
   afterEach(() => {
@@ -470,6 +484,11 @@ describe('SDK session contract', () => {
       conversationId: 'default',
     };
 
+    vi.mocked(recoverPendingApprovalsForAgent).mockResolvedValueOnce({
+      recovered: true,
+      details: 'Rejected 1 pending approval(s) and cancelled 1 run(s)',
+    });
+
     vi.mocked(resumeSession)
       .mockReturnValueOnce(initialSession as never)
       .mockReturnValueOnce(recoveredSession as never);
@@ -483,6 +502,8 @@ describe('SDK session contract', () => {
 
     expect(response).toBe('ok');
     expect(vi.mocked(resumeSession)).toHaveBeenCalledTimes(2);
+    expect(recoverOrphanedConversationApproval).not.toHaveBeenCalled();
+    expect(recoverPendingApprovalsForAgent).toHaveBeenCalledWith('agent-contract-test');
     expect(initialSession.close).toHaveBeenCalledTimes(1);
   });
 
@@ -518,6 +539,11 @@ describe('SDK session contract', () => {
       conversationId: 'conv-fresh',
     };
 
+    vi.mocked(recoverOrphanedConversationApproval).mockResolvedValueOnce({
+      recovered: true,
+      details: "Denied 1 approval(s) from failed run run-ok; Failed to deny 1 approval(s) from run run-stuck: Invalid tool call IDs. Expected '['call_a']', but received '['call_b']'",
+    });
+
     vi.mocked(resumeSession)
       .mockReturnValueOnce(initialSession as never)
       .mockReturnValueOnce(recoveredSession as never);
@@ -533,6 +559,11 @@ describe('SDK session contract', () => {
     const response = await bot.sendToAgent('hello');
 
     expect(response).toBe('proactive recovered');
+    expect(recoverOrphanedConversationApproval).toHaveBeenCalledWith(
+      'agent-contract-test',
+      'conv-stuck',
+      true
+    );
     expect(vi.mocked(resumeSession)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(resumeSession).mock.calls[0][0]).toBe('conv-stuck');
     expect(vi.mocked(resumeSession).mock.calls[1][0]).toBe('conv-stuck');
@@ -1114,6 +1145,10 @@ describe('SDK session contract', () => {
       stopReason: 'requires_approval',
       isApprovalError: true,
     });
+    vi.mocked(recoverOrphanedConversationApproval).mockResolvedValueOnce({
+      recovered: false,
+      details: 'No unresolved approval requests found',
+    });
 
     const adapter = {
       id: 'mock',
@@ -1140,6 +1175,11 @@ describe('SDK session contract', () => {
     await (bot as any).processMessage(msg, adapter);
 
     expect((bot as any).sessionManager.runSession).toHaveBeenCalledTimes(2);
+    expect(recoverOrphanedConversationApproval).toHaveBeenCalledWith(
+      'agent-contract-test',
+      'conv-approval',
+      true
+    );
     const sentTexts = adapter.sendMessage.mock.calls.map((call) => {
       const payload = call[0] as { text?: string };
       return payload.text;
@@ -1176,6 +1216,11 @@ describe('SDK session contract', () => {
       },
     }));
 
+    vi.mocked(recoverOrphanedConversationApproval).mockResolvedValueOnce({
+      recovered: false,
+      details: 'No unresolved approval requests found',
+    });
+
     const adapter = {
       id: 'mock',
       name: 'Mock',
@@ -1203,8 +1248,13 @@ describe('SDK session contract', () => {
     // The pre-foreground error is filtered, so lastErrorDetail is null.
     // The result (success=false, nothing delivered) triggers shouldRetryForErrorResult,
     // NOT isApprovalConflict. The retry goes through the error-result path with
-    // SDK-level approval recovery, then retries and succeeds.
+    // orphaned approval recovery, then retries and succeeds.
     expect((bot as any).sessionManager.runSession).toHaveBeenCalledTimes(2);
+    // Approval recovery should have been attempted via the error-result path
+    expect(recoverOrphanedConversationApproval).toHaveBeenCalledWith(
+      'agent-contract-test',
+      'conv-approval',
+    );
     const sentTexts = adapter.sendMessage.mock.calls.map((call) => {
       const payload = call[0] as { text?: string };
       return payload.text;
@@ -1236,6 +1286,10 @@ describe('SDK session contract', () => {
       stopReason: 'error',
       isApprovalError: true,
     });
+    vi.mocked(recoverPendingApprovalsForAgent).mockResolvedValueOnce({
+      recovered: true,
+      details: 'Rejected 1 pending approval(s) and cancelled 1 run(s)',
+    });
 
     const adapter = {
       id: 'mock',
@@ -1262,6 +1316,8 @@ describe('SDK session contract', () => {
     await (bot as any).processMessage(msg, adapter);
 
     expect((bot as any).sessionManager.runSession).toHaveBeenCalledTimes(2);
+    expect(recoverOrphanedConversationApproval).not.toHaveBeenCalled();
+    expect(recoverPendingApprovalsForAgent).toHaveBeenCalledWith('agent-contract-test');
     const sentTexts = adapter.sendMessage.mock.calls.map((call) => {
       const payload = call[0] as { text?: string };
       return payload.text;
@@ -1286,10 +1342,7 @@ describe('SDK session contract', () => {
         })()
       ),
       close: vi.fn(() => undefined),
-      recoverPendingApprovals: vi.fn(async () => ({
-        recovered: true,
-        details: "Denied 1 approval(s) from failed run run-ok; Failed to deny 1 approval(s) from run run-stuck: Invalid tool call IDs. Expected '['call_a']', but received '['call_b']'",
-      })),
+      recoverPendingApprovals: vi.fn(async () => ({ recovered: false, unsupported: true, detail: 'mock' })),
       agentId: 'agent-contract-test',
       conversationId: 'conv-stuck',
     };
@@ -1310,6 +1363,11 @@ describe('SDK session contract', () => {
       conversationId: 'conv-fresh',
     };
 
+    vi.mocked(recoverOrphanedConversationApproval).mockResolvedValueOnce({
+      recovered: true,
+      details: "Denied 1 approval(s) from failed run run-ok; Failed to deny 1 approval(s) from run run-stuck: Invalid tool call IDs. Expected '['call_a']', but received '['call_b']'",
+    });
+
     vi.mocked(resumeSession)
       .mockReturnValueOnce(stuckSession as never)
       .mockReturnValueOnce(recoveredSession as never);
@@ -1325,7 +1383,7 @@ describe('SDK session contract', () => {
     const response = await bot.sendToAgent('hello');
 
     expect(response).toBe('reactive recovered');
-    expect(stuckSession.recoverPendingApprovals).toHaveBeenCalledTimes(1);
+    expect(recoverOrphanedConversationApproval).toHaveBeenCalledWith('agent-contract-test', 'conv-stuck');
     expect(vi.mocked(resumeSession)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(resumeSession).mock.calls[0][0]).toBe('conv-stuck');
     expect(vi.mocked(resumeSession).mock.calls[1][0]).toBe('conv-stuck');

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -10,7 +10,7 @@ import { createAgent, createSession, resumeSession, type Session, type SendMessa
 import type { BotConfig, StreamMsg } from './types.js';
 import { isApprovalConflictError, isConversationMissingError, isAgentMissingFromInitError } from './errors.js';
 import { Store } from './store.js';
-import { updateAgentName } from '../tools/letta-api.js';
+import { updateAgentName, recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
 import { installSkillsToAgent, prependSkillDirsToPath } from '../skills/loader.js';
 import { loadMemoryBlocks } from './memory.js';
 import { SYSTEM_PROMPT } from './system-prompt.js';
@@ -376,13 +376,24 @@ export class SessionManager {
           const convId = bootstrap.conversationId || session.conversationId;
           log.warn(`Pending approval detected at session startup (key=${key}, conv=${convId}), recovering...`);
 
+          // Try SDK-level recovery first (goes through CLI control protocol)
           const sdkResult = await recoverPendingApprovalsWithSdk(session, 10_000);
           if (sdkResult.recovered) {
             log.info('Proactive SDK approval recovery succeeded');
-          } else {
-            log.warn(`SDK approval recovery did not resolve (${sdkResult.detail ?? 'unknown'})`);
+            return this._createSessionForKey(key, true, generation);
           }
+
+          // SDK recovery failed -- fall back to API-level recovery
+          log.warn(`SDK recovery did not resolve (${sdkResult.detail ?? 'unknown'}), trying API-level recovery...`);
           session.close();
+          const result = isRecoverableConversationId(convId)
+            ? await recoverOrphanedConversationApproval(this.store.agentId, convId, true)
+            : await recoverPendingApprovalsForAgent(this.store.agentId);
+          if (result.recovered) {
+            log.info(`Proactive API-level recovery succeeded: ${result.details}`);
+          } else {
+            log.warn(`Proactive approval recovery did not find resolvable approvals: ${result.details}`);
+          }
           return this._createSessionForKey(key, true, generation);
         }
       } catch (err) {
@@ -561,17 +572,25 @@ export class SessionManager {
     try {
       await this.withSessionTimeout(session.send(message), `Session send (key=${convKey})`);
     } catch (error) {
-      // 409 CONFLICT from orphaned approval -- use SDK recovery
+      // 409 CONFLICT from orphaned approval -- use SDK recovery first, fall back to API
       if (!retried && isApprovalConflictError(error) && this.store.agentId) {
         log.info('CONFLICT detected - attempting SDK approval recovery...');
         const sdkResult = await recoverPendingApprovalsWithSdk(session, 10_000);
         if (sdkResult.recovered) {
           log.info('SDK approval recovery succeeded, retrying...');
-          this.invalidateSession(convKey);
           return this.runSession(message, { retried: true, canUseTool, convKey });
         }
-        log.error(`SDK approval recovery failed (${sdkResult.detail ?? 'unknown'})`);
+        // SDK recovery failed or unsupported -- fall back to API-level recovery
+        log.warn(`SDK recovery did not resolve (${sdkResult.detail ?? 'unknown'}), trying API-level recovery...`);
         this.invalidateSession(convKey);
+        const result = isRecoverableConversationId(convId)
+          ? await recoverOrphanedConversationApproval(this.store.agentId, convId)
+          : await recoverPendingApprovalsForAgent(this.store.agentId);
+        if (result.recovered) {
+          log.info(`API-level recovery succeeded (${result.details}), retrying...`);
+          return this.runSession(message, { retried: true, canUseTool, convKey });
+        }
+        log.error(`Approval recovery failed: ${result.details}`);
         throw error;
       }
 

--- a/src/tools/letta-api.test.ts
+++ b/src/tools/letta-api.test.ts
@@ -33,7 +33,62 @@ vi.mock('@letta-ai/letta-client', () => {
   };
 });
 
-import { getLatestRunError } from './letta-api.js';
+describe('recoverPendingApprovalsForAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentsRetrieve.mockResolvedValue({ pending_approval: null });
+    mockAgentsMessagesList.mockReturnValue(mockPageIterator([]));
+    mockAgentsMessagesCancel.mockResolvedValue(undefined);
+  });
+
+  it('cancels approval-blocked runs when pending approval payload is unavailable', async () => {
+    // First runs.list call: getPendingApprovals run scan (no tool calls resolved)
+    mockRunsList
+      .mockReturnValueOnce(mockPageIterator([
+        { id: 'run-stuck', status: 'created', stop_reason: 'requires_approval' },
+      ]))
+      // Second runs.list call: listAgentApprovalRunIds fallback
+      .mockReturnValueOnce(mockPageIterator([
+        { id: 'run-stuck', status: 'created', stop_reason: 'requires_approval' },
+      ]));
+
+    const result = await recoverPendingApprovalsForAgent('agent-1');
+
+    expect(result.recovered).toBe(true);
+    expect(result.details).toContain('Cancelled 1 approval-blocked run(s)');
+    expect(mockAgentsMessagesCancel).toHaveBeenCalledWith('agent-1', {
+      run_ids: ['run-stuck'],
+    });
+  });
+
+  it('returns false when no pending approvals and no approval-blocked runs are found', async () => {
+    mockRunsList
+      .mockReturnValueOnce(mockPageIterator([]))
+      .mockReturnValueOnce(mockPageIterator([]));
+
+    const result = await recoverPendingApprovalsForAgent('agent-1');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toBe('No pending approvals found on agent');
+    expect(mockAgentsMessagesCancel).not.toHaveBeenCalled();
+  });
+});
+
+import { getLatestRunError, recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent } from './letta-api.js';
+
+describe('isRecoverableConversationId', () => {
+  it('returns false for aliases and empty values', () => {
+    expect(isRecoverableConversationId(undefined)).toBe(false);
+    expect(isRecoverableConversationId(null)).toBe(false);
+    expect(isRecoverableConversationId('')).toBe(false);
+    expect(isRecoverableConversationId('default')).toBe(false);
+    expect(isRecoverableConversationId('shared')).toBe(false);
+  });
+
+  it('returns true for materialized conversation ids', () => {
+    expect(isRecoverableConversationId('conv-123')).toBe(true);
+  });
+});
 
 // Helper to create a mock async iterable from an array (Letta client returns paginated iterators)
 function mockPageIterator<T>(items: T[]) {
@@ -43,6 +98,281 @@ function mockPageIterator<T>(items: T[]) {
     },
   };
 }
+
+describe('recoverOrphanedConversationApproval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunsList.mockReturnValue(mockPageIterator([]));
+    mockAgentsRetrieve.mockResolvedValue({ pending_approval: null });
+    mockAgentsMessagesList.mockReturnValue(mockPageIterator([]));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false when no messages in conversation', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([]));
+
+    const result = await recoverOrphanedConversationApproval('agent-1', 'conv-1');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toBe('No messages in conversation');
+  });
+
+  it('skips non-recoverable conversation ids like default', async () => {
+    const result = await recoverOrphanedConversationApproval('agent-1', 'default');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toContain('Conversation is not recoverable: default');
+    expect(mockConversationsMessagesList).not.toHaveBeenCalled();
+  });
+
+  it('returns false when no unresolved approval requests', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      { message_type: 'assistant_message', content: 'hello' },
+    ]));
+
+    const result = await recoverOrphanedConversationApproval('agent-1', 'conv-1');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toBe('No unresolved approval requests found');
+  });
+
+  it('recovers from failed run with unresolved approval', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-1', name: 'Bash' }],
+        run_id: 'run-1',
+        id: 'msg-1',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'failed', stop_reason: 'error' });
+    mockConversationsMessagesCreate.mockResolvedValue({});
+    mockRunsList.mockReturnValue(mockPageIterator([{ id: 'run-denial-1' }]));
+    mockAgentsMessagesCancel.mockResolvedValue(undefined);
+
+    // Recovery has a 3s delay after denial; advance fake timers to resolve it
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await resultPromise;
+
+    expect(result.recovered).toBe(true);
+    expect(result.details).toContain('Denied 1 approval(s) from failed run run-1');
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledOnce();
+    // Should only cancel runs active in this same conversation
+    expect(mockAgentsMessagesCancel).toHaveBeenCalledOnce();
+    expect(mockAgentsMessagesCancel).toHaveBeenCalledWith('agent-1', {
+      run_ids: ['run-denial-1'],
+    });
+  });
+
+  it('recovers from stuck running+requires_approval and cancels the run', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-2', name: 'Grep' }],
+        run_id: 'run-2',
+        id: 'msg-2',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'running', stop_reason: 'requires_approval' });
+    mockConversationsMessagesCreate.mockResolvedValue({});
+    mockRunsList.mockReturnValue(mockPageIterator([{ id: 'run-2' }]));
+    mockAgentsMessagesCancel.mockResolvedValue(undefined);
+
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await resultPromise;
+
+    expect(result.recovered).toBe(true);
+    expect(result.details).toContain('(runs cancelled)');
+    // Should send denial
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledOnce();
+    const createCall = mockConversationsMessagesCreate.mock.calls[0];
+    expect(createCall[0]).toBe('conv-1');
+    const approvals = createCall[1].messages[0].approvals;
+    expect(approvals[0].approve).toBe(false);
+    expect(approvals[0].tool_call_id).toBe('tc-2');
+    // Should cancel the stuck run
+    expect(mockAgentsMessagesCancel).toHaveBeenCalledOnce();
+    expect(mockAgentsMessagesCancel).toHaveBeenCalledWith('agent-1', {
+      run_ids: ['run-2'],
+    });
+  });
+
+  it('skips already-resolved approvals', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-3', name: 'Read' }],
+        run_id: 'run-3',
+        id: 'msg-3',
+      },
+      {
+        message_type: 'approval_response_message',
+        approvals: [{ tool_call_id: 'tc-3' }],
+      },
+    ]));
+
+    const result = await recoverOrphanedConversationApproval('agent-1', 'conv-1');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toBe('No unresolved approval requests found');
+    expect(mockRunsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it('does not recover from healthy running run', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-4', name: 'Bash' }],
+        run_id: 'run-4',
+        id: 'msg-4',
+      },
+    ]));
+    // Running but NOT stuck on approval -- normal in-progress run
+    mockRunsRetrieve.mockResolvedValue({ status: 'running', stop_reason: null });
+
+    const result = await recoverOrphanedConversationApproval('agent-1', 'conv-1');
+
+    expect(result.recovered).toBe(false);
+    expect(result.details).toContain('not orphaned');
+    expect(mockConversationsMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates identical tool_call_ids across multiple approval_request_messages', async () => {
+    // Simulate the server returning the same tool_call_id in multiple
+    // approval_request_messages (the root cause of #359).
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-dup', name: 'Bash' }],
+        run_id: 'run-dup',
+        id: 'msg-dup-1',
+      },
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-dup', name: 'Bash' }],
+        run_id: 'run-dup',
+        id: 'msg-dup-2',
+      },
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-dup', name: 'Bash' }],
+        run_id: 'run-dup',
+        id: 'msg-dup-3',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'failed', stop_reason: 'error' });
+    mockConversationsMessagesCreate.mockResolvedValue({});
+    mockRunsList.mockReturnValue(mockPageIterator([]));
+
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await resultPromise;
+
+    expect(result.recovered).toBe(true);
+    // Should only send ONE denial despite three identical approval_request_messages
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledOnce();
+    const approvals = mockConversationsMessagesCreate.mock.calls[0][1].messages[0].approvals;
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0].tool_call_id).toBe('tc-dup');
+  });
+
+  it('recovers remaining approvals by submitting denials sequentially', async () => {
+    // Parallel tool calls can fail when denied as one batch. Verify we keep
+    // progressing by submitting one tool_call_id per request.
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [
+          { tool_call_id: 'tc-a', name: 'Bash' },
+          { tool_call_id: 'tc-b', name: 'Read' },
+          { tool_call_id: 'tc-c', name: 'Grep' },
+        ],
+        run_id: 'run-parallel',
+        id: 'msg-parallel',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'failed', stop_reason: 'error' });
+    mockConversationsMessagesCreate
+      .mockRejectedValueOnce(new Error("Invalid tool call IDs. Expected '['tc-b']', but received '['tc-a']'"))
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    mockRunsList.mockReturnValue(mockPageIterator([]));
+
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(10000);
+    const result = await resultPromise;
+
+    expect(result.recovered).toBe(true);
+    expect(result.details).toContain('Failed to deny approval tc-a from run run-parallel');
+    expect(result.details).toContain('Denied 2 approval(s) from failed run run-parallel');
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledTimes(3);
+    expect(mockConversationsMessagesCreate.mock.calls.map((call) => call[1].messages[0].approvals[0].tool_call_id))
+      .toEqual(['tc-a', 'tc-b', 'tc-c']);
+  });
+
+  it('continues recovery if approval denial API call fails for one run', async () => {
+    // Two runs with approvals -- first denial fails, second should still succeed
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-fail', name: 'Bash' }],
+        run_id: 'run-fail',
+        id: 'msg-fail',
+      },
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-ok', name: 'Read' }],
+        run_id: 'run-ok',
+        id: 'msg-ok',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'failed', stop_reason: 'error' });
+    mockConversationsMessagesCreate
+      .mockRejectedValueOnce(new Error('400 BadRequestError'))
+      .mockResolvedValueOnce({});
+    mockRunsList.mockReturnValue(mockPageIterator([]));
+
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await resultPromise;
+
+    // Second run still recovered despite first failing
+    expect(result.recovered).toBe(true);
+    expect(result.details).toContain('Failed to deny');
+    expect(result.details).toContain('Denied 1 approval(s) from failed run run-ok');
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports cancel failure accurately', async () => {
+    mockConversationsMessagesList.mockReturnValue(mockPageIterator([
+      {
+        message_type: 'approval_request_message',
+        tool_calls: [{ tool_call_id: 'tc-5', name: 'Grep' }],
+        run_id: 'run-5',
+        id: 'msg-5',
+      },
+    ]));
+    mockRunsRetrieve.mockResolvedValue({ status: 'running', stop_reason: 'requires_approval' });
+    mockConversationsMessagesCreate.mockResolvedValue({});
+    mockRunsList.mockReturnValue(mockPageIterator([{ id: 'run-5' }]));
+    // Cancel fails
+    mockAgentsMessagesCancel.mockRejectedValue(new Error('cancel failed'));
+
+    const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await resultPromise;
+
+    expect(result.recovered).toBe(true);
+    // Cancel failure is logged but doesn't change the suffix anymore
+    expect(result.details).toContain('Denied 1 approval(s) from running run run-5');
+  });
+});
 
 describe('getLatestRunError', () => {
   beforeEach(() => {

--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -21,6 +21,31 @@ function getClient(): Letta {
   });
 }
 
+async function listAgentApprovalRunIds(agentId: string, limit = 10): Promise<string[]> {
+  try {
+    const client = getClient();
+    const runsPage = await client.runs.list({
+      agent_id: agentId,
+      stop_reason: 'requires_approval',
+      limit,
+    });
+
+    const runIds: string[] = [];
+    for await (const run of runsPage) {
+      if (run.stop_reason !== 'requires_approval') continue;
+      const id = (run as { id?: unknown }).id;
+      if (typeof id === 'string' && id.length > 0) {
+        runIds.push(id);
+      }
+      if (runIds.length >= limit) break;
+    }
+    return runIds;
+  } catch (e) {
+    log.warn('Failed to list approval-blocked runs:', e instanceof Error ? e.message : e);
+    return [];
+  }
+}
+
 /**
  * Test connection to Letta server (silent, no error logging)
  */
@@ -33,6 +58,88 @@ export async function testConnection(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Recover stuck approvals at the agent level without requiring a concrete
+ * conversation ID. This is the fallback for default/alias conversations.
+ */
+export async function recoverPendingApprovalsForAgent(
+  agentId: string,
+  reason = 'Session was interrupted - retrying request'
+): Promise<{ recovered: boolean; details: string }> {
+  try {
+    const pending = await getPendingApprovals(agentId);
+    if (pending.length === 0) {
+      // Some servers report approval conflicts while omitting pending_approval
+      // details/tool_call IDs. In that case, cancel approval-blocked runs directly.
+      const approvalRunIds = await listAgentApprovalRunIds(agentId);
+      if (approvalRunIds.length === 0) {
+        return { recovered: false, details: 'No pending approvals found on agent' };
+      }
+      const cancelled = await cancelRuns(agentId, approvalRunIds);
+      if (!cancelled) {
+        return {
+          recovered: false,
+          details: `Found ${approvalRunIds.length} approval-blocked run(s) but failed to cancel`,
+        };
+      }
+      return {
+        recovered: true,
+        details: `Cancelled ${approvalRunIds.length} approval-blocked run(s) without tool-call details`,
+      };
+    }
+
+    // Deduplicate by tool_call_id defensively (getPendingApprovals should
+    // already dedup, but this guards against any upstream regression).
+    const rejectedIds = new Set<string>();
+    let rejectedCount = 0;
+    for (const approval of pending) {
+      if (rejectedIds.has(approval.toolCallId)) continue;
+      rejectedIds.add(approval.toolCallId);
+      const ok = await rejectApproval(agentId, {
+        toolCallId: approval.toolCallId,
+        reason,
+      });
+      if (ok) rejectedCount += 1;
+    }
+
+    const runIds = [...new Set(
+      pending
+        .map(a => a.runId)
+        .filter((id): id is string => !!id && id !== 'unknown')
+    )];
+    if (runIds.length > 0) {
+      await cancelRuns(agentId, runIds);
+    }
+
+    if (rejectedCount === 0) {
+      return { recovered: false, details: 'Failed to reject pending approvals' };
+    }
+
+    return {
+      recovered: true,
+      details: `Rejected ${rejectedCount} pending approval(s)${runIds.length > 0 ? ` and cancelled ${runIds.length} run(s)` : ''}`,
+    };
+  } catch (e) {
+    return {
+      recovered: false,
+      details: `Agent-level approval recovery failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+/**
+ * Returns true when a conversation id refers to a concrete conversation record
+ * that can be queried for messages/runs.
+ */
+export function isRecoverableConversationId(conversationId?: string | null): conversationId is string {
+  if (typeof conversationId !== 'string') return false;
+  const value = conversationId.trim();
+  if (!value) return false;
+  // SDK/API aliases are not materialized conversation IDs.
+  if (value === 'default' || value === 'shared') return false;
+  return true;
 }
 
 // Re-export types that callers use
@@ -247,6 +354,235 @@ export async function findAgentByName(name: string): Promise<{ id: string; name:
 // Tool Approval Management
 // ============================================================================
 
+export interface PendingApproval {
+  runId: string;
+  toolCallId: string;
+  toolName: string;
+  messageId: string;
+}
+
+/**
+ * Check for pending approval requests on an agent's conversation.
+ * Returns details of any tool calls waiting for approval.
+ */
+export async function getPendingApprovals(
+  agentId: string,
+  conversationId?: string
+): Promise<PendingApproval[]> {
+  try {
+    const client = getClient();
+
+    // Prefer agent-level pending approval to avoid scanning stale history.
+    // IMPORTANT: Must include 'agent.pending_approval' or the field won't be returned.
+    try {
+      const agentState = await client.agents.retrieve(agentId, {
+        include: ['agent.pending_approval'],
+      });
+      if ('pending_approval' in agentState) {
+        const pending = agentState.pending_approval;
+        if (!pending) {
+          log.info('No pending approvals on agent; falling back to run scan');
+        } else {
+          log.info(`Found pending approval: ${pending.id}, run_id=${pending.run_id}`);
+
+          // Extract tool calls - handle both Array<ToolCall> and ToolCallDelta formats
+          const rawToolCalls = pending.tool_calls;
+          const toolCallsList: Array<{ tool_call_id: string; name: string }> = [];
+
+          if (Array.isArray(rawToolCalls)) {
+            for (const tc of rawToolCalls) {
+              if (tc && 'tool_call_id' in tc && tc.tool_call_id) {
+                toolCallsList.push({ tool_call_id: tc.tool_call_id, name: tc.name || 'unknown' });
+              }
+            }
+          } else if (rawToolCalls && typeof rawToolCalls === 'object' && 'tool_call_id' in rawToolCalls && rawToolCalls.tool_call_id) {
+            // ToolCallDelta case
+            toolCallsList.push({ tool_call_id: rawToolCalls.tool_call_id, name: rawToolCalls.name || 'unknown' });
+          }
+
+          // Fallback to deprecated singular tool_call field
+          if (toolCallsList.length === 0 && pending.tool_call) {
+            const tc = pending.tool_call;
+            if ('tool_call_id' in tc && tc.tool_call_id) {
+              toolCallsList.push({ tool_call_id: tc.tool_call_id, name: tc.name || 'unknown' });
+            }
+          }
+
+          const seen = new Set<string>();
+          const approvals: PendingApproval[] = [];
+          for (const tc of toolCallsList) {
+            if (seen.has(tc.tool_call_id)) continue;
+            seen.add(tc.tool_call_id);
+            approvals.push({
+              runId: pending.run_id || 'unknown',
+              toolCallId: tc.tool_call_id,
+              toolName: tc.name || 'unknown',
+              messageId: pending.id,
+            });
+          }
+          if (approvals.length > 0) {
+            log.info(`Extracted ${approvals.length} pending approval(s): ${approvals.map(a => a.toolName).join(', ')}`);
+            return approvals;
+          }
+          log.warn('Agent pending_approval had no tool_call_ids; falling back to run scan');
+        }
+      }
+    } catch (e) {
+      log.warn('Failed to retrieve agent pending_approval, falling back to run scan:', e);
+    }
+    
+    // First, check for runs with 'requires_approval' stop reason
+    const runsPage = await client.runs.list({
+      agent_id: agentId,
+      conversation_id: conversationId,
+      stop_reason: 'requires_approval',
+      limit: 10,
+    });
+
+    // Collect qualifying run IDs (avoid re-fetching messages per run)
+    const qualifyingRunIds: string[] = [];
+    for await (const run of runsPage) {
+      if (run.status === 'running' || run.stop_reason === 'requires_approval') {
+        qualifyingRunIds.push(run.id);
+      }
+    }
+
+    if (qualifyingRunIds.length === 0) {
+      return [];
+    }
+
+    // Fetch messages ONCE and scan for resolved + pending approvals
+    const messagesPage = await client.agents.messages.list(agentId, {
+      conversation_id: conversationId,
+      limit: 100,
+    });
+
+    const messages: Array<{ message_type?: string }> = [];
+    for await (const msg of messagesPage) {
+      messages.push(msg as { message_type?: string });
+    }
+
+    // Build set of already-resolved tool_call_ids
+    const resolvedToolCalls = new Set<string>();
+    for (const msg of messages) {
+      if ('message_type' in msg && msg.message_type === 'approval_response_message') {
+        const approvalMsg = msg as {
+          approvals?: Array<{ tool_call_id?: string | null }>;
+        };
+        const approvals = approvalMsg.approvals || [];
+        for (const approval of approvals) {
+          if (approval.tool_call_id) {
+            resolvedToolCalls.add(approval.tool_call_id);
+          }
+        }
+      }
+    }
+
+    // Collect unresolved approval requests, deduplicating across all runs
+    const pendingApprovals: PendingApproval[] = [];
+    const seenToolCalls = new Set<string>();
+    for (const msg of messages) {
+      if ('message_type' in msg && msg.message_type === 'approval_request_message') {
+        const approvalMsg = msg as {
+          id: string;
+          tool_calls?: Array<{ tool_call_id: string; name: string }>;
+          tool_call?: { tool_call_id: string; name: string };
+          run_id?: string;
+        };
+
+        const toolCalls = approvalMsg.tool_calls || (approvalMsg.tool_call ? [approvalMsg.tool_call] : []);
+        for (const tc of toolCalls) {
+          if (resolvedToolCalls.has(tc.tool_call_id)) continue;
+          if (seenToolCalls.has(tc.tool_call_id)) continue;
+          seenToolCalls.add(tc.tool_call_id);
+          pendingApprovals.push({
+            runId: approvalMsg.run_id || qualifyingRunIds[0],
+            toolCallId: tc.tool_call_id,
+            toolName: tc.name,
+            messageId: approvalMsg.id,
+          });
+        }
+      }
+    }
+
+    return pendingApprovals;
+  } catch (e) {
+    log.error('Failed to get pending approvals:', e);
+    return [];
+  }
+}
+
+/**
+ * Reject a pending tool approval request.
+ * Sends an approval response with approve: false.
+ */
+export async function rejectApproval(
+  agentId: string,
+  approval: {
+    toolCallId: string;
+    reason?: string;
+  },
+  conversationId?: string
+): Promise<boolean> {
+  try {
+    const client = getClient();
+    
+    // Send approval response via messages.create
+    await client.agents.messages.create(agentId, {
+      messages: [{
+        type: 'approval',
+        approvals: [{
+          approve: false,
+          tool_call_id: approval.toolCallId,
+          type: 'approval',
+          reason: approval.reason || 'Session was interrupted - please retry your request',
+        }],
+      }],
+      streaming: false,
+    });
+    
+    log.info(`Rejected approval for tool call ${approval.toolCallId}`);
+    return true;
+  } catch (e) {
+    const err = e as { status?: number; error?: { detail?: string } };
+    const detail = err?.error?.detail || '';
+    if (err?.status === 400 && detail.includes('No tool call is currently awaiting approval')) {
+      log.warn(`Approval already resolved for tool call ${approval.toolCallId}`);
+      return true;
+    }
+    // Re-throw rate limit errors so callers can bail out early instead of
+    // hammering the API in a tight loop.
+    if (err?.status === 429) {
+      log.error('Failed to reject approval:', e);
+      throw e;
+    }
+    log.error('Failed to reject approval:', e);
+    return false;
+  }
+}
+
+/**
+ * Cancel active runs for an agent.
+ * Optionally specify specific run IDs to cancel.
+ * Note: Requires Redis on the server for canceling active runs.
+ */
+export async function cancelRuns(
+  agentId: string,
+  runIds?: string[]
+): Promise<boolean> {
+  try {
+    const client = getClient();
+    await client.agents.messages.cancel(agentId, {
+      run_ids: runIds,
+    });
+    log.info(`Cancelled runs for agent ${agentId}${runIds ? ` (${runIds.join(', ')})` : ''}`);
+    return true;
+  } catch (e) {
+    log.error('Failed to cancel runs:', e);
+    return false;
+  }
+}
+
 /**
  * Cancel active runs for a specific conversation.
  * Scoped to a single conversation -- won't affect other channels/conversations.
@@ -336,6 +672,35 @@ export async function getLatestRunError(
   }
 }
 
+async function listActiveConversationRunIds(
+  agentId: string,
+  conversationId: string,
+  limit = 25
+): Promise<string[]> {
+  try {
+    const client = getClient();
+    const runs = await client.runs.list({
+      agent_id: agentId,
+      conversation_id: conversationId,
+      active: true,
+      limit,
+    });
+
+    const runIds: string[] = [];
+    for await (const run of runs) {
+      const id = (run as { id?: unknown }).id;
+      if (typeof id === 'string' && id.length > 0) {
+        runIds.push(id);
+      }
+      if (runIds.length >= limit) break;
+    }
+    return runIds;
+  } catch (e) {
+    log.warn('Failed to list active conversation runs:', e instanceof Error ? e.message : e);
+    return [];
+  }
+}
+
 /**
  * Disable tool approval requirement for a specific tool on an agent.
  * This sets requires_approval: false at the server level.
@@ -412,6 +777,205 @@ export async function ensureNoToolApprovals(agentId: string): Promise<void> {
  * Disable approval requirement for ALL tools on an agent.
  * Useful for ensuring a headless deployment doesn't get stuck.
  */
+/**
+ * Recover from orphaned approval_request_messages by directly inspecting the conversation.
+ * 
+ * Unlike getPendingApprovals() which relies on agent.pending_approval or run stop_reason,
+ * this function looks at the actual conversation messages to find unresolved approval requests
+ * from terminated (failed/cancelled) runs.
+ * 
+ * Returns { recovered: true } if orphaned approvals were found and resolved.
+ */
+export async function recoverOrphanedConversationApproval(
+  agentId: string,
+  conversationId: string,
+  deepScan = false
+): Promise<{ recovered: boolean; details: string }> {
+  try {
+    if (!isRecoverableConversationId(conversationId)) {
+      return {
+        recovered: false,
+        details: `Conversation is not recoverable: ${conversationId || '(empty)'}`,
+      };
+    }
+
+    const client = getClient();
+    
+    // List recent messages from the conversation to find orphaned approvals.
+    // Default: 50 (fast path). Deep scan: 500 (for conversations with many approvals).
+    const scanLimit = deepScan ? 500 : 50;
+    log.info(`Scanning ${scanLimit} messages for orphaned approvals...`);
+    const messagesPage = await client.conversations.messages.list(conversationId, { limit: scanLimit });
+    const messages: Array<Record<string, unknown>> = [];
+    for await (const msg of messagesPage) {
+      messages.push(msg as unknown as Record<string, unknown>);
+    }
+    
+    if (messages.length === 0) {
+      return { recovered: false, details: 'No messages in conversation' };
+    }
+    
+    // Build set of tool_call_ids that already have approval responses
+    const resolvedToolCalls = new Set<string>();
+    for (const msg of messages) {
+      if (msg.message_type === 'approval_response_message') {
+        const approvals = (msg.approvals as Array<{ tool_call_id?: string }>) || [];
+        for (const a of approvals) {
+          if (a.tool_call_id) resolvedToolCalls.add(a.tool_call_id);
+        }
+      }
+    }
+    
+    // Find unresolved approval_request_messages
+    interface UnresolvedApproval {
+      toolCallId: string;
+      toolName: string;
+      runId: string;
+    }
+    const unresolvedByRun = new Map<string, UnresolvedApproval[]>();
+    const seenToolCallIds = new Set<string>();
+    
+    for (const msg of messages) {
+      if (msg.message_type !== 'approval_request_message') continue;
+      
+      const toolCalls = (msg.tool_calls as Array<{ tool_call_id: string; name: string }>) 
+        || (msg.tool_call ? [msg.tool_call as { tool_call_id: string; name: string }] : []);
+      const runId = msg.run_id as string | undefined;
+      
+      for (const tc of toolCalls) {
+        if (!tc.tool_call_id || resolvedToolCalls.has(tc.tool_call_id)) continue;
+        // Skip duplicate tool_call_ids across multiple approval_request_messages
+        if (seenToolCallIds.has(tc.tool_call_id)) continue;
+        seenToolCallIds.add(tc.tool_call_id);
+        
+        const key = runId || 'unknown';
+        if (!unresolvedByRun.has(key)) unresolvedByRun.set(key, []);
+        unresolvedByRun.get(key)!.push({
+          toolCallId: tc.tool_call_id,
+          toolName: tc.name || 'unknown',
+          runId: key,
+        });
+      }
+    }
+    
+    if (unresolvedByRun.size === 0) {
+      return { recovered: false, details: 'No unresolved approval requests found' };
+    }
+    
+    // Check each run's status - only resolve orphaned approvals from terminated runs
+    let recoveredCount = 0;
+    const details: string[] = [];
+    
+    for (const [runId, approvals] of unresolvedByRun) {
+      if (runId === 'unknown') {
+        // No run_id on the approval message - can't verify, skip
+        details.push(`Skipped ${approvals.length} approval(s) with no run_id`);
+        continue;
+      }
+      
+      try {
+        const run = await client.runs.retrieve(runId);
+        const status = run.status;
+        const stopReason = run.stop_reason;
+        const isTerminated = status === 'failed' || status === 'cancelled';
+        const isAbandonedApproval = status === 'completed' && stopReason === 'requires_approval';
+        // Active runs stuck on approval block the entire conversation.
+        // No client is going to approve them -- reject and cancel so
+        // lettabot can proceed.
+        const isStuckApproval = status === 'running' && stopReason === 'requires_approval';
+        // Letta Cloud uses status "created" with no stop_reason for runs
+        // that paused on requires_approval but haven't been resumed yet.
+        // If we found unresolved approval_request_messages for this run,
+        // it's stuck -- treat it the same as a running/requires_approval.
+        const isCreatedWithApproval = status === 'created';
+        
+        if (isTerminated || isAbandonedApproval || isStuckApproval || isCreatedWithApproval) {
+          log.info(`Found ${approvals.length} blocking approval(s) from ${status}/${stopReason} run ${runId}`);
+          
+          // Send denial for each unresolved tool call
+          const approvalResponses = approvals.map(a => ({
+            approve: false as const,
+            tool_call_id: a.toolCallId,
+            type: 'approval' as const,
+            reason: `Auto-denied: originating run was ${status}/${stopReason}`,
+          }));
+          
+          let deniedForRun = 0;
+          for (let i = 0; i < approvalResponses.length; i++) {
+            const approvalResponse = approvalResponses[i];
+            try {
+              // Letta surfaces one pending approval at a time for parallel tool calls,
+              // so submit denials sequentially instead of as a single multi-ID batch.
+              await client.conversations.messages.create(conversationId, {
+                messages: [{
+                  type: 'approval',
+                  approvals: [approvalResponse],
+                }],
+                streaming: false,
+              });
+              deniedForRun += 1;
+            } catch (approvalError) {
+              const approvalErrMsg = approvalError instanceof Error ? approvalError.message : String(approvalError);
+              log.warn(
+                `Failed to submit approval denial for run ${runId} (tool_call_id=${approvalResponse.tool_call_id}):`,
+                approvalError,
+              );
+              details.push(`Failed to deny approval ${approvalResponse.tool_call_id} from run ${runId}: ${approvalErrMsg}`);
+              continue;
+            }
+
+            if (i < approvalResponses.length - 1) {
+              await new Promise(resolve => setTimeout(resolve, 1500));
+            }
+          }
+
+          if (deniedForRun === 0) {
+            continue;
+          }
+          
+          // The denial triggers a new agent run server-side. Wait for it to
+          // settle before returning, otherwise the caller retries immediately
+          // and hits a 409 because the denial's run is still processing.
+          await new Promise(resolve => setTimeout(resolve, 3000));
+
+          // Cancel only active runs for this conversation to avoid interrupting
+          // unrelated in-flight requests on other conversations.
+          const activeRunIds = await listActiveConversationRunIds(agentId, conversationId);
+          let cancelled = false;
+          if (activeRunIds.length > 0) {
+            cancelled = await cancelRuns(agentId, activeRunIds);
+            if (cancelled) {
+              log.info(`Cancelled ${activeRunIds.length} active conversation run(s) after approval denial`);
+            }
+          } else {
+            log.info(`No active runs to cancel for conversation ${conversationId}`);
+          }
+          
+          recoveredCount += deniedForRun;
+          const suffix = cancelled ? ' (runs cancelled)' : '';
+          details.push(`Denied ${deniedForRun} approval(s) from ${status} run ${runId}${suffix}`);
+        } else {
+          details.push(`Run ${runId} is ${status}/${stopReason} - not orphaned`);
+        }
+      } catch (runError) {
+        log.warn(`Failed to check run ${runId}:`, runError);
+        details.push(`Failed to check run ${runId}`);
+      }
+    }
+    
+    const detailStr = details.join('; ');
+    if (recoveredCount > 0) {
+      log.info(`Recovered ${recoveredCount} orphaned approval(s): ${detailStr}`);
+      return { recovered: true, details: detailStr };
+    }
+    
+    return { recovered: false, details: detailStr };
+  } catch (e) {
+    log.error('Failed to recover orphaned conversation approval:', e);
+    return { recovered: false, details: `Error: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
 export async function disableAllToolApprovals(agentId: string): Promise<number> {
   try {
     const tools = await getAgentTools(agentId);


### PR DESCRIPTION
## Summary

Reverts #603 which removed the API-level approval recovery path.

The SDK's `recoverPendingApprovals()` has a bug: the CLI's headless handler calls `requestPermission()` for approvals needing user input, which deadlocks (no one to respond in recovery context). This causes a timeout, leaving agents permanently stuck.

The API-level recovery (getPendingApprovals, rejectApproval, cancelRuns) works and needs to remain until CLI 0.18.5 ships the fix (letta-ai/letta-code#1415).

## Test plan

- [x] Build passes
- [x] Tests pass (29/29)
- [ ] Deploy and verify stuck agents recover

Written by Cameron ◯ Letta Code

"Move fast and break things. Unless you just broke things, then move fast and fix things."