### PR TITLE
fix: preserve self-hosted model endpoints on model changes

### DIFF
--- a/src/tools/letta-api.test.ts
+++ b/src/tools/letta-api.test.ts
@@ -165,9 +165,44 @@ describe('updateAgentModel', () => {
     const ok = await updateAgentModel('agent-1', 'anthropic/claude-sonnet-4-5-20250929');
 
     expect(ok).toBe(true);
+    expect(mockAgentsRetrieve).not.toHaveBeenCalled();
     expect(mockAgentsUpdate).toHaveBeenCalledWith('agent-1', {
       model: 'anthropic/claude-sonnet-4-5-20250929',
     });
+  });
+
+  it('skips preserving self-hosted endpoints when switching to a different provider', async () => {
+    process.env.LETTA_BASE_URL = 'http://localhost:8283';
+    mockAgentsRetrieve.mockResolvedValue({
+      llm_config: {
+        context_window: 128000,
+        model: 'kimi-k2.5:cloud',
+        model_endpoint_type: 'openai',
+        model_endpoint: 'http://host.docker.internal:11434/v1',
+        provider_name: 'ollama',
+        handle: 'ollama/kimi-k2.5:cloud',
+      },
+      embedding_config: {
+        embedding_dim: 4096,
+        embedding_endpoint_type: 'openai',
+        embedding_model: 'qwen3-embedding:8b-q8_0',
+        embedding_endpoint: 'http://host.docker.internal:11434/v1',
+      },
+    });
+
+    const ok = await updateAgentModel('agent-1', 'anthropic/claude-sonnet-4-5-20250929');
+
+    expect(ok).toBe(true);
+    expect(mockAgentsRetrieve).toHaveBeenCalledWith('agent-1');
+    expect(mockAgentsUpdate).toHaveBeenCalledWith('agent-1', {
+      model: 'anthropic/claude-sonnet-4-5-20250929',
+      embedding_config: expect.objectContaining({
+        embedding_endpoint: 'http://host.docker.internal:11434/v1',
+      }),
+    });
+    expect(mockAgentsUpdate).not.toHaveBeenCalledWith('agent-1', expect.objectContaining({
+      llm_config: expect.anything(),
+    }));
   });
 });
 

--- a/src/tools/letta-api.ts
+++ b/src/tools/letta-api.ts
@@ -279,6 +279,12 @@ export async function getAgentModel(agentId: string): Promise<string | null> {
 export async function updateAgentModel(agentId: string, model: string): Promise<boolean> {
   try {
     const client = getClient();
+
+    if (isLettaApiUrl(getBaseUrl())) {
+      await client.agents.update(agentId, { model });
+      return true;
+    }
+
     const agent = await client.agents.retrieve(agentId);
     const update: {
       model: string;


### PR DESCRIPTION
## Summary
- preserve self-hosted LLM endpoints when switching models
- preserve self-hosted embedding endpoints during model changes
- add regression coverage for Ollama/self-hosted and cloud-only updates

## Context
Self-hosted Letta deployments can store custom model and embedding endpoints such as Ollama. Updating the model with a minimal payload was causing those saved endpoints to be dropped, which broke agents using Docker plus Ollama setups.

## Testing
- npm run test:run -- src/tools/letta-api.test.ts