### PR TITLE
fix: deliver agent response after skill loading tool calls

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1735,14 +1735,20 @@ export class LettaBot implements AgentSession {
                 response = event.text;
               } else if (!sentAnyMessage && response.trim().length === 0 && event.success && !event.error) {
                 // Safety fallback: if nothing was delivered yet and response is empty.
-                // Prefer the raw result field when the pipeline's text came from
-                // pre-tool assistant content that was discarded (hadStreamedText is
-                // true but response was cleared by the tool_call discard logic).
+                // This covers two cases:
+                // 1. No text was streamed at all -- use pipeline text or raw result
+                // 2. Pre-tool text was streamed then discarded by the tool_call handler,
+                //    but the agent's post-tool response is in the result field (e.g. after
+                //    skill loading where the model doesn't re-stream text after the tool)
                 const rawResult = typeof event.raw.result === 'string' ? event.raw.result.trim() : '';
                 if (!event.hadStreamedText && event.text.trim()) {
                   response = event.text;
                 } else if (rawResult) {
                   response = rawResult;
+                } else if (event.text.trim()) {
+                  // Last resort: pipeline accumulated text (may include pre-tool content,
+                  // but better to deliver something than drop the response entirely)
+                  response = event.text;
                 }
               }
 


### PR DESCRIPTION
## Summary

When a skill tool call occurs mid-conversation, the pre-tool assistant text is correctly discarded (model scratch notes). But the result handler couldn't recover the post-tool response because `hadStreamedText` was `true` from the discarded pre-tool text, blocking the primary path.

The existing `rawResult` fallback should catch this, but fails when the result field is also empty (some models don't populate it after tool loops). Added a last-resort fallback that uses the pipeline's accumulated text.

Fixes #634

## Test plan

- [x] 997 tests pass
- [ ] Manual: trigger skill loading in a conversation, verify response is delivered after

Written by Cameron ◯ Letta Code