### PR TITLE
fix: prevent LETTA_AGENT_ID env var from leaking across agents

### DIFF
--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -221,23 +221,16 @@ describe('Store', () => {
     expect(store.isServerMismatch('https://api.letta.com')).toBe(true);
   });
 
-  it('should apply LETTA_AGENT_ID as fallback for all agent names', () => {
-    process.env.LETTA_AGENT_ID = 'global-agent';
-    const defaultStore = new Store(testStorePath, 'LettaBot');
-    const namedStore = new Store(testStorePath, 'Bot2');
-
-    expect(defaultStore.agentId).toBe('global-agent');
-    expect(namedStore.agentId).toBe('global-agent');
-  });
-
-  it('should not fall back to LETTA_AGENT_ID after clearAgent', () => {
+  it('should not read LETTA_AGENT_ID from store getter (handled by main.ts)', () => {
     process.env.LETTA_AGENT_ID = 'global-agent';
     const store = new Store(testStorePath, 'LettaBot');
-    store.agentId = 'agent-1';
-    expect(store.agentId).toBe('agent-1');
 
+    // Seeded at construction time
+    expect(store.agentId).toBe('global-agent');
+
+    // clearAgent genuinely clears -- env var doesn't resurrect at runtime
     store.clearAgent();
-    expect(store.agentId).toBeNull(); // cleared, don't fall back to env var
+    expect(store.agentId).toBeNull();
   });
 
   // Per-key conversation management

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -53,6 +53,15 @@ export class Store {
     this.backupPath = `${this.storePath}.bak`;
     this.agentName = agentName || 'LettaBot';
     this.data = this.load();
+
+    // One-shot bootstrap: if the store has no agent ID yet, seed from env var.
+    // Persisted to disk so refresh() doesn't discard it.
+    // This is NOT a runtime fallback -- clearAgent() will genuinely clear it,
+    // and the env var won't leak across agents in multi-agent mode.
+    if (!this.agentData().agentId && process.env.LETTA_AGENT_ID) {
+      this.agentData().agentId = process.env.LETTA_AGENT_ID;
+      this.save();
+    }
   }
 
   /**
@@ -290,17 +299,12 @@ export class Store {
   }
 
   get agentId(): string | null {
-    const data = this.agentData();
-    // Use stored ID, fall back to env var only if the agent wasn't explicitly cleared
-    if (data.agentId) return data.agentId;
-    if (data.agentCleared) return null;
-    return process.env.LETTA_AGENT_ID || null;
+    return this.agentData().agentId || null;
   }
 
   set agentId(id: string | null) {
     const agent = this.agentData();
     agent.agentId = id;
-    if (id) delete agent.agentCleared;
     agent.lastUsedAt = new Date().toISOString();
     if (id && !agent.createdAt) {
       agent.createdAt = new Date().toISOString();
@@ -409,7 +413,6 @@ export class Store {
   clearAgent(): void {
     const agent = this.agentData();
     agent.agentId = null;
-    agent.agentCleared = true;
     agent.conversationId = null;
     agent.conversations = undefined;
     agent.baseUrl = undefined;


### PR DESCRIPTION
## Summary

Regression from #656. In multi-agent mode, `session-manager` sets `process.env.LETTA_AGENT_ID` for subprocess communication. The store getter was reading this as a runtime fallback, causing all agents to resolve to whichever agent's session ran last.

Fix: move env var handling from the getter to a one-shot bootstrap in the `Store` constructor. The env var seeds the store data once at construction time and is persisted to disk (so `refresh()` doesn't discard it). `clearAgent()` genuinely clears the value.

## Test plan

- [x] 997 tests pass
- [x] Store test: env var seeds at construction, clearAgent genuinely clears
- [ ] Manual: run 3 agents on same server, verify each responds as itself

Written by Cameron ◯ Letta Code