### PR TITLE
fix: resolve bluesky shim paths from repo root

### DIFF
--- a/skills/bluesky/lettabot-bluesky
+++ b/skills/bluesky/lettabot-bluesky
@@ -4,13 +4,19 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+
 # Prefer project-local entrypoints so development worktrees run their current code.
-if [[ -f "./dist/cli.js" ]]; then
-  exec node "./dist/cli.js" bluesky "$@"
+# Run from the repo root so cwd-based config discovery finds lettabot.yaml / lettabot-agent.json.
+if [[ -f "$REPO_ROOT/dist/cli.js" ]]; then
+  cd "$REPO_ROOT"
+  exec node "$REPO_ROOT/dist/cli.js" bluesky "$@"
 fi
 
-if [[ -f "./src/cli.ts" ]] && command -v npx >/dev/null 2>&1; then
-  exec npx tsx "./src/cli.ts" bluesky "$@"
+if [[ -f "$REPO_ROOT/src/cli.ts" ]] && command -v npx >/dev/null 2>&1; then
+  cd "$REPO_ROOT"
+  exec npx tsx "$REPO_ROOT/src/cli.ts" bluesky "$@"
 fi
 
 # Fallback to an installed base CLI.
@@ -19,5 +25,5 @@ if command -v lettabot >/dev/null 2>&1; then
 fi
 
 echo "Error: unable to resolve a Bluesky CLI entrypoint." >&2
-echo "Expected one of: ./dist/cli.js, ./src/cli.ts (via npx tsx), or lettabot on PATH." >&2
+echo "Expected one of: $REPO_ROOT/dist/cli.js, $REPO_ROOT/src/cli.ts (via npx tsx), or lettabot on PATH." >&2
 exit 1


### PR DESCRIPTION
## Summary
- resolve the skill-local Bluesky shim relative to its own location instead of the caller's working directory
- cd into the repo root before launching the CLI so cwd-based config discovery finds the correct lettabot config and agent registry
- restore documented `lettabot-bluesky ... --agent co-3` behavior when invoked outside the repo root

## Test plan
- [x] Run `export $(grep BLUESKY_CO_APP_PASSWORD ~/lettabot/.env) && /home/cameron/lettabot/skills/bluesky/lettabot-bluesky profile co.cameron.stream --agent co-3`
- [x] Verify the command returns the co-3 Bluesky profile instead of `Agent not found: co-3`

👾 Generated with [Letta Code](https://letta.com)