### PR TITLE
Fix: Multi-step agent turns only display the first tool call

### DIFF
--- a/src/core/display-pipeline.ts
+++ b/src/core/display-pipeline.ts
@@ -216,13 +216,16 @@ export async function* createDisplayPipeline(
       filteredCount++;
       continue;
     } else if (foregroundRunId && eventRunIds.length > 0 && !eventRunIds.includes(foregroundRunId)) {
-      // Event from a different run. Rebind on assistant events only
-      // (background Tasks don't produce assistant events in the foreground stream).
-      if (msg.type === 'assistant') {
+      // Event from a different run. The Letta agent creates a new run ID per
+      // step in its tool loop, so within a single turn the foreground run
+      // changes on every tool call. Rebind on any substantive event type to
+      // avoid filtering legitimate intermediate tool calls. Background Tasks
+      // use separate sessions and cannot produce events in this stream.
+      if (isLockType) {
         const newRunId = eventRunIds[0];
         pipeLog.info(`Foreground run rebind: ${foregroundRunId} -> ${newRunId}`);
         foregroundRunId = newRunId;
-        foregroundSource = 'assistant';
+        foregroundSource = msg.type;
       } else {
         filteredCount++;
         continue;


### PR DESCRIPTION
This is a fix for #662.

The display pipeline was dropping all tool calls except the first in multi-step agent steps. The agent creates a new run ID per step in its tool loop. The display loop currently only looks at the first run's ID and only rebound on `assistant` events, so all intermediate tool calls and reasoning were filtered out.

This PR changes the display condition such that it's not looking only for `assistant` events, but any substantive event type (using `isLockType`, which was defined earlier in the file).

--

Full disclosure: I ran into this issue while using Lettabot and had Claude isolate the issue. It solved the issue for me, but I may have missed a wider architectural decision.