### PR TITLE
fix: batch-deny parallel tool call approvals in a single API request

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -951,11 +951,19 @@ export class LettaBot implements AgentSession {
       log.info(`Found ${pendingApprovals.length} pending approval(s), attempting recovery (attempt ${attempts + 1}/${maxAttempts})...`);
       this.store.incrementRecoveryAttempts();
       
+      // Group approvals by run_id and batch-deny (server requires all parallel
+      // tool calls from the same run to be denied in a single request).
+      const byRun = new Map<string, Array<{ toolCallId: string; reason: string }>>();
       for (const approval of pendingApprovals) {
-        log.info(`Rejecting approval for ${approval.toolName} (${approval.toolCallId})`);
+        const key = approval.runId || 'unknown';
+        if (!byRun.has(key)) byRun.set(key, []);
+        byRun.get(key)!.push({ toolCallId: approval.toolCallId, reason: 'Session was interrupted - retrying request' });
+      }
+      for (const [runId, batch] of byRun) {
+        log.info(`Batch-denying ${batch.length} approval(s) from run ${runId}`);
         await rejectApproval(
           this.store.agentId,
-          { toolCallId: approval.toolCallId, reason: 'Session was interrupted - retrying request' },
+          batch,
           this.store.conversationId || undefined
         );
       }

--- a/src/tools/letta-api.test.ts
+++ b/src/tools/letta-api.test.ts
@@ -282,9 +282,7 @@ describe('recoverOrphanedConversationApproval', () => {
     expect(approvals[0].tool_call_id).toBe('tc-dup');
   });
 
-  it('recovers remaining approvals by submitting denials sequentially', async () => {
-    // Parallel tool calls can fail when denied as one batch. Verify we keep
-    // progressing by submitting one tool_call_id per request.
+  it('batch-denies all parallel tool calls from the same run in a single request', async () => {
     mockConversationsMessagesList.mockReturnValue(mockPageIterator([
       {
         message_type: 'approval_request_message',
@@ -298,10 +296,7 @@ describe('recoverOrphanedConversationApproval', () => {
       },
     ]));
     mockRunsRetrieve.mockResolvedValue({ status: 'failed', stop_reason: 'error' });
-    mockConversationsMessagesCreate
-      .mockRejectedValueOnce(new Error("Invalid tool call IDs. Expected '['tc-b']', but received '['tc-a']'"))
-      .mockResolvedValueOnce({})
-      .mockResolvedValueOnce({});
+    mockConversationsMessagesCreate.mockResolvedValueOnce({});
     mockRunsList.mockReturnValue(mockPageIterator([]));
 
     const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
@@ -309,15 +304,16 @@ describe('recoverOrphanedConversationApproval', () => {
     const result = await resultPromise;
 
     expect(result.recovered).toBe(true);
-    expect(result.details).toContain('Failed to deny approval tc-a from run run-parallel');
-    expect(result.details).toContain('Denied 2 approval(s) from failed run run-parallel');
-    expect(mockConversationsMessagesCreate).toHaveBeenCalledTimes(3);
-    expect(mockConversationsMessagesCreate.mock.calls.map((call) => call[1].messages[0].approvals[0].tool_call_id))
-      .toEqual(['tc-a', 'tc-b', 'tc-c']);
+    expect(result.details).toContain('Denied 3 approval(s) from failed run run-parallel');
+    // All 3 tool calls sent in a single API request
+    expect(mockConversationsMessagesCreate).toHaveBeenCalledTimes(1);
+    const approvals = mockConversationsMessagesCreate.mock.calls[0][1].messages[0].approvals;
+    expect(approvals).toHaveLength(3);
+    expect(approvals.map((a: any) => a.tool_call_id)).toEqual(['tc-a', 'tc-b', 'tc-c']);
   });
 
-  it('continues recovery if approval denial API call fails for one run', async () => {
-    // Two runs with approvals -- first denial fails, second should still succeed
+  it('continues recovery if batch denial fails for one run', async () => {
+    // Two runs with approvals -- first batch denial fails, second should still succeed
     mockConversationsMessagesList.mockReturnValue(mockPageIterator([
       {
         message_type: 'approval_request_message',
@@ -339,12 +335,12 @@ describe('recoverOrphanedConversationApproval', () => {
     mockRunsList.mockReturnValue(mockPageIterator([]));
 
     const resultPromise = recoverOrphanedConversationApproval('agent-1', 'conv-1');
-    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(10000);
     const result = await resultPromise;
 
     // Second run still recovered despite first failing
     expect(result.recovered).toBe(true);
-    expect(result.details).toContain('Failed to deny');
+    expect(result.details).toContain('Failed to batch-deny');
     expect(result.details).toContain('Denied 1 approval(s) from failed run run-ok');
     expect(mockConversationsMessagesCreate).toHaveBeenCalledTimes(2);
   });

--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -90,18 +90,22 @@ export async function recoverPendingApprovalsForAgent(
       };
     }
 
-    // Deduplicate by tool_call_id defensively (getPendingApprovals should
-    // already dedup, but this guards against any upstream regression).
-    const rejectedIds = new Set<string>();
-    let rejectedCount = 0;
+    // Group approvals by run_id so we can batch-deny parallel tool calls
+    // from the same run in a single API request (server requirement).
+    const byRun = new Map<string, Array<{ toolCallId: string; reason?: string }>>();
+    const seen = new Set<string>();
     for (const approval of pending) {
-      if (rejectedIds.has(approval.toolCallId)) continue;
-      rejectedIds.add(approval.toolCallId);
-      const ok = await rejectApproval(agentId, {
-        toolCallId: approval.toolCallId,
-        reason,
-      });
-      if (ok) rejectedCount += 1;
+      if (seen.has(approval.toolCallId)) continue;
+      seen.add(approval.toolCallId);
+      const key = approval.runId || 'unknown';
+      if (!byRun.has(key)) byRun.set(key, []);
+      byRun.get(key)!.push({ toolCallId: approval.toolCallId, reason });
+    }
+
+    let rejectedCount = 0;
+    for (const [, batch] of byRun) {
+      const ok = await rejectApproval(agentId, batch);
+      if (ok) rejectedCount += batch.length;
     }
 
     const runIds = [...new Set(
@@ -516,42 +520,52 @@ export async function getPendingApprovals(
  * Reject a pending tool approval request.
  * Sends an approval response with approve: false.
  */
+/**
+ * Reject one or more pending tool call approvals in a single API request.
+ * The Letta API requires ALL parallel tool call IDs from the same run to be
+ * denied together; sending them individually returns 400.
+ */
 export async function rejectApproval(
   agentId: string,
-  approval: {
+  approvals: {
     toolCallId: string;
     reason?: string;
-  },
+  } | Array<{
+    toolCallId: string;
+    reason?: string;
+  }>,
   conversationId?: string
 ): Promise<boolean> {
+  const approvalList = Array.isArray(approvals) ? approvals : [approvals];
+  if (approvalList.length === 0) return true;
+
   try {
     const client = getClient();
+    const defaultReason = 'Session was interrupted - please retry your request';
     
-    // Send approval response via messages.create
     await client.agents.messages.create(agentId, {
       messages: [{
         type: 'approval',
-        approvals: [{
+        approvals: approvalList.map(a => ({
           approve: false,
-          tool_call_id: approval.toolCallId,
-          type: 'approval',
-          reason: approval.reason || 'Session was interrupted - please retry your request',
-        }],
+          tool_call_id: a.toolCallId,
+          type: 'approval' as const,
+          reason: a.reason || defaultReason,
+        })),
       }],
       streaming: false,
     });
     
-    log.info(`Rejected approval for tool call ${approval.toolCallId}`);
+    const ids = approvalList.map(a => a.toolCallId).join(', ');
+    log.info(`Rejected ${approvalList.length} approval(s): ${ids}`);
     return true;
   } catch (e) {
     const err = e as { status?: number; error?: { detail?: string } };
     const detail = err?.error?.detail || '';
     if (err?.status === 400 && detail.includes('No tool call is currently awaiting approval')) {
-      log.warn(`Approval already resolved for tool call ${approval.toolCallId}`);
+      log.warn(`Approval(s) already resolved`);
       return true;
     }
-    // Re-throw rate limit errors so callers can bail out early instead of
-    // hammering the API in a tight loop.
     if (err?.status === 429) {
       log.error('Failed to reject approval:', e);
       throw e;
@@ -892,7 +906,9 @@ export async function recoverOrphanedConversationApproval(
         if (isTerminated || isAbandonedApproval || isStuckApproval || isCreatedWithApproval) {
           log.info(`Found ${approvals.length} blocking approval(s) from ${status}/${stopReason} run ${runId}`);
           
-          // Send denial for each unresolved tool call
+          // Send denial for all unresolved tool calls in this run as a single batch.
+          // The Letta API requires all parallel tool call IDs from the same run
+          // to be denied together; sending them individually returns 400.
           const approvalResponses = approvals.map(a => ({
             approve: false as const,
             tool_call_id: a.toolCallId,
@@ -900,36 +916,22 @@ export async function recoverOrphanedConversationApproval(
             reason: `Auto-denied: originating run was ${status}/${stopReason}`,
           }));
           
-          let deniedForRun = 0;
-          for (let i = 0; i < approvalResponses.length; i++) {
-            const approvalResponse = approvalResponses[i];
-            try {
-              // Letta surfaces one pending approval at a time for parallel tool calls,
-              // so submit denials sequentially instead of as a single multi-ID batch.
-              await client.conversations.messages.create(conversationId, {
-                messages: [{
-                  type: 'approval',
-                  approvals: [approvalResponse],
-                }],
-                streaming: false,
-              });
-              deniedForRun += 1;
-            } catch (approvalError) {
-              const approvalErrMsg = approvalError instanceof Error ? approvalError.message : String(approvalError);
-              log.warn(
-                `Failed to submit approval denial for run ${runId} (tool_call_id=${approvalResponse.tool_call_id}):`,
-                approvalError,
-              );
-              details.push(`Failed to deny approval ${approvalResponse.tool_call_id} from run ${runId}: ${approvalErrMsg}`);
-              continue;
-            }
-
-            if (i < approvalResponses.length - 1) {
-              await new Promise(resolve => setTimeout(resolve, 1500));
-            }
-          }
-
-          if (deniedForRun === 0) {
+          try {
+            await client.conversations.messages.create(conversationId, {
+              messages: [{
+                type: 'approval',
+                approvals: approvalResponses,
+              }],
+              streaming: false,
+            });
+          } catch (approvalError) {
+            const approvalErrMsg = approvalError instanceof Error ? approvalError.message : String(approvalError);
+            const toolCallIds = approvals.map(a => a.toolCallId).join(', ');
+            log.warn(
+              `Failed to batch-deny ${approvals.length} approval(s) for run ${runId} (${toolCallIds}):`,
+              approvalError,
+            );
+            details.push(`Failed to batch-deny approvals from run ${runId}: ${approvalErrMsg}`);
             continue;
           }
           
@@ -951,9 +953,9 @@ export async function recoverOrphanedConversationApproval(
             log.info(`No active runs to cancel for conversation ${conversationId}`);
           }
           
-          recoveredCount += deniedForRun;
+          recoveredCount += approvals.length;
           const suffix = cancelled ? ' (runs cancelled)' : '';
-          details.push(`Denied ${deniedForRun} approval(s) from ${status} run ${runId}${suffix}`);
+          details.push(`Denied ${approvals.length} approval(s) from ${status} run ${runId}${suffix}`);
         } else {
           details.push(`Run ${runId} is ${status}/${stopReason} - not orphaned`);
         }


### PR DESCRIPTION
## Summary

The Letta API requires all parallel tool call IDs from the same run to be denied together in a single request. Lettabot was sending them individually, which the server rejects with 400:

```
Invalid tool call IDs. Expected '['call_a', 'call_b', 'call_c']', but received '['call_a']'.
```

This caused approval recovery to fail completely for any run with parallel tool calls (3 tool calls in the stuck Signal case), leaving conversations permanently stuck with no automatic recovery path.

### Changes

- **`rejectApproval()`** now accepts an array of approvals and sends them as a single batch in one API request
- **`recoverOrphanedConversationApproval()`** groups unresolved approvals by `run_id` before denying, so all parallel tool calls from the same run go in one batch
- **`bot.ts` startup recovery** same grouping by `run_id`

### Root cause

The comment at the old line 907 said "Letta surfaces one pending approval at a time for parallel tool calls, so submit denials sequentially." This was wrong -- the server expects all of them together.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 974 tests pass, 0 failures
- [x] Updated existing tests to verify batch behavior

Written by Cameron ◯ Letta Code

"Batch what the server expects batched."