### PR TITLE
fix(api): use responsive outputMode for sync chat endpoints

### DIFF
--- a/src/api/server.test.ts
+++ b/src/api/server.test.ts
@@ -135,7 +135,7 @@ describe('POST /api/v1/chat', () => {
     expect(router.sendToAgent).toHaveBeenCalledWith(
       undefined,
       'Hello',
-      { type: 'webhook', outputMode: 'silent' },
+      { type: 'webhook', outputMode: 'responsive' },
     );
   });
 
@@ -148,7 +148,7 @@ describe('POST /api/v1/chat', () => {
     expect(router.sendToAgent).toHaveBeenCalledWith(
       'LettaBot',
       'Hi',
-      { type: 'webhook', outputMode: 'silent' },
+      { type: 'webhook', outputMode: 'responsive' },
     );
   });
 

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -29,7 +29,14 @@ const VALID_CHANNELS: ChannelId[] = ['telegram', 'slack', 'discord', 'whatsapp',
 const MAX_BODY_SIZE = 10 * 1024; // 10KB
 const MAX_TEXT_LENGTH = 10000; // 10k chars
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
-const WEBHOOK_CONTEXT = { type: 'webhook' as const, outputMode: 'silent' as const };
+// Sync endpoints (/api/v1/chat, /api/v1/chat stream): the HTTP response IS
+// the delivery mechanism, so the agent's output is genuinely responsive.
+// Keeping this silent makes the "response discarded" WARN fire on every
+// sync call even though the caller actually received the text.
+const WEBHOOK_SYNC_CONTEXT = { type: 'webhook' as const, outputMode: 'responsive' as const };
+// Async endpoint (/api/v1/chat/async): returns 202 immediately, nothing is
+// waiting for the agent's text output, so silent is correct.
+const WEBHOOK_ASYNC_CONTEXT = { type: 'webhook' as const, outputMode: 'silent' as const };
 const PORTAL_HTML = fs.readFileSync(new URL('./portal.html', import.meta.url), 'utf-8');
 
 type ResolvedChatRequest = {
@@ -376,7 +383,7 @@ export function createApiServer(deliverer: AgentRouter, options: ServerOptions):
           req.on('close', () => { clientDisconnected = true; });
 
           try {
-            for await (const msg of deliverer.streamToAgent(resolved.agentName, resolved.message, WEBHOOK_CONTEXT)) {
+            for await (const msg of deliverer.streamToAgent(resolved.agentName, resolved.message, WEBHOOK_SYNC_CONTEXT)) {
               if (clientDisconnected) break;
               res.write(`data: ${JSON.stringify(msg)}\n\n`);
               if (msg.type === 'result') break;
@@ -389,7 +396,7 @@ export function createApiServer(deliverer: AgentRouter, options: ServerOptions):
           res.end();
         } else {
           // Sync: wait for full response
-          const response = await deliverer.sendToAgent(resolved.agentName, resolved.message, WEBHOOK_CONTEXT);
+          const response = await deliverer.sendToAgent(resolved.agentName, resolved.message, WEBHOOK_SYNC_CONTEXT);
 
           const chatRes: ChatResponse = {
             success: true,
@@ -430,7 +437,7 @@ export function createApiServer(deliverer: AgentRouter, options: ServerOptions):
         res.end(JSON.stringify(asyncRes));
 
         // Process in background (detached promise)
-        deliverer.sendToAgent(resolved.agentName, resolved.message, WEBHOOK_CONTEXT).catch((error: any) => {
+        deliverer.sendToAgent(resolved.agentName, resolved.message, WEBHOOK_ASYNC_CONTEXT).catch((error: any) => {
           log.error(`Async chat background error for agent "${resolved.resolvedName}":`, error);
         });
       } catch (error: any) {


### PR DESCRIPTION
## What

`POST /api/v1/chat` (sync JSON and SSE stream) is passed `outputMode: 'silent'`. Split the single `WEBHOOK_CONTEXT` into sync vs async variants so sync endpoints use `outputMode: 'responsive'`.

## Why

Currently every sync API call logs:

```
WARN: Silent mode: agent produced N chars but did NOT use lettabot-message CLI
      or directives — response discarded.
```

But the agent's text is returned to the HTTP caller via the response body — it isn't actually discarded. Silent mode is designed for triggers where nothing is listening for output (heartbeats, cron, background work); a sync HTTP call is the opposite — the caller's response handle is the delivery channel.

Concretely, silent mode causes:

- Misleading log noise on every API call (makes real issues harder to spot).
- `isSilent` paths in `bot.ts` that watch for `lettabot-message send` Bash calls, which is irrelevant when the caller is getting the response via HTTP.

## Change

Replace the single `WEBHOOK_CONTEXT` with two contexts, pick the right one per endpoint:

| Endpoint | Caller listens for response? | Mode |
|---|---|---|
| `POST /api/v1/chat` (sync + stream) | yes | `responsive` |
| `POST /api/v1/chat/async` | no (202, fire-and-forget) | `silent` |

## Testing

`src/api/server.test.ts` covers all three endpoints. Updated the two sync assertions to expect `outputMode: 'responsive'`; the async assertion still expects `silent`. All 15 tests in `server.test.ts` pass.

No behavior change for `/api/v1/chat/async` or for non-API callers (Discord/Telegram/etc.) — only the sync API paths.
