### PR TITLE
feat: add /approve and /disapprove commands for tool approvals

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,24 @@ Heartbeats are background tasks where the agent can:
 
 **Note:** This command runs silently - the agent won't automatically reply. If the agent wants to message you during a heartbeat, it will use the `lettabot-message` CLI.
 
+### `/approve`
+
+Approves all currently pending tool approvals for your current conversation scope.
+
+- In shared mode, this applies to the shared conversation.
+- In per-channel/per-chat modes, this applies only to that channel/chat conversation.
+
+Useful when a run is blocked waiting on tool approval and you want to continue directly from chat.
+
+### `/disapprove [reason]`
+
+Denies all currently pending tool approvals for your current conversation scope.
+
+- You can provide an optional reason, e.g. `/disapprove not safe to run`.
+- Without a reason, LettaBot sends a default denial reason.
+
+Use this to quickly reject pending tool calls without leaving your chat client.
+
 ## Sending Messages
 
 Just type any message to chat with your agent. The agent has:

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -287,6 +287,8 @@ Ask the bot owner to approve with:
           command === 'reset' ||
           command === 'heartbeat' ||
           command === 'cancel' ||
+          command === 'approve' ||
+          command === 'disapprove' ||
           command === 'model' ||
           command === 'setconv';
 

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -33,6 +33,8 @@ const KNOWN_TELEGRAM_COMMANDS = new Set([
   'heartbeat',
   'reset',
   'cancel',
+  'approve',
+  'disapprove',
   'setconv',
   'help',
   'start',
@@ -187,6 +189,41 @@ export class TelegramAdapter implements ChannelAdapter {
           await ctx.api.leaveChat(chatId);
         } catch (err) {
           log.error('Failed to leave group:', err);
+        }
+      }
+    });
+
+    this.bot.command('approve', async (ctx) => {
+      if (this.onCommand) {
+        const result = await this.onCommand('approve', String(ctx.chat.id));
+        if (result) {
+          const replyToMessageId =
+            'message' in ctx && ctx.message
+              ? String(ctx.message.message_id)
+              : undefined;
+          await this.sendMessage({
+            chatId: String(ctx.chat.id),
+            text: result,
+            replyToMessageId,
+          });
+        }
+      }
+    });
+
+    this.bot.command('disapprove', async (ctx) => {
+      if (this.onCommand) {
+        const args = ctx.match?.trim() || undefined;
+        const result = await this.onCommand('disapprove', String(ctx.chat.id), args);
+        if (result) {
+          const replyToMessageId =
+            'message' in ctx && ctx.message
+              ? String(ctx.message.message_id)
+              : undefined;
+          await this.sendMessage({
+            chatId: String(ctx.chat.id),
+            text: result,
+            replyToMessageId,
+          });
         }
       }
     });

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -16,7 +16,7 @@ import { formatApiErrorForUser } from './errors.js';
 import { formatToolCallDisplay, formatReasoningDisplay, formatQuestionsForChannel } from './display.js';
 import type { AgentSession } from './interfaces.js';
 import { Store } from './store.js';
