### PR TITLE
fix(whatsapp): only treat @lid DMs as self-chat when LID matches bot

### DIFF
--- a/src/channels/whatsapp/inbound/extract.test.ts
+++ b/src/channels/whatsapp/inbound/extract.test.ts
@@ -30,9 +30,9 @@ function createMessage(
   };
 }
 
-function createSocket(options: { lidMapping?: Map<string, string> } = {}): Record<string, unknown> {
+function createSocket(options: { lidMapping?: Map<string, string>; lid?: string } = {}): Record<string, unknown> {
   return {
-    user: { id: '19998887777@s.whatsapp.net' },
+    user: { id: '19998887777@s.whatsapp.net', lid: options.lid },
     signalRepository: options.lidMapping ? { lidMapping: options.lidMapping } : {},
     groupMetadata: vi.fn(),
   };
@@ -95,6 +95,51 @@ describe('extractInboundMessage (LID DM resolution)', () => {
     expect(extracted?.chatId).toBe(REMOTE_LID);
     expect(extracted?.from).toBe('210501234567890');
     expect(extracted?.senderE164).toBe('210501234567890');
+  });
+
+  it('does NOT mark foreign @lid DMs as self-chat', async () => {
+    const msg = createMessage();
+    // Bot's own LID is different from REMOTE_LID
+    const sock = createSocket({ lid: '999999999@lid' });
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.isSelfChat).toBe(false);
+  });
+
+  it('marks @lid DM as self-chat only when LID matches bot', async () => {
+    const msg = createMessage();
+    // Bot's own LID matches the remote JID
+    const sock = createSocket({ lid: REMOTE_LID });
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.isSelfChat).toBe(true);
+  });
+
+  it('matches self-chat LID with device suffix stripped', async () => {
+    // Remote has device suffix :25
+    const msg = createMessage({
+      key: { remoteJid: '210501234567890:25@lid' },
+    });
+    // Bot LID has no suffix
+    const sock = createSocket({ lid: REMOTE_LID });
+
+    const extracted = await extractInboundMessage(
+      msg as any,
+      sock as any,
+      createGroupMetaCache()
+    );
+
+    expect(extracted?.isSelfChat).toBe(true);
   });
 
   it('accepts plain phone-number senderPn values by converting them to PN JIDs', async () => {

--- a/src/channels/whatsapp/inbound/extract.ts
+++ b/src/channels/whatsapp/inbound/extract.ts
@@ -283,9 +283,13 @@ export async function extractInboundMessage(
   // Check if sender mentioned the bot
   const wasMentioned = mentionedJids?.includes(selfJid) ?? false;
 
-  // Detect self-chat (including LID-based self-chat on newer WhatsApp versions)
-  const isLidChat = remoteJid.includes('@lid');
-  const isSelfChat = !isGroup && (from === selfE164 || isLidChat);
+  // Detect self-chat (including LID-based self-chat on newer WhatsApp versions).
+  // IMPORTANT: Not all @lid DMs are self-chat. Only match if the remoteJid
+  // is the bot's own LID (strip device suffix :XX before comparing).
+  const selfLid = sock.user?.lid || '';
+  const isLidSelfChat = !!(selfLid && remoteJid.includes('@lid')
+    && remoteJid.replace(/:\d+(@|$)/, '$1') === selfLid.replace(/:\d+(@|$)/, '$1'));
+  const isSelfChat = !isGroup && (from === selfE164 || isLidSelfChat);
 
   // Build normalized message (convert all nulls to undefined for type safety)
   const inboundMessage: WebInboundMessage = {


### PR DESCRIPTION
## Summary

All `@lid`-addressed WhatsApp DMs were treated as self-chat, bypassing `checkInboundAccess()` entirely. On newer WhatsApp sessions, LIDs are used for all contacts -- not just the bot's own self-chat.

Fix: compare `remoteJid` against the bot's own LID (`sock.user.lid`) with device suffix normalization (`:25@lid` -> `@lid`). Only mark as self-chat when they match.

Fixes #645

## Test plan

- [x] 997 tests pass (3 new)
- [x] Foreign `@lid` DMs are NOT marked as self-chat
- [x] Bot's own `@lid` DMs ARE marked as self-chat
- [x] Device suffix stripping works (`:25@lid` matches `@lid`)

Written by Cameron ◯ Letta Code