### PR TITLE
fix: remove auto-agent-creation, warn on 404 instead

### DIFF
--- a/src/core/sdk-session-contract.test.ts
+++ b/src/core/sdk-session-contract.test.ts
@@ -230,9 +230,7 @@ describe('SDK session contract', () => {
     expect(mockSession.close).toHaveBeenCalledTimes(1);
   });
 
-  it('recreates agent after explicit agent-not-found initialize error', async () => {
-    delete process.env.LETTA_AGENT_ID;
-
+  it('rejects with error on agent-not-found without clearing agent ID', async () => {
     const staleSession = {
       initialize: vi.fn(async () => {
         throw new Error('No init message received from subprocess. stderr: {"detail":"Agent agent-contract-test not found"}');
@@ -249,26 +247,7 @@ describe('SDK session contract', () => {
       conversationId: 'conv-stale',
     };
 
-    const recoveredSession = {
-      initialize: vi.fn(async () => undefined),
-      send: vi.fn(async (_message: unknown) => undefined),
-      stream: vi.fn(() =>
-        (async function* () {
-          yield { type: 'assistant', content: 'fresh response' };
-          yield { type: 'result', success: true };
-        })()
-      ),
-      close: vi.fn(() => undefined),
-      recoverPendingApprovals: vi.fn(async () => ({ recovered: false, unsupported: true, detail: 'mock' })),
-      agentId: 'agent-recreated',
-      conversationId: 'conv-recreated',
-    };
-
-    vi.mocked(createAgent).mockResolvedValue('agent-recreated');
-    // First call: agentId exists, no convId → resumeSession(agentId)
     vi.mocked(resumeSession).mockReturnValueOnce(staleSession as never);
-    // After clearAgent + createAgent → createSession(newAgentId)
-    vi.mocked(createSession).mockReturnValueOnce(recoveredSession as never);
 
     const bot = new LettaBot({
       workingDir: join(dataDir, 'working'),
@@ -277,12 +256,11 @@ describe('SDK session contract', () => {
     });
     bot.setAgentId('agent-contract-test');
 
-    const response = await bot.sendToAgent('recover me');
-    expect(response).toBe('fresh response');
+    // Should reject without auto-creating a replacement agent
+    await expect(bot.sendToAgent('recover me')).rejects.toThrow('not found');
     expect(staleSession.close).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(createAgent)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(resumeSession).mock.calls[0][0]).toBe('agent-contract-test');
-    expect(vi.mocked(createSession).mock.calls[0][0]).toBe('agent-recreated');
+    // Agent ID should NOT be cleared -- the 404 may be transient
+    expect(bot.getStatus().agentId).toBe('agent-contract-test');
   });
 
   it('does not clear agent state on generic initialize failures', async () => {
@@ -1390,50 +1368,18 @@ describe('SDK session contract', () => {
     expect(stuckSession.close).toHaveBeenCalledTimes(1);
   });
 
-  it('passes tags: [origin:lettabot] to createAgent when creating a new agent', async () => {
+  it('throws when no agent ID is configured instead of auto-creating', async () => {
     delete process.env.LETTA_AGENT_ID;
-
-    vi.mocked(createAgent).mockResolvedValue('agent-new-tagged');
-
-    const mockSession = {
-      initialize: vi.fn(async () => undefined),
-      send: vi.fn(async (_message: unknown) => undefined),
-      stream: vi.fn(() =>
-        (async function* () {
-          yield { type: 'assistant', content: 'hello' };
-          yield { type: 'result', success: true };
-        })()
-      ),
-      close: vi.fn(() => undefined),
-      recoverPendingApprovals: vi.fn(async () => ({ recovered: false, unsupported: true, detail: 'mock' })),
-      agentId: 'agent-new-tagged',
-      conversationId: 'conversation-new-tagged',
-    };
-
-    vi.mocked(createSession).mockReturnValue(mockSession as never);
 
     const bot = new LettaBot({
       workingDir: join(dataDir, 'working'),
       allowedTools: [],
-      memfs: true,
-      sleeptime: {
-        trigger: 'compaction-event',
-        behavior: 'auto-launch',
-      },
     });
 
-    await bot.sendToAgent('first message');
-
-    expect(vi.mocked(createAgent)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(createAgent)).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tags: ['origin:lettabot'],
-        sleeptime: {
-          trigger: 'compaction-event',
-          behavior: 'auto-launch',
-        },
-      })
+    await expect(bot.sendToAgent('first message')).rejects.toThrow(
+      'No agent ID configured',
     );
+    expect(vi.mocked(createAgent)).not.toHaveBeenCalled();
   });
 
   it('retries sendToAgent when SDK result runIds repeat the previous run', async () => {

--- a/src/core/session-manager.ts
+++ b/src/core/session-manager.ts
@@ -6,14 +6,13 @@
  * routing, channel management, and directive execution.
  */
 
-import { createAgent, createSession, resumeSession, type Session, type SendMessage, type CanUseToolCallback } from '@letta-ai/letta-code-sdk';
+import { createSession, resumeSession, type Session, type SendMessage, type CanUseToolCallback } from '@letta-ai/letta-code-sdk';
 import type { BotConfig, StreamMsg } from './types.js';
 import { isApprovalConflictError, isConversationMissingError, isAgentMissingFromInitError } from './errors.js';
 import { Store } from './store.js';
-import { updateAgentName, recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
+import { recoverOrphanedConversationApproval, isRecoverableConversationId, recoverPendingApprovalsForAgent } from '../tools/letta-api.js';
 import { installSkillsToAgent, prependSkillDirsToPath } from '../skills/loader.js';
-import { loadMemoryBlocks } from './memory.js';
-import { SYSTEM_PROMPT } from './system-prompt.js';
+
 import { createManageTodoTool } from '../tools/todo.js';
 import { syncTodosFromTool } from '../todo/store.js';
 import { recoverPendingApprovalsWithSdk } from './session-sdk-compat.js';
@@ -305,31 +304,10 @@ export class SessionManager {
         ? resumeSession(this.store.agentId, opts)
         : createSession(this.store.agentId, opts);
     } else {
-      // Create new agent -- persist immediately so we don't orphan it on later failures
-      this.log.info('Creating new agent');
-      const newAgentId = await createAgent({
-        systemPrompt: SYSTEM_PROMPT,
-        memory: loadMemoryBlocks(this.config.agentName),
-        tags: ['origin:lettabot'],
-        ...(this.config.memfs !== undefined ? { memfs: this.config.memfs } : {}),
-        ...(this.config.sleeptime ? { sleeptime: this.config.sleeptime } : {}),
-      });
-      const currentBaseUrl = process.env.LETTA_BASE_URL || 'https://api.letta.com';
-      this.store.setAgent(newAgentId, currentBaseUrl);
-      this.log.info('Saved new agent ID:', newAgentId);
-
-      if (this.config.agentName) {
-        updateAgentName(newAgentId, this.config.agentName).catch(() => {});
-      }
-      installSkillsToAgent(newAgentId, this.config.skills);
-      sessionAgentId = newAgentId;
-      prependSkillDirsToPath(sessionAgentId); // must be before createSession spawns subprocess
-
-      // In disabled mode, resume the built-in default conversation instead of
-      // creating a new one.  Other modes create a fresh conversation per key.
-      session = key === 'default'
-        ? resumeSession('default', opts)
-        : createSession(newAgentId, opts);
+      throw new Error(
+        'No agent ID configured. Set agent.id in lettabot.yaml, ' +
+        'LETTA_AGENT_ID env var, or run lettabot onboard.',
+      );
     }
 
     // Initialize eagerly so the subprocess is ready before the first send()
@@ -346,15 +324,15 @@ export class SessionManager {
       // Close immediately so failed initialization cannot leak a subprocess.
       session.close();
 
-      // If the stored agent ID doesn't exist on the server (deleted externally,
-      // ghost agent from failed pairing, etc.), clear the stale ID and retry.
-      if (this.store.agentId && !bootstrapRetried && isAgentMissingFromInitError(error)) {
-        this.log.warn(
-          `Agent ${this.store.agentId} appears missing from server, ` +
-          `clearing stale agent ID and recreating...`,
+      // If the stored agent ID doesn't exist on the server, log an error but
+      // DON'T clear the stored ID or auto-create a replacement. The 404 may be
+      // transient; the next message will retry with the same agent ID.
+      if (this.store.agentId && isAgentMissingFromInitError(error)) {
+        this.log.error(
+          `Agent ${this.store.agentId} not found on server (404). ` +
+          `This may be transient -- will retry on next message. ` +
+          `If the agent was deleted, reconfigure agent.id in lettabot.yaml.`,
         );
-        this.store.clearAgent();
-        return this._createSessionForKey(key, /* bootstrapRetried */ true, generation);
       }
 
       throw error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,13 +433,15 @@ async function main() {
       initialStatus = bot.getStatus();
     }
     
-    // Verify agent exists (clear stale ID if deleted)
+    // Verify agent exists on server. If not found, warn but keep the ID --
+    // the 404 may be transient (server restart, network blip, etc.).
     if (initialStatus.agentId) {
       const exists = await agentExists(initialStatus.agentId);
       if (!exists) {
-        log.info(`Stored agent ${initialStatus.agentId} not found on server`);
-        bot.reset();
-        initialStatus = bot.getStatus();
+        log.warn(
+          `Agent ${initialStatus.agentId} not found on server. ` +
+          `Keeping config -- the agent may reappear if this was transient.`,
+        );
       }
     }
 
@@ -468,7 +470,10 @@ async function main() {
     }
 
     if (!initialStatus.agentId) {
-      log.info(`No agent found - will create on first message`);
+      log.error(
+        `No agent ID configured. Set agent.id in lettabot.yaml, ` +
+        `LETTA_AGENT_ID env var, or run lettabot onboard.`,
+      );
     }
     
     // Disable tool approvals


### PR DESCRIPTION
## Summary

Lettabot was silently creating a new agent whenever it couldn't find the configured one. This broke setups when a transient 404 caused the existing agent to be discarded and a fresh empty one created.

- **Session-manager**: remove auto-creation `else` branch. If no agent ID is configured, throw `"No agent ID configured"` error with guidance
- **404 recovery**: agent-not-found during session init logs an error and re-throws WITHOUT clearing the stored agent ID. Next message retries with the same ID
- **Startup**: warn instead of `bot.reset()` when `agentExists()` returns false. Config stays intact
- **Fleet discovery**: `findAgentByName` path preserved -- `lettactl apply` bootstrap still works
- Net -71 lines

## Test plan

- [x] 997 tests pass
- [x] New test: no agent ID -> throws "No agent ID configured", never calls createAgent
- [x] New test: agent-not-found 404 -> rejects, keeps agent ID in store
- [ ] Manual: restart with valid agent ID, verify no recreation

Written by Cameron ◯ Letta Code