### PR TITLE
docs: mark LettaBot as deprecated, point to Channels + Remote Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 > - **Heartbeats and scheduled tasks** → [letta cron](https://docs.letta.com/letta-code/scheduling) — built into remote environments
 >
 > Existing LettaBot deployments will continue to function, but for any new project, use Channels + Remote Environments. Migration is typically straightforward (~20 minutes).
+>
+> **Need migration help?** Ask in the `#ezra` channel on the [Letta Discord](https://discord.gg/letta).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<div align="center">
+
+# LettaBot is deprecated
+
+</div>
+
+> [!WARNING]
+> **LettaBot is no longer actively maintained.** All new development is happening in [Letta Code](https://docs.letta.com/letta-code) via [Channels](https://docs.letta.com/letta-code/channels) and [Remote Environments](https://docs.letta.com/letta-code/remote).
+>
+> **Where to go instead:**
+> - **Telegram / Slack messaging** → [Channels](https://docs.letta.com/letta-code/channels) — same agent, same memory, integrated into Letta Code directly
+> - **Always-on agent on a VPS or server** → [Remote Environments](https://docs.letta.com/letta-code/remote) — `letta server` uses outbound WebSocket, no ports to open, no reverse proxy needed
+> - **Heartbeats and scheduled tasks** → [letta cron](https://docs.letta.com/letta-code/scheduling) — built into remote environments
+>
+> Existing LettaBot deployments will continue to function, but for any new project, use Channels + Remote Environments. Migration is typically straightforward (~20 minutes).
+
+---
+
 # LettaBot
 
 Your personal AI assistant that remembers everything across **Telegram, Slack, Discord, WhatsApp, and Signal** — plus Bluesky Jetstream feed ingestion. Powered by the [Letta Code SDK](https://github.com/letta-ai/letta-code-sdk).


### PR DESCRIPTION
## Summary

LettaBot is no longer actively maintained. Per team direction, the actively developed path for messaging agents and always-on servers is [Letta Code](https://docs.letta.com/letta-code) via [Channels](https://docs.letta.com/letta-code/channels) and [Remote Environments](https://docs.letta.com/letta-code/remote).

This PR adds a prominent deprecation banner to the top of the README so anyone landing on this repo is immediately directed to the supported replacement. Existing deployments continue to function — this is a signalling change only, no code touched.

## Banner contents

- **Telegram / Slack messaging** → [Channels](https://docs.letta.com/letta-code/channels)
- **Always-on agent on a VPS or server** → [Remote Environments](https://docs.letta.com/letta-code/remote) (outbound WebSocket, no ports to open)
- **Heartbeats and scheduled tasks** → [letta cron](https://docs.letta.com/letta-code/scheduling)

Uses a GitHub `[!WARNING]` alert block for visual prominence and a centered `# LettaBot is deprecated` heading above it.

## Test plan

- [x] README renders correctly on GitHub (alert block + centered heading)
- [x] All three doc links resolve (channels, remote, scheduling)
- [x] Original README content preserved below the banner unchanged
- [ ] Optional: follow-up PR to add the banner to SKILL.md and docs/*.md setup guides if desired

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>