### PR TITLE
fix: add python3 and build tools to Docker image for node-pty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:22-slim AS build
+RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY package*.json ./
@@ -8,7 +9,7 @@ COPY . .
 RUN npm run build
 
 FROM node:22-slim
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git python3 make g++ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- `node-pty` (transitive dep via `@letta-ai/letta-code-sdk` → `@letta-ai/letta-code`) needs `python3`, `make`, and `g++` for native compilation when no prebuilt binary exists
- The `node:22-slim` base image doesn't include these, causing Docker builds to fail in CI
- Adds build dependencies to both the build stage and runtime stage (both run `npm ci`)

## Test plan
- [ ] CI Docker build passes on this PR
- [ ] Dependabot PR for `@letta-ai/letta-client` 1.8.0 can be re-run successfully after merge

🤖 Generated with [Letta Code](https://letta.com)