### PR TITLE
fix(telegram): add forum topic support

### DIFF
--- a/src/channels/group-mode.ts
+++ b/src/channels/group-mode.ts
@@ -18,6 +18,8 @@ export interface GroupModeConfig {
   threadMode?: 'any' | 'thread-only';
   /** Discord only: when true, @mentions in parent channels auto-create a thread. */
   autoCreateThreadOnMention?: boolean;
+  /** Only process messages from these topic IDs (Telegram forum topics). Omit to allow all topics. */
+  allowedTopics?: string[];
   /**
    * @deprecated Use mode: "mention-only" (true) or "open" (false).
    */
@@ -184,6 +186,23 @@ export function resolveDailyLimits(
     dailyUserLimit: matched.config.dailyUserLimit ?? wildcard?.dailyUserLimit,
     matchedKey: matched.key,
   };
+}
+
+/**
+ * Resolve the allowed topic IDs for a group/channel.
+ * Returns undefined if no allowedTopics is configured (allow all topics).
+ */
+export function resolveAllowedTopics(
+  groups: GroupsConfig | undefined,
+  keys: string[],
+): string[] | undefined {
+  if (groups) {
+    for (const key of keys) {
+      if (groups[key]?.allowedTopics) return groups[key].allowedTopics;
+    }
+    if (groups['*']?.allowedTopics) return groups['*'].allowedTopics;
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/channels/telegram-group-gating.ts
+++ b/src/channels/telegram-group-gating.ts
@@ -11,7 +11,7 @@
  * actively participate in?"
  */
 
-import { isGroupAllowed, isGroupUserAllowed, resolveGroupMode, type GroupMode, type GroupModeConfig } from './group-mode.js';
+import { isGroupAllowed, isGroupUserAllowed, resolveGroupMode, resolveAllowedTopics, type GroupMode, type GroupModeConfig } from './group-mode.js';
 
 export interface TelegramGroupGatingParams {
   /** Message text */
@@ -31,6 +31,9 @@ export interface TelegramGroupGatingParams {
 
   /** Per-group configuration */
   groupsConfig?: Record<string, GroupModeConfig>;
+
+  /** Telegram forum topic ID (message_thread_id), if any */
+  threadId?: string;
 
   /** Regex patterns for additional mention detection */
   mentionPatterns?: string[];
@@ -91,6 +94,18 @@ export function applyTelegramGroupGating(params: TelegramGroupGatingParams): Tel
       mode: 'open',
       reason: 'user-not-allowed',
     };
+  }
+
+  // Step 1c: Topic allowlist (Telegram forum topics)
+  const allowedTopics = resolveAllowedTopics(groupsConfig, [chatId]);
+  if (allowedTopics && allowedTopics.length > 0) {
+    if (!params.threadId || !allowedTopics.includes(params.threadId)) {
+      return {
+        shouldProcess: false,
+        mode: 'open',
+        reason: 'topic-not-in-allowlist',
+      };
+    }
   }
 
   // Step 2: Resolve mode (default: open)

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -98,7 +98,7 @@ export class TelegramAdapter implements ChannelAdapter {
    * Apply group gating for a message context.
    * Returns null if the message should be dropped, or message metadata if it should proceed.
    */
-  private applyGroupGating(ctx: { chat: { type: string; id: number; title?: string }; from?: { id: number }; message?: { text?: string; entities?: { type: string; offset: number; length: number }[] } }): { isGroup: boolean; groupName?: string; wasMentioned: boolean; isListeningMode?: boolean } | null {
+  private applyGroupGating(ctx: { chat: { type: string; id: number; title?: string }; from?: { id: number }; message?: { text?: string; entities?: { type: string; offset: number; length: number }[]; message_thread_id?: number; is_topic_message?: boolean } }): { isGroup: boolean; groupName?: string; wasMentioned: boolean; isListeningMode?: boolean } | null {
     const chatType = ctx.chat.type;
     const isGroup = chatType === 'group' || chatType === 'supergroup';
     const groupName = isGroup && 'title' in ctx.chat ? ctx.chat.title : undefined;
@@ -122,6 +122,7 @@ export class TelegramAdapter implements ChannelAdapter {
       })),
       groupsConfig: this.config.groups,
       mentionPatterns: this.config.mentionPatterns,
+      threadId: ctx.message?.is_topic_message ? String(ctx.message.message_thread_id) : undefined,
     });
 
     if (!gatingResult.shouldProcess) {
@@ -391,6 +392,7 @@ export class TelegramAdapter implements ChannelAdapter {
           groupName,
           wasMentioned,
           isListeningMode,
+          threadId: ctx.message.is_topic_message ? String(ctx.message.message_thread_id) : undefined,
           formatterHints: this.getFormatterHints(),
         });
       }
