### PR TITLE
Fix channel add/remove write path for multi-agent config format

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,15 @@ async function configure() {
   const { resolveConfigPath } = await import('./config/index.js');
   const config = getConfig();
   
+  // Resolve channels from agents[0] (multi-agent) or top-level (legacy)
+  const primaryChannels = config.agents?.[0]?.channels;
+  const channels = {
+    ...config.channels,
+    ...(primaryChannels?.telegram ? { telegram: { ...primaryChannels.telegram, ...config.channels?.telegram } } : {}),
+    ...(primaryChannels?.slack ? { slack: { ...primaryChannels.slack, ...config.channels?.slack } } : {}),
+    ...(primaryChannels?.discord ? { discord: { ...primaryChannels.discord, ...config.channels?.discord } } : {}),
+  };
+  
   p.intro('🤖 LettaBot Configuration');
 
   // Show current config from YAML
@@ -68,9 +77,9 @@ async function configure() {
     ['Server Mode', serverModeLabel(config.server.mode)],
     ['API Key', config.server.apiKey ? '✓ Set' : '✗ Not set'],
     ['Agent Name', config.agent.name],
-    ['Telegram', config.channels.telegram?.enabled ? '✓ Enabled' : '✗ Disabled'],
-    ['Slack', config.channels.slack?.enabled ? '✓ Enabled' : '✗ Disabled'],
-    ['Discord', config.channels.discord?.enabled ? '✓ Enabled' : '✗ Disabled'],
+    ['Telegram', channels.telegram?.enabled ? '✓ Enabled' : '✗ Disabled'],
+    ['Slack', channels.slack?.enabled ? '✓ Enabled' : '✗ Disabled'],
+    ['Discord', channels.discord?.enabled ? '✓ Enabled' : '✗ Disabled'],
     ['Cron', config.features?.cron ? '✓ Enabled' : '✗ Disabled'],
     ['Heartbeat', config.features?.heartbeat?.enabled ? `✓ ${config.features.heartbeat.intervalMin}min` : '✗ Disabled'],
     ['BYOK Providers', config.providers?.length ? config.providers.map(p => p.name).join(', ') : 'None'],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,12 @@ const args = process.argv.slice(2);
 const command = args[0];
 const subCommand = args[1];
 
+// Parse --config <path> early so it propagates to main.js subprocess
+const configIdx = args.indexOf('--config');
+if (configIdx !== -1 && args[configIdx + 1]) {
+  process.env.LETTABOT_CONFIG = resolve(args[configIdx + 1]);
+}
+
 // Check if value is a placeholder
 const isPlaceholder = (val?: string) => !val || /^(your_|sk-\.\.\.|placeholder|example)/i.test(val);
 

--- a/src/cli/channel-management.test.ts
+++ b/src/cli/channel-management.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { resolveChannels, isMultiAgentConfig } from './channel-management.js';
+
+describe('channel-management helpers', () => {
+  describe('isMultiAgentConfig', () => {
+    it('returns true when agents array has entries', () => {
+      const config = {
+        agents: [{ name: 'Bot1', channels: {} }],
+        channels: {},
+      };
+      expect(isMultiAgentConfig(config)).toBe(true);
+    });
+
+    it('returns false when agents is undefined', () => {
+      const config = { channels: {} };
+      expect(isMultiAgentConfig(config)).toBe(false);
+    });
+
+    it('returns false when agents is empty array', () => {
+      const config = { agents: [], channels: {} };
+      expect(isMultiAgentConfig(config)).toBe(false);
+    });
+
+    it('returns false for single-agent format', () => {
+      const config = {
+        agent: { name: 'Bot' },
+        channels: { signal: { enabled: true } },
+      };
+      expect(isMultiAgentConfig(config)).toBe(false);
+    });
+  });
+
+  describe('resolveChannels', () => {
+    it('returns top-level channels when no agents[] present', () => {
+      const config = {
+        channels: {
+          signal: { enabled: true, phone: '+1234' },
+          telegram: { enabled: false },
+        },
+      };
+      const resolved = resolveChannels(config);
+      expect(resolved.signal.enabled).toBe(true);
+      expect(resolved.signal.phone).toBe('+1234');
+      expect(resolved.telegram.enabled).toBe(false);
+    });
+
+    it('merges agents[0].channels with top-level channels', () => {
+      const config = {
+        agents: [{
+          name: 'TestBot',
+          channels: {
+            signal: { enabled: true, phone: '+1234' },
+            telegram: { enabled: true, token: 'tg-token' },
+          },
+        }],
+        channels: {
+          signal: { enabled: false }, // top-level override (should take precedence)
+          discord: { enabled: true, token: 'dc-token' },
+        },
+      };
+      const resolved = resolveChannels(config);
+      
+      // Signal: agent-level merged with top-level; top-level fields override
+      expect(resolved.signal.enabled).toBe(false); // top-level override
+      expect(resolved.signal.phone).toBe('+1234'); // from agent-level
+      
+      // Telegram: only in agent-level
+      expect(resolved.telegram.enabled).toBe(true);
+      expect(resolved.telegram.token).toBe('tg-token');
+      
+      // Discord: only in top-level
+      expect(resolved.discord.enabled).toBe(true);
+      expect(resolved.discord.token).toBe('dc-token');
+    });
+
+    it('returns agent channels when top-level channels is empty', () => {
+      const config = {
+        agents: [{
+          name: 'TestBot',
+          channels: {
+            telegram: { enabled: true, token: 'bot-token' },
+            signal: { enabled: true, phone: '+1555' },
+          },
+        }],
+        channels: {},
+      };
+      const resolved = resolveChannels(config);
+      expect(resolved.telegram.enabled).toBe(true);
+      expect(resolved.signal.enabled).toBe(true);
+      expect(resolved.signal.phone).toBe('+1555');
+    });
+
+    it('handles empty config', () => {
+      const config = {};
+      const resolved = resolveChannels(config);
+      expect(resolved).toEqual({});
+    });
+
+    it('handles agents without channels', () => {
+      const config = {
+        agents: [{ name: 'Bot' }],
+        channels: { telegram: { enabled: true } },
+      };
+      const resolved = resolveChannels(config);
+      expect(resolved.telegram.enabled).toBe(true);
+    });
+  });
+});

--- a/src/cli/channel-management.ts
+++ b/src/cli/channel-management.ts
@@ -50,20 +50,35 @@ function getChannelDetails(id: ChannelId, channelConfig: any): string | undefine
   }
 }
 
