### PR TITLE
fix(logging): use mm (minutes) instead of MM (months) in timestamp format

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -39,7 +39,7 @@ function resolveTransport(): pino.TransportSingleOptions | undefined {
       target: 'pino-pretty',
       options: {
         colorize: true,
-        translateTime: 'HH:MM:ss',
+        translateTime: 'HH:mm:ss',
         ignore: 'pid,hostname,service,module',
         messageFormat: '[{module}] {msg}',
         singleLine: true,


### PR DESCRIPTION
## Summary

One-character fix: `HH:MM:ss` -> `HH:mm:ss` in pino-pretty config.

`MM` in dateformat = months, not minutes. Timestamps were showing `17:03:25` (where `03` = March) instead of `17:25:25`.

Closes #626

Written by Cameron ◯ Letta Code