### PR TITLE
fix(bluesky): filter wildcard from Jetstream wantedDids

### DIFF
--- a/src/channels/bluesky/adapter.ts
+++ b/src/channels/bluesky/adapter.ts
@@ -776,7 +776,7 @@ export class BlueskyAdapter implements ChannelAdapter {
       .filter(([, mode]) => mode !== 'disabled')
       .map(([did]) => did);
     const combined = uniqueList([...configured, ...explicitAllowed, ...listAllowed]);
-    return combined.filter(did => !disabledDids.has(did));
+    return combined.filter(did => !disabledDids.has(did) && did !== '*');
   }
 
   private getNotificationsConfig(): {


### PR DESCRIPTION
## Summary

The `*` wildcard key in `groups` config was leaking into `getWantedDids()` and being sent to Jetstream as a DID filter. Jetstream ignores invalid DIDs, effectively subscribing to all network events -- causing massive backfill floods on restart.

One-line fix: filter `*` from the combined DID list before passing to Jetstream.

## Test plan

- [x] 983 tests pass
- [ ] Verify agent with `groups: "*": mode: open` and no `wantedDids` does NOT connect to Jetstream (relies on notifications for DID discovery instead)

Written by Cameron ◯ Letta Code