+/**
+ * Resolve merged channels from a config object.
+ * In multi-agent format (agents[] present), merges agents[0].channels with
+ * top-level channels (agent-level takes precedence for overlapping fields).
+ * In single-agent format, returns top-level channels directly.
+ */
+export function resolveChannels(config: any): Record<string, any> {
+  const agentChannels = config.agents?.[0]?.channels;
+  return {
+    ...config.channels,
+    ...(agentChannels?.telegram ? { telegram: { ...agentChannels.telegram, ...config.channels?.telegram } } : {}),
+    ...(agentChannels?.slack ? { slack: { ...agentChannels.slack, ...config.channels?.slack } } : {}),
+    ...(agentChannels?.discord ? { discord: { ...agentChannels.discord, ...config.channels?.discord } } : {}),
+    ...(agentChannels?.whatsapp ? { whatsapp: { ...agentChannels.whatsapp, ...config.channels?.whatsapp } } : {}),
+    ...(agentChannels?.signal ? { signal: { ...agentChannels.signal, ...config.channels?.signal } } : {}),
+    ...(agentChannels?.bluesky ? { bluesky: { ...agentChannels.bluesky, ...config.channels?.bluesky } } : {}),
+  };
+}
+
+/**
+ * Check if config uses multi-agent format (agents[] with entries).
+ */
+export function isMultiAgentConfig(config: any): boolean {
+  return !!(config.agents && Array.isArray(config.agents) && config.agents.length > 0);
+}
+
 function getChannelStatus(): ChannelStatus[] {
   const rawConfig = loadAppConfigOrExit();
-  
-  // Merge channels from both top-level and agents[0] (multi-agent format)
-  const agentChannels = rawConfig.agents?.[0]?.channels;
-  const channels = {
-    ...rawConfig.channels,
-    ...(agentChannels?.telegram ? { telegram: { ...agentChannels.telegram, ...rawConfig.channels?.telegram } } : {}),
-    ...(agentChannels?.slack ? { slack: { ...agentChannels.slack, ...rawConfig.channels?.slack } } : {}),
-    ...(agentChannels?.discord ? { discord: { ...agentChannels.discord, ...rawConfig.channels?.discord } } : {}),
-    ...(agentChannels?.whatsapp ? { whatsapp: { ...agentChannels.whatsapp, ...rawConfig.channels?.whatsapp } } : {}),
-    ...(agentChannels?.signal ? { signal: { ...agentChannels.signal, ...rawConfig.channels?.signal } } : {}),
-    ...(agentChannels?.bluesky ? { bluesky: { ...agentChannels.bluesky, ...rawConfig.channels?.bluesky } } : {}),
-  };
+  const channels = resolveChannels(rawConfig);
   
   return CHANNELS.map(ch => {
     const channelConfig = channels[ch.id as keyof typeof channels];
@@ -220,14 +235,24 @@ export async function addChannel(channelId?: string): Promise<void> {
   }
   
   const config = loadAppConfigOrExit();
-  const existingConfig = config.channels[channelId as keyof typeof config.channels];
+  
+  // In multi-agent format, read/write from agents[0].channels
+  const multiAgent = isMultiAgentConfig(config);
+  const channelSource = multiAgent
+    ? (config.agents![0].channels ?? {})
+    : config.channels;
+  const existingConfig = channelSource[channelId as keyof typeof channelSource];
   
   // Get and run the setup function
   const setup = getSetupFunction(channelId as ChannelId);
   const newConfig = await setup(existingConfig);
   
-  // Save
-  (config.channels as any)[channelId] = newConfig;
+  // Save — write to the correct location based on config format
+  if (multiAgent) {
+    (config.agents![0].channels as any)[channelId] = newConfig;
+  } else {
+    (config.channels as any)[channelId] = newConfig;
+  }
   saveConfig(config);
   p.log.success(`Configuration saved to ${resolveConfigPath()}`);
 }
@@ -248,7 +273,13 @@ export async function removeChannel(channelId?: string): Promise<void> {
   }
   
   const config = loadAppConfigOrExit();
-  const channelConfig = config.channels[channelId as keyof typeof config.channels];
+  
+  // In multi-agent format, read/write from agents[0].channels
+  const multiAgent = isMultiAgentConfig(config);
+  const channelSource = multiAgent
+    ? (config.agents![0].channels ?? {})
+    : config.channels;
+  const channelConfig = channelSource[channelId as keyof typeof channelSource];
   
   if (!channelConfig?.enabled) {
     console.log(`${channelId} is already disabled.`);
@@ -266,7 +297,12 @@ export async function removeChannel(channelId?: string): Promise<void> {
     return;
   }
   
-  (config.channels as any)[channelId] = { enabled: false };
+  // Write to the correct location based on config format
+  if (multiAgent) {
+    (config.agents![0].channels as any)[channelId] = { enabled: false };
+  } else {
+    (config.channels as any)[channelId] = { enabled: false };
+  }
   saveConfig(config);
   p.log.success(`${meta.displayName} disabled`);
 }

--- a/src/cli/channel-management.ts
+++ b/src/cli/channel-management.ts
@@ -51,10 +51,22 @@ function getChannelDetails(id: ChannelId, channelConfig: any): string | undefine
 }
 
 function getChannelStatus(): ChannelStatus[] {
-  const config = loadAppConfigOrExit();
+  const rawConfig = loadAppConfigOrExit();
+  
+  // Merge channels from both top-level and agents[0] (multi-agent format)
+  const agentChannels = rawConfig.agents?.[0]?.channels;
+  const channels = {
+    ...rawConfig.channels,
+    ...(agentChannels?.telegram ? { telegram: { ...agentChannels.telegram, ...rawConfig.channels?.telegram } } : {}),
+    ...(agentChannels?.slack ? { slack: { ...agentChannels.slack, ...rawConfig.channels?.slack } } : {}),
+    ...(agentChannels?.discord ? { discord: { ...agentChannels.discord, ...rawConfig.channels?.discord } } : {}),
+    ...(agentChannels?.whatsapp ? { whatsapp: { ...agentChannels.whatsapp, ...rawConfig.channels?.whatsapp } } : {}),
+    ...(agentChannels?.signal ? { signal: { ...agentChannels.signal, ...rawConfig.channels?.signal } } : {}),
+    ...(agentChannels?.bluesky ? { bluesky: { ...agentChannels.bluesky, ...rawConfig.channels?.bluesky } } : {}),
+  };
   
   return CHANNELS.map(ch => {
-    const channelConfig = config.channels[ch.id as keyof typeof config.channels];
+    const channelConfig = channels[ch.id as keyof typeof channels];
     return {
       id: ch.id,
       displayName: ch.displayName,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,12 @@
 import { existsSync, mkdirSync, promises as fs } from 'node:fs';
 import { join, resolve } from 'node:path';
 
+// Parse --config <path> early so resolveConfigPath() picks it up via LETTABOT_CONFIG
+const configIdx = process.argv.indexOf('--config');
+if (configIdx !== -1 && process.argv[configIdx + 1]) {
+  process.env.LETTABOT_CONFIG = resolve(process.argv[configIdx + 1]);
+}
+
 // API server imports
 import { createApiServer } from './api/server.js';
 import { loadOrGenerateApiKey } from './api/auth.js';

--- a/src/onboard.ts
+++ b/src/onboard.ts
@@ -1659,6 +1659,28 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
   const configPath = resolveConfigPath();
   const hasExistingConfig = existsSync(configPath);
   
+  // Resolve channels from either top-level config or agents[0] (multi-agent format)
+  const agentChannels = existingConfig.agents?.[0]?.channels;
+  const ec = {
+    ...existingConfig,
+    channels: {
+      ...existingConfig.channels,
+      // Merge agent-level channels as fallback for fields not set at top level
+      ...(agentChannels?.telegram ? { telegram: { ...agentChannels.telegram, ...existingConfig.channels?.telegram } } : {}),
+      ...(agentChannels?.slack ? { slack: { ...agentChannels.slack, ...existingConfig.channels?.slack } } : {}),
+      ...(agentChannels?.discord ? { discord: { ...agentChannels.discord, ...existingConfig.channels?.discord } } : {}),
+      ...(agentChannels?.whatsapp ? { whatsapp: { ...agentChannels.whatsapp, ...existingConfig.channels?.whatsapp } } : {}),
+      ...(agentChannels?.signal ? { signal: { ...agentChannels.signal, ...existingConfig.channels?.signal } } : {}),
+    },
+    agent: {
+      ...existingConfig.agent,
+      ...(existingConfig.agents?.[0] ? {
+        name: existingConfig.agents[0].name || existingConfig.agent.name,
+        id: existingConfig.agents[0].id || existingConfig.agent.id,
+      } : {}),
+    },
+  };
+  
   // Non-interactive mode: read all config from env vars
   if (nonInteractive) {
     console.log('🤖 LettaBot Non-Interactive Setup\n');
@@ -1787,8 +1809,8 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
     p.log.info(`Loading existing config from ${configPath}`);
   }
   
-  // Pre-populate from existing config
-  const baseUrl = existingConfig.server.baseUrl || process.env.LETTA_BASE_URL || 'https://api.letta.com';
+  // Pre-populate from existing config (merged channels from both top-level and agents[])
+  const baseUrl = ec.server.baseUrl || process.env.LETTA_BASE_URL || 'https://api.letta.com';
   const isLocal = !isLettaApiUrl(baseUrl);
   p.note(`${baseUrl}\n${isLocal ? 'Docker server' : 'Letta API'}`, 'Server');
   
@@ -1814,70 +1836,70 @@ export async function onboard(options?: { nonInteractive?: boolean }): Promise<v
   }
   
   // Initialize config from existing env
-  // Pre-populate from existing YAML config
+  // Pre-populate from existing YAML config (ec merges top-level + agents[0] channels)
   const config: OnboardConfig = {
     authMethod: hasExistingConfig ? 'keep' : 'skip',
-    apiKey: existingConfig.server.apiKey,
-    baseUrl: existingConfig.server.baseUrl,
+    apiKey: ec.server.apiKey,
+    baseUrl: ec.server.baseUrl,
     telegram: { 
-      enabled: existingConfig.channels.telegram?.enabled || false,
-      token: existingConfig.channels.telegram?.token,
-      dmPolicy: existingConfig.channels.telegram?.dmPolicy,
-      allowedUsers: existingConfig.channels.telegram?.allowedUsers?.map(String),
+      enabled: ec.channels.telegram?.enabled || false,
+      token: ec.channels.telegram?.token,
+      dmPolicy: ec.channels.telegram?.dmPolicy,
+      allowedUsers: ec.channels.telegram?.allowedUsers?.map(String),
     },
     slack: { 
-      enabled: existingConfig.channels.slack?.enabled || false,
-      appToken: existingConfig.channels.slack?.appToken,
-      botToken: existingConfig.channels.slack?.botToken,
-      allowedUsers: existingConfig.channels.slack?.allowedUsers,
+      enabled: ec.channels.slack?.enabled || false,
+      appToken: ec.channels.slack?.appToken,
+      botToken: ec.channels.slack?.botToken,
+      allowedUsers: ec.channels.slack?.allowedUsers,
     },
     discord: {
-      enabled: existingConfig.channels.discord?.enabled || false,
-      token: existingConfig.channels.discord?.token,
-      dmPolicy: existingConfig.channels.discord?.dmPolicy,
-      allowedUsers: existingConfig.channels.discord?.allowedUsers,
+      enabled: ec.channels.discord?.enabled || false,
+      token: ec.channels.discord?.token,
+      dmPolicy: ec.channels.discord?.dmPolicy,
+      allowedUsers: ec.channels.discord?.allowedUsers,
     },
     whatsapp: { 
-      enabled: existingConfig.channels.whatsapp?.enabled || false,
-      selfChat: existingConfig.channels.whatsapp?.selfChat ?? true, // Default true
-      dmPolicy: existingConfig.channels.whatsapp?.dmPolicy,
+      enabled: ec.channels.whatsapp?.enabled || false,
+      selfChat: ec.channels.whatsapp?.selfChat ?? true, // Default true
+      dmPolicy: ec.channels.whatsapp?.dmPolicy,
     },
     signal: { 
-      enabled: existingConfig.channels.signal?.enabled || false,
-      phone: existingConfig.channels.signal?.phone,
-      selfChat: existingConfig.channels.signal?.selfChat ?? true, // Default true
-      dmPolicy: existingConfig.channels.signal?.dmPolicy,
+      enabled: ec.channels.signal?.enabled || false,
+      phone: ec.channels.signal?.phone,
+      selfChat: ec.channels.signal?.selfChat ?? true, // Default true
+      dmPolicy: ec.channels.signal?.dmPolicy,
     },
     google: (() => {
-      const existingAccounts = existingConfig.integrations?.google?.accounts
-        ? existingConfig.integrations.google.accounts.map(a => ({
+      const existingAccounts = ec.integrations?.google?.accounts
+        ? ec.integrations.google.accounts.map(a => ({
             account: a.account,
             services: a.services || [],
           }))
-        : (existingConfig.integrations?.google?.account ? [{
-            account: existingConfig.integrations.google.account,
-            services: existingConfig.integrations.google.services || [],
+        : (ec.integrations?.google?.account ? [{
+            account: ec.integrations.google.account,
+            services: ec.integrations.google.services || [],
           }] : []);
       return {
-        enabled: (existingConfig.integrations?.google?.enabled || false) || existingAccounts.length > 0,
+        enabled: (ec.integrations?.google?.enabled || false) || existingAccounts.length > 0,
         accounts: existingAccounts,
       };
     })(),
     heartbeat: { 
-      enabled: existingConfig.features?.heartbeat?.enabled || false,
-      interval: existingConfig.features?.heartbeat?.intervalMin?.toString(),
+      enabled: ec.features?.heartbeat?.enabled || false,
+      interval: ec.features?.heartbeat?.intervalMin?.toString(),
     },
-    cron: existingConfig.features?.cron || false,
+    cron: ec.features?.cron || false,
     transcription: {
-      enabled: !!existingConfig.transcription?.apiKey || !!process.env.OPENAI_API_KEY || !!process.env.MISTRAL_API_KEY,
-      provider: existingConfig.transcription?.provider || 'openai',
-      apiKey: existingConfig.transcription?.apiKey,
-      model: existingConfig.transcription?.model,
+      enabled: !!ec.transcription?.apiKey || !!process.env.OPENAI_API_KEY || !!process.env.MISTRAL_API_KEY,
+      provider: ec.transcription?.provider || 'openai',
+      apiKey: ec.transcription?.apiKey,
+      model: ec.transcription?.model,
     },
     agentChoice: hasExistingConfig ? 'env' : 'skip',
-    agentName: existingConfig.agent.name,
-    agentId: existingConfig.agent.id,
-    providers: existingConfig.providers?.map(p => ({ id: p.id, name: p.name, apiKey: p.apiKey })),
+    agentName: ec.agent.name,
+    agentId: ec.agent.id,
+    providers: ec.providers?.map(p => ({ id: p.id, name: p.name, apiKey: p.apiKey })),
   };
   
   // Run through all steps


### PR DESCRIPTION
## Summary
- Follow-up to #675 (b285f1b) which fixed the **read** path but missed the **write** path
- `addChannel` and `removeChannel` in channel-management.ts now detect multi-agent format and write to `agents[0].channels` instead of top-level `config.channels`
- Extracted `resolveChannels()` and `isMultiAgentConfig()` helpers for reuse
- Added 9 unit tests for the new helpers

## Problem
In multi-agent config format (e.g. `lettabot.yaml` with `agents[]`), `lettabot channels add signal` would write to `config.channels.signal` (top-level) instead of `agents[0].channels.signal`. Since the runtime only reads from `agents[].channels` in multi-agent mode, the added channel would be silently ignored.

## Test plan
- [x] 9 new unit tests pass (`resolveChannels`, `isMultiAgentConfig`)
- [x] Full suite: 1011 passed (1 pre-existing failure in normalize.test.ts unrelated to this change)
- [ ] Manual: `lettabot channels add <channel>` with multi-agent config → verify agents[0].channels updated
- [ ] Manual: `lettabot channels remove <channel>` with multi-agent config → verify agents[0].channels updated

Relates to #674.

👾 Generated with [Letta Code](https://letta.com)