### PR TITLE
chore(deps): bump @letta-ai/letta-code-sdk to ^0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@clack/prompts": "^0.11.0",
         "@hapi/boom": "^10.0.1",
         "@letta-ai/letta-client": "^1.7.12",
-        "@letta-ai/letta-code-sdk": "^0.1.12",
+        "@letta-ai/letta-code-sdk": "^0.1.14",
         "@types/express": "^5.0.6",
         "@types/node": "^25.0.10",
         "@types/node-schedule": "^2.1.8",
@@ -1351,9 +1351,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@letta-ai/letta-code": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.18.3.tgz",
-      "integrity": "sha512-Om1Ck3bx//FCfAV3AjOO0L0nZYfW3tdzR3sYcNFeM6MlB90S3UiA1d6fzzD62XSOC2+1KQVAaPTC7mlWs0+e5w==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code/-/letta-code-0.19.5.tgz",
+      "integrity": "sha512-INEDS79dkzJoQyL3IJRof+HNob3GZXgAge/JdJRFaVfJhU/o/6aTPcPWpQwxygE5ExIDSUlL85OlZ3CcBv0TyA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1378,12 +1378,12 @@
       }
     },
     "node_modules/@letta-ai/letta-code-sdk": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.12.tgz",
-      "integrity": "sha512-pwVKBLx8TPEIjWqJb/t9ioIezc1a0qWo3HYq88MXNpZmUh0yMhI7RcMitToa/+YpvejYU1Et4HKk5uoMWUe1KQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@letta-ai/letta-code-sdk/-/letta-code-sdk-0.1.14.tgz",
+      "integrity": "sha512-rSMp7kYwRZ4PAe3jET+PETFesuYCbeodEp6Qf7a5rLu97epqs+zNegSR+UUgq6c9+c5eqbuo+BsRThTKiSNJkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@letta-ai/letta-code": "0.18.3"
+        "@letta-ai/letta-code": "0.19.5"
       }
     },
     "node_modules/@letta-ai/letta-code/node_modules/balanced-match": {
@@ -4818,9 +4818,9 @@
       }
     },
     "node_modules/ink/node_modules/type-fest": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
-      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
       "license": "(MIT OR CC0-1.0)",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@clack/prompts": "^0.11.0",
     "@hapi/boom": "^10.0.1",
     "@letta-ai/letta-client": "^1.7.12",
-    "@letta-ai/letta-code-sdk": "^0.1.12",
+    "@letta-ai/letta-code-sdk": "^0.1.14",
     "@types/express": "^5.0.6",
     "@types/node": "^25.0.10",
     "@types/node-schedule": "^2.1.8",


### PR DESCRIPTION
## Summary

Bumps SDK to 0.1.14 which depends on letta-code 0.19.5. Picks up:

- **letta-code#1448**: drain queued turns during approval reentry -- directly improves approval recovery reliability
- **letta-code#1447**: re-enable memory tool in default toolsets
- **letta-code#1446**: fall back to node-pty when Bun is not defined (Electron/Node.js)

No code changes, just the dependency bump.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 974 tests pass, 0 failures

Written by Cameron ◯ Letta Code