@@ -498,6 +500,7 @@ export class TelegramAdapter implements ChannelAdapter {
             groupName,
             wasMentioned,
             isListeningMode,
+            threadId: ctx.message.is_topic_message ? String(ctx.message.message_thread_id) : undefined,
             formatterHints: this.getFormatterHints(),
           });
         }
@@ -517,6 +520,7 @@ export class TelegramAdapter implements ChannelAdapter {
             groupName,
             wasMentioned,
             isListeningMode,
+            threadId: ctx.message.is_topic_message ? String(ctx.message.message_thread_id) : undefined,
             formatterHints: this.getFormatterHints(),
           });
         }
@@ -552,6 +556,7 @@ export class TelegramAdapter implements ChannelAdapter {
           wasMentioned,
           isListeningMode,
           attachments,
+          threadId: ctx.message.is_topic_message ? String(ctx.message.message_thread_id) : undefined,
           formatterHints: this.getFormatterHints(),
         });
       }
@@ -620,6 +625,7 @@ export class TelegramAdapter implements ChannelAdapter {
           const result = await this.bot.api.sendMessage(msg.chatId, chunk, {
             parse_mode: msg.parseMode as 'MarkdownV2' | 'HTML',
             reply_to_message_id: replyId,
+              message_thread_id: msg.threadId ? Number(msg.threadId) : undefined,
           });
           lastMessageId = String(result.message_id);
           continue;
@@ -639,6 +645,7 @@ export class TelegramAdapter implements ChannelAdapter {
             const result = await this.bot.api.sendMessage(msg.chatId, sub, {
               parse_mode: 'MarkdownV2',
               reply_to_message_id: replyId,
+              message_thread_id: msg.threadId ? Number(msg.threadId) : undefined,
             });
             lastMessageId = String(result.message_id);
           }
@@ -646,6 +653,7 @@ export class TelegramAdapter implements ChannelAdapter {
           const result = await this.bot.api.sendMessage(msg.chatId, formatted, {
             parse_mode: 'MarkdownV2',
             reply_to_message_id: replyId,
+              message_thread_id: msg.threadId ? Number(msg.threadId) : undefined,
           });
           lastMessageId = String(result.message_id);
         }
@@ -656,6 +664,7 @@ export class TelegramAdapter implements ChannelAdapter {
         for (const plain of plainChunks) {
           const result = await this.bot.api.sendMessage(msg.chatId, plain, {
             reply_to_message_id: replyId,
+              message_thread_id: msg.threadId ? Number(msg.threadId) : undefined,
           });
           lastMessageId = String(result.message_id);
         }


### PR DESCRIPTION

# Telegram Forum Topics Support

Two related improvements to lettabot for Telegram supergroups with forum topics enabled.

---

## Problem

1. **Replies landing in wrong topic** — When a user wrote in a forum topic, Loris always replied in the General topic instead of the correct one. `message_thread_id` was never read from incoming messages and never passed to the Telegram API on outgoing ones.

2. **Token waste on wrong-topic messages** — Even with a bot instruction like "don't reply unless mentioned", lettabot still forwarded every group message to Letta Cloud, which processed them and returned `<no-reply/>`. This consumed tokens silently without any visible output on Telegram.

---

## Changes

- Populate threadId on InboundMessage from message_thread_id
- Pass message_thread_id in all outgoing sendMessage calls
- Add allowedTopics filter in group gating to avoid token waste
- Add resolveAllowedTopics helper in group-mode.ts

### `src/channels/telegram.ts`
- **Inbound:** populated `threadId` on `InboundMessage` from `ctx.message.message_thread_id` (guarded by `is_topic_message`) for text, voice, and photo handlers
- **Outbound:** passed `message_thread_id` to all 4 `sendMessage` API calls so replies stay in the correct topic
- **Gating:** extended `applyGroupGating` to pass `threadId` to `applyTelegramGroupGating` for topic-level filtering

### `src/channels/telegram-group-gating.ts`
- Added `threadId?: string` to `TelegramGroupGatingParams`
- Added **Step 1c** topic allowlist check: if `allowedTopics` is configured for a group and the incoming message's `threadId` is not in the list, the message is dropped before reaching Letta — no token cost

### `src/channels/group-mode.ts`
- Added `allowedTopics?: string[]` field to `GroupModeConfig` interface
- Added `resolveAllowedTopics()` helper function following the same priority pattern as existing helpers (specific key → wildcard `*` → undefined = allow all)

---

## New yaml config

```yaml
"-100123456789":
  mode: open
  allowedTopics:
    - "123"       # Only this topic is forwarded to Letta
  allowedUsers:
    - "123456789"
```

When `allowedTopics` is omitted, behavior is unchanged — all topics are processed as before.

---

## Notes
- `allowedTopics` is opt-in and fully backward compatible
- Works for any number of topics per group: just add more IDs to the list
- The same `threadId` field already existed in `OutboundMessage` and `InboundMessage` interfaces — it was simply never populated by the Telegram adapter
