### PR TITLE
feat(logging): include conversation ID in processMessage log

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1353,7 +1353,8 @@ export class LettaBot implements AgentSession {
       const convKey = this.resolveConversationKey(msg.channel, msg.chatId, msg.forcePerChat);
       const seq = ++this.sendSequence;
       const userText = msg.text || '';
-      this.log.info(`processMessage seq=${seq} key=${convKey} retried=${retried} user=${msg.userId} textLen=${userText.length}`);
+      const convId = this.store.getConversationId(convKey);
+      this.log.info(`processMessage seq=${seq} key=${convKey} conv=${convId ?? '(new)'} retried=${retried} user=${msg.userId} textLen=${userText.length}`);
       if (userText.length > 0) {
         this.log.debug(`processMessage seq=${seq} textPreview=${userText.slice(0, 80)}`);
       }


### PR DESCRIPTION
## Summary

Adds the Letta conversation ID to the `processMessage` log line so you can tell exactly which conversation each inbound message routes to.

**Before:**
```
[Bot/void] processMessage seq=1 key=shared retried=false user=515978553 textLen=65
```

**After:**
```
[Bot/void] processMessage seq=1 key=shared conv=conv-6040caeb-cc92-4cc... retried=false user=515978553 textLen=65
[Bot/void] processMessage seq=2 key=heartbeat conv=(new) retried=false user=system textLen=200
```

Shows `(new)` when no conversation exists yet for that key.

## Test plan

- [x] 983 tests pass

Written by Cameron ◯ Letta Code