### PR TITLE
fix: restrict slash commands to authorized users in group chats

### DIFF
--- a/src/channels/discord-adapter.test.ts
+++ b/src/channels/discord-adapter.test.ts
@@ -275,6 +275,7 @@ describe('DiscordAdapter command gating', () => {
   it('allows slash commands inside threads in thread-only mode', async () => {
     const adapter = new DiscordAdapter({
       token: 'token',
+      allowedUsers: ['user-1'],
       groups: {
         'channel-1': { mode: 'open', threadMode: 'thread-only' },
       },
@@ -304,6 +305,7 @@ describe('DiscordAdapter command gating', () => {
   it('redirects mentioned top-level commands into an auto-created thread', async () => {
     const adapter = new DiscordAdapter({
       token: 'token',
+      allowedUsers: ['user-1'],
       groups: {
         'channel-1': { mode: 'open', threadMode: 'thread-only', autoCreateThreadOnMention: true },
       },

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -8,7 +8,7 @@
 import type { ChannelAdapter } from './types.js';
 import type { InboundAttachment, InboundMessage, InboundReaction, OutboundFile, OutboundMessage } from '../core/types.js';
 import type { DmPolicy } from '../pairing/types.js';
-import { upsertPairingRequest } from '../pairing/store.js';
+import { isUserAllowed, upsertPairingRequest } from '../pairing/store.js';
 import { checkDmAccess } from './shared/access-control.js';
 import { resolveEmoji } from './shared/emoji.js';
 import { splitMessageText } from './shared/message-splitter.js';
@@ -291,6 +291,13 @@ Ask the bot owner to approve with:
           command === 'disapprove' ||
           command === 'model' ||
           command === 'setconv';
+
+        // Commands require user-level authorization (paired or allowlisted).
+        // Chat access (mode: open, guild membership) should not imply command access.
+        if (isHelpCommand || isManagedCommand) {
+          const commandAllowed = await isUserAllowed('discord', userId, this.config.allowedUsers);
+          if (!commandAllowed) return;
+        }
 
         // Unknown commands (or managed commands without onCommand) fall through to agent processing.
         if (isHelpCommand || (isManagedCommand && this.onCommand)) {

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -203,6 +203,13 @@ export class TelegramAdapter implements ChannelAdapter {
       if (chatType === 'group' || chatType === 'supergroup') {
         const dmPolicy = this.config.dmPolicy || 'pairing';
         if (dmPolicy === 'open' || await isGroupApproved('telegram', String(ctx.chat!.id))) {
+          // Commands in groups require user-level authorization (paired or allowlisted).
+          // Chat access (mode: open) should not imply command access.
+          const msgText = ctx.message && 'text' in ctx.message ? ctx.message.text : undefined;
+          if (msgText?.startsWith('/')) {
+            const allowed = await isUserAllowed('telegram', String(userId), this.config.allowedUsers?.map(String));
+            if (!allowed) return; // silently drop unauthorized commands
+          }
           await next();
         }
         // Silently drop messages from unapproved groups


### PR DESCRIPTION
## Summary

In group chats with `mode: open`, ALL users could execute slash commands (`/help`, `/model`, `/approve`, etc.) -- not just paired/allowlisted users. This leaked server IPs via `/help` and allowed unauthorized model switching via `/model`.

- **Telegram**: user-level `isUserAllowed` check in group middleware before passing commands through. Regular messages still allowed in `mode: open`.
- **Discord**: `isUserAllowed` check before all managed command execution. Covers both the group gap and a separate DM gap where commands bypassed the access check entirely.

Chat access (mode: open) no longer implies command access.

Fixes #666

## Test plan

- [x] 997 tests pass
- [x] Updated Discord command gating tests to include `allowedUsers` for authorized test user
- [ ] Manual: unauthorized user in Telegram group cannot run /help, /model
- [ ] Manual: authorized user in same group can still run commands

Written by Cameron ◯ Letta Code