-import { getPendingApprovals, rejectApproval, cancelRuns, cancelConversation, recoverOrphanedConversationApproval, getLatestRunError, getAgentModel, updateAgentModel, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
+import { getPendingApprovals, rejectApproval, approvePendingApproval, cancelRuns, cancelConversation, recoverOrphanedConversationApproval, getLatestRunError, getAgentModel, updateAgentModel, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
 import { getAgentSkillExecutableDirs, isVoiceMemoConfigured } from '../skills/loader.js';
 import { formatMessageEnvelope, formatGroupBatchEnvelope, type SessionContextOptions } from './formatter.js';
 import type { GroupBatcher } from './group-batcher.js';
@@ -892,6 +892,75 @@ export class LettaBot implements AgentSession {
 
         this.log.info(`/cancel - run cancelled (key=${convKey})`);
         return '(Run cancelled.)';
+      }
+      case 'approve': {
+        const agentId = this.store.agentId;
+        if (!agentId) return '(No agent configured.)';
+
+        const convKey = channelId ? this.resolveConversationKey(channelId, chatId, forcePerChat) : 'shared';
+        const convId = convKey === 'shared'
+          ? this.store.conversationId || undefined
+          : this.store.getConversationId(convKey) || undefined;
+
+        const pendingApprovals = await getPendingApprovals(agentId, convId);
+        if (pendingApprovals.length === 0) {
+          return '(No pending approvals found for this conversation.)';
+        }
+
+        const byRun = new Map<string, Array<{ toolCallId: string; reason?: string }>>();
+        for (const approval of pendingApprovals) {
+          const key = approval.runId || 'unknown';
+          if (!byRun.has(key)) byRun.set(key, []);
+          byRun.get(key)!.push({ toolCallId: approval.toolCallId });
+        }
+
+        let approvedCount = 0;
+        const failedRuns: string[] = [];
+        for (const [runId, batch] of byRun) {
+          const ok = await approvePendingApproval(agentId, batch, convId);
+          if (ok) approvedCount += batch.length;
+          else failedRuns.push(runId);
+        }
+
+        if (failedRuns.length > 0) {
+          return `(Approved ${approvedCount}/${pendingApprovals.length} pending tool call(s). Failed runs: ${failedRuns.join(', ')})`;
+        }
+        return `(Approved ${approvedCount} pending tool call(s).)`;
+      }
+      case 'disapprove': {
+        const agentId = this.store.agentId;
+        if (!agentId) return '(No agent configured.)';
+
+        const convKey = channelId ? this.resolveConversationKey(channelId, chatId, forcePerChat) : 'shared';
+        const convId = convKey === 'shared'
+          ? this.store.conversationId || undefined
+          : this.store.getConversationId(convKey) || undefined;
+
+        const pendingApprovals = await getPendingApprovals(agentId, convId);
+        if (pendingApprovals.length === 0) {
+          return '(No pending approvals found for this conversation.)';
+        }
+
+        const reason = args?.trim() || 'Denied by user from chat command';
+        const byRun = new Map<string, Array<{ toolCallId: string; reason?: string }>>();
+        for (const approval of pendingApprovals) {
+          const key = approval.runId || 'unknown';
+          if (!byRun.has(key)) byRun.set(key, []);
+          byRun.get(key)!.push({ toolCallId: approval.toolCallId, reason });
+        }
+
+        let deniedCount = 0;
+        const failedRuns: string[] = [];
+        for (const [runId, batch] of byRun) {
+          const ok = await rejectApproval(agentId, batch, convId);
+          if (ok) deniedCount += batch.length;
+          else failedRuns.push(runId);
+        }
+
+        if (failedRuns.length > 0) {
+          return `(Denied ${deniedCount}/${pendingApprovals.length} pending tool call(s). Failed runs: ${failedRuns.join(', ')})`;
+        }
+        return `(Denied ${deniedCount} pending tool call(s).)`;
       }
       case 'model': {
         const agentId = this.store.agentId;

--- a/src/core/commands.test.ts
+++ b/src/core/commands.test.ts
@@ -30,6 +30,14 @@ describe('parseCommand', () => {
     it('returns { command, args } for /cancel', () => {
       expect(parseCommand('/cancel')).toEqual({ command: 'cancel', args: '' });
     });
+
+    it('returns { command, args } for /approve', () => {
+      expect(parseCommand('/approve')).toEqual({ command: 'approve', args: '' });
+    });
+
+    it('returns { command, args } for /disapprove', () => {
+      expect(parseCommand('/disapprove')).toEqual({ command: 'disapprove', args: '' });
+    });
   });
 
   describe('invalid input', () => {
@@ -91,14 +99,16 @@ describe('COMMANDS', () => {
     expect(COMMANDS).toContain('status');
     expect(COMMANDS).toContain('heartbeat');
     expect(COMMANDS).toContain('reset');
+    expect(COMMANDS).toContain('approve');
+    expect(COMMANDS).toContain('disapprove');
     expect(COMMANDS).toContain('help');
     expect(COMMANDS).toContain('start');
     expect(COMMANDS).toContain('model');
     expect(COMMANDS).toContain('setconv');
   });
 
-  it('has exactly 8 commands', () => {
-    expect(COMMANDS).toHaveLength(8);
+  it('has exactly 10 commands', () => {
+    expect(COMMANDS).toHaveLength(10);
   });
 });
 
@@ -108,6 +118,8 @@ describe('HELP_TEXT', () => {
     expect(HELP_TEXT).toContain('/heartbeat');
     expect(HELP_TEXT).toContain('/reset');
     expect(HELP_TEXT).toContain('/cancel');
+    expect(HELP_TEXT).toContain('/approve');
+    expect(HELP_TEXT).toContain('/disapprove');
     expect(HELP_TEXT).toContain('/help');
     expect(HELP_TEXT).toContain('/start');
     expect(HELP_TEXT).toContain('/model');

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -4,7 +4,7 @@
  * Shared command parsing and help text for all channels.
  */
 
-export const COMMANDS = ['status', 'heartbeat', 'reset', 'cancel', 'help', 'start', 'model', 'setconv'] as const;
+export const COMMANDS = ['status', 'heartbeat', 'reset', 'cancel', 'approve', 'disapprove', 'help', 'start', 'model', 'setconv'] as const;
 export type Command = typeof COMMANDS[number];
 
 export interface ParsedCommand {
@@ -19,6 +19,8 @@ Commands:
 /heartbeat - Trigger heartbeat
 /reset - Reset conversation (keeps agent memory)
 /cancel - Abort the current agent run
+/approve - Approve all pending tool calls for this conversation
+/disapprove [reason] - Deny all pending tool calls for this conversation
 /model - Show current model and list available models
 /model <handle> - Switch to a different model
 /setconv <id> - Set conversation ID for this chat

--- a/src/tools/letta-api.test.ts
+++ b/src/tools/letta-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getLatestRunError, recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent, approvePendingApproval } from './letta-api.js';
 
 // Mock the Letta client before importing the module under test
 const mockConversationsMessagesList = vi.fn();
@@ -6,6 +7,7 @@ const mockConversationsMessagesCreate = vi.fn();
 const mockRunsRetrieve = vi.fn();
 const mockRunsList = vi.fn();
 const mockAgentsMessagesCancel = vi.fn();
+const mockAgentsMessagesCreate = vi.fn();
 const mockAgentsRetrieve = vi.fn();
 const mockAgentsMessagesList = vi.fn();
 
@@ -26,6 +28,7 @@ vi.mock('@letta-ai/letta-client', () => {
         retrieve: mockAgentsRetrieve,
         messages: {
           cancel: mockAgentsMessagesCancel,
+          create: mockAgentsMessagesCreate,
           list: mockAgentsMessagesList,
         },
       };
@@ -39,6 +42,7 @@ describe('recoverPendingApprovalsForAgent', () => {
     mockAgentsRetrieve.mockResolvedValue({ pending_approval: null });
     mockAgentsMessagesList.mockReturnValue(mockPageIterator([]));
     mockAgentsMessagesCancel.mockResolvedValue(undefined);
+    mockAgentsMessagesCreate.mockResolvedValue({});
   });
 
   it('cancels approval-blocked runs when pending approval payload is unavailable', async () => {
@@ -74,7 +78,54 @@ describe('recoverPendingApprovalsForAgent', () => {
   });
 });
 
-import { getLatestRunError, recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent } from './letta-api.js';
+describe('approvePendingApproval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentsMessagesCreate.mockResolvedValue({});
+  });
+
+  it('approves a single tool call', async () => {
+    const ok = await approvePendingApproval('agent-1', { toolCallId: 'call-1' });
+
+    expect(ok).toBe(true);
+    expect(mockAgentsMessagesCreate).toHaveBeenCalledOnce();
+    expect(mockAgentsMessagesCreate).toHaveBeenCalledWith('agent-1', {
+      messages: [{
+        type: 'approval',
+        approvals: [{
+          approve: true,
+          tool_call_id: 'call-1',
+          type: 'approval',
+          reason: 'Approved by user from chat command',
+        }],
+      }],
+      streaming: false,
+    });
+  });
+
+  it('approves multiple tool calls in one request', async () => {
+    const ok = await approvePendingApproval('agent-1', [
+      { toolCallId: 'call-a' },
+      { toolCallId: 'call-b', reason: 'Approved by moderator' },
+    ]);
+
+    expect(ok).toBe(true);
+    const payload = mockAgentsMessagesCreate.mock.calls[0][1];
+    expect(payload.messages[0].approvals).toHaveLength(2);
+    expect(payload.messages[0].approvals.map((a: any) => a.tool_call_id)).toEqual(['call-a', 'call-b']);
+    expect(payload.messages[0].approvals[1].reason).toBe('Approved by moderator');
+  });
+
+  it('returns true when approval is already resolved', async () => {
+    mockAgentsMessagesCreate.mockRejectedValue({
+      status: 400,
+      error: { detail: 'No tool call is currently awaiting approval' },
+    });
+
+    const ok = await approvePendingApproval('agent-1', { toolCallId: 'call-1' });
+    expect(ok).toBe(true);
+  });
+});
 
 describe('isRecoverableConversationId', () => {
   it('returns false for aliases and empty values', () => {

--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -576,6 +576,60 @@ export async function rejectApproval(
 }
 
 /**
+ * Approve one or more pending tool call approvals in a single API request.
+ * The Letta API expects all parallel tool_call_ids for a run together.
+ */
+export async function approvePendingApproval(
+  agentId: string,
+  approvals: {
+    toolCallId: string;
+    reason?: string;
+  } | Array<{
+    toolCallId: string;
+    reason?: string;
+  }>,
+  conversationId?: string
+): Promise<boolean> {
+  const approvalList = Array.isArray(approvals) ? approvals : [approvals];
+  if (approvalList.length === 0) return true;
+
+  try {
+    const client = getClient();
+    const defaultReason = 'Approved by user from chat command';
+
+    await client.agents.messages.create(agentId, {
+      messages: [{
+        type: 'approval',
+        approvals: approvalList.map(a => ({
+          approve: true,
+          tool_call_id: a.toolCallId,
+          type: 'approval' as const,
+          reason: a.reason || defaultReason,
+        })),
+      }],
+      streaming: false,
+    });
+
+    const ids = approvalList.map(a => a.toolCallId).join(', ');
+    log.info(`Approved ${approvalList.length} approval(s): ${ids}`);
+    return true;
+  } catch (e) {
+    const err = e as { status?: number; error?: { detail?: string } };
+    const detail = err?.error?.detail || '';
+    if (err?.status === 400 && detail.includes('No tool call is currently awaiting approval')) {
+      log.warn('Approval(s) already resolved');
+      return true;
+    }
+    if (err?.status === 429) {
+      log.error('Failed to approve approval:', e);
+      throw e;
+    }
+    log.error('Failed to approve approval:', e);
+    return false;
+  }
+}
+
+/**
  * Cancel active runs for an agent.
  * Optionally specify specific run IDs to cancel.
  * Note: Requires Redis on the server for canceling active runs.


### PR DESCRIPTION
## Summary
- add two chat commands, /approve and /disapprove [reason], to resolve pending tool approvals without leaving the channel
- implement conversation-scoped approval/denial handling in bot core, batching by run to support parallel tool calls safely
- wire command routing for Telegram and Discord, and update command help/docs and approval API tests

## Test plan
- [x] 
px tsc --noEmit
- [x] 
px vitest src/core/commands.test.ts src/tools/letta-api.test.ts src/channels/discord-adapter.test.ts
- [ ] manual validation in a live channel:
  - [ ] trigger a pending tool approval and run /approve
  - [ ] trigger a pending tool approval and run /disapprove optional reason
  - [ ] verify no-op response when there are no pending approvals

?? Generated with [Letta Code](https://letta.